### PR TITLE
Fix SolidQueue segfault with PostgreSQL 18 on macOS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
+    ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -229,6 +230,7 @@ GEM
     matrix (0.4.3)
     memory_profiler (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.26.0)
     msgpack (1.8.0)
     multi_json (1.17.0)
@@ -247,6 +249,9 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-musl)
@@ -268,12 +273,12 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    pg (1.6.2)
-    pg (1.6.2-aarch64-linux)
-    pg (1.6.2-aarch64-linux-musl)
-    pg (1.6.2-arm64-darwin)
-    pg (1.6.2-x86_64-linux)
-    pg (1.6.2-x86_64-linux-musl)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -531,6 +536,7 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   arm64-darwin-25
+  ruby
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: env OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails server -p 3002
+web: bin/rails server -p 3002
 css: bin/rails tailwindcss:watch
-/*worker: bin/rails solid_queue:start*/
+worker: bin/rails solid_queue:start

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,6 +22,10 @@ default: &default
   password: <%= ENV.fetch("POSTGRES_PASSWORD") { "" } %>
   host: <%= ENV.fetch("POSTGRES_HOST") { "localhost" } %>
   port: <%= ENV.fetch("POSTGRES_PORT") { 5432 } %>
+  # Disable GSS encryption to prevent segfault in forked processes on macOS.
+  # PostgreSQL 18's libpq probes Kerberos/GSS credentials via XPC, which
+  # crashes after fork() because XPC ports aren't inherited.
+  gssencmode: disable
   # Performance optimizations
   checkout_timeout: 5
   reaping_frequency: 10


### PR DESCRIPTION
## Summary

- **Root cause**: PostgreSQL 18's libpq probes Kerberos/GSS credentials via macOS XPC during connection negotiation (`pg_GSS_have_cred_cache`). XPC ports aren't inherited across `fork()`, causing a segfault in `_os_log_preferences_refresh` when SolidQueue forks worker processes.
- **Fix**: Add `gssencmode: disable` to `database.yml` default config to skip the GSS/Kerberos probe entirely
- **Cleanup**: Re-enable SolidQueue worker in `Procfile.dev` and remove the ineffective `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` workaround
- **Dependency**: Upgrade pg gem from 1.6.2 to 1.6.3

## Test plan

- [x] `bin/rails runner` connects to PostgreSQL successfully
- [x] `bundle exec rake solid_queue:start` runs without segfault
- [x] `bin/dev` starts all processes (web, css, worker) cleanly
- [x] SolidQueue registers Supervisor, Dispatcher, Worker, and Scheduler
- [x] Graceful shutdown works correctly
- [x] All unit tests pass (5899 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)