### PR TITLE
⚡️ perf(test): migrate to PostgreSQL and optimize test performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 !/tmp/pids/
 !/tmp/pids/.keep
 
-# Ignore storage (uploaded files in development and any SQLite databases).
+# Ignore storage (uploaded files in development and any database dumps).
 /storage/*
 !/storage/.keep
 /tmp/storage/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ A pre-commit hook has been configured to automatically run tests, RuboCop lintin
 This is a fresh Rails 8 application with the following stack:
 
 **Backend:**
-- Rails 8.0.2 with SQLite3 database
+- Rails 8.0.2 with PostgreSQL database
 - Solid Cache, Queue, and Cable for performance
 - Puma web server
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.1"
+# Use postgresql as the database for Active Record
+gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
@@ -71,6 +71,10 @@ group :development, :test do
 
   # Test data factories
   gem "factory_bot_rails"
+
+  # Spring preloader for faster test startup
+  gem "spring"
+  gem "spring-commands-rspec"
 end
 
 group :development do
@@ -82,6 +86,9 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # Parallel test execution
+  gem "parallel_tests"
 end
 
 gem "rspec-rails", "~> 8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,9 +215,17 @@ GEM
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)
+    parallel_tests (5.4.0)
+      parallel
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.1)
+    pg (1.6.1-aarch64-linux)
+    pg (1.6.1-aarch64-linux-musl)
+    pg (1.6.1-arm64-darwin)
+    pg (1.6.1-x86_64-linux)
+    pg (1.6.1-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -372,13 +380,9 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sqlite3 (2.7.3-aarch64-linux-gnu)
-    sqlite3 (2.7.3-aarch64-linux-musl)
-    sqlite3 (2.7.3-arm-linux-gnu)
-    sqlite3 (2.7.3-arm-linux-musl)
-    sqlite3 (2.7.3-arm64-darwin)
-    sqlite3 (2.7.3-x86_64-linux-gnu)
-    sqlite3 (2.7.3-x86_64-linux-musl)
+    spring (4.3.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sshkit (1.24.0)
       base64
       logger
@@ -456,6 +460,8 @@ DEPENDENCIES
   kaminari
   mail
   net-imap
+  parallel_tests
+  pg (~> 1.1)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
@@ -469,7 +475,8 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
-  sqlite3 (>= 2.1)
+  spring
+  spring-commands-rspec
   stimulus-rails
   tailwindcss-rails
   thruster

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without loading other gems in the Gemfile in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  require "bundler"
+
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,41 +1,66 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
+# PostgreSQL. Versions 9.3 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem "pg"
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { "" } %>
+  host: <%= ENV.fetch("POSTGRES_HOST") { "localhost" } %>
+  port: <%= ENV.fetch("POSTGRES_PORT") { 5432 } %>
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: expense_tracker_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+# The test environment is used exclusively to run your application's
+# test suite. You never need to work with it otherwise. Remember that
+# your test database is "scratch space" for the test suite and is wiped
+# and recreated between test runs. Don't rely on the data there!
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: expense_tracker_test<%= ENV['TEST_ENV_NUMBER'] %>
+  # Optimize for testing performance
+  min_messages: WARNING
+  # Use template0 to avoid encoding issues
+  template: template0
 
-
-# Store production database in the storage/ directory, which by default
-# is mounted as a persistent Docker volume in config/deploy.yml.
+# Store production database configuration securely
 production:
   primary:
     <<: *default
-    database: storage/production.sqlite3
+    database: expense_tracker_production
+    username: <%= ENV.fetch("POSTGRES_USER") { "expense_tracker" } %>
+    password: <%= ENV["POSTGRES_PASSWORD"] %>
   cache:
     <<: *default
-    database: storage/production_cache.sqlite3
+    database: expense_tracker_production_cache
+    username: <%= ENV.fetch("POSTGRES_USER") { "expense_tracker" } %>
+    password: <%= ENV["POSTGRES_PASSWORD"] %>
     migrations_paths: db/cache_migrate
   queue:
     <<: *default
-    database: storage/production_queue.sqlite3
+    database: expense_tracker_production_queue
+    username: <%= ENV.fetch("POSTGRES_USER") { "expense_tracker" } %>
+    password: <%= ENV["POSTGRES_PASSWORD"] %>
     migrations_paths: db/queue_migrate
   cable:
     <<: *default
-    database: storage/production_cable.sqlite3
+    database: expense_tracker_production_cable
+    username: <%= ENV.fetch("POSTGRES_USER") { "expense_tracker" } %>
+    password: <%= ENV["POSTGRES_PASSWORD"] %>
     migrations_paths: db/cable_migrate

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_08_03_205052) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "api_tokens", force: :cascade do |t|
     t.string "name", null: false
     t.string "token_digest", null: false


### PR DESCRIPTION
Switch from SQLite to PostgreSQL for better production parity and performance. Add parallel test support and Spring preloader for faster test execution.

Key changes:
- Replace SQLite with PostgreSQL adapter in Gemfile and database.yml
- Add parallel_tests gem with multi-database support (TEST_ENV_NUMBER)
- Add Spring preloader with spring-commands-rspec
- Reduce BCrypt cost to minimum in test environment
- Fix ExpensesController GROUP BY for PostgreSQL compatibility
- Configure PostgreSQL-specific optimizations for test database

Test performance improved from ~26s to ~4.87s (81% faster).