### PR TITLE
chore(deps): update brakeman from 7.1.0 to 8.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## Summary
- Updates brakeman security scanner from 7.1.0 to 8.0.2
- All 370 unit tests passing, zero security warnings

## Test plan
- [x] Pre-commit hook passed (RuboCop, Brakeman, RSpec unit tests)
- [x] Brakeman 8.0.2 scan: 0 warnings, 0 errors
- [x] Rails Best Practices: no warnings