### PR TITLE
🔒 fix(auth): add authentication to ApplicationController

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   # Base controller for admin functionality with secure authentication
   class BaseController < ApplicationController
+    skip_before_action :authenticate_user!
     include AdminAuthentication
 
     # Rate limiting for admin actions

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   # Controller for admin authentication (login/logout)
   class SessionsController < ApplicationController
+    skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token, only: [ :create ]
     before_action :redirect_if_authenticated, only: [ :new, :create ]
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ module Api
   class BaseController < ApplicationController
     include ApiConfiguration
 
+    skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token
     before_action :authenticate_api_token
     before_action :set_default_headers

--- a/app/controllers/api/client_errors_controller.rb
+++ b/app/controllers/api/client_errors_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ClientErrorsController < ApplicationController
+    skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token
 
     # POST /api/client_errors

--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -3,6 +3,7 @@
 module Api
   # Health check controller for monitoring and Kubernetes probes
   class HealthController < ApplicationController
+    skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token
 
     # Comprehensive health check endpoint

--- a/app/controllers/api/monitoring_controller.rb
+++ b/app/controllers/api/monitoring_controller.rb
@@ -3,6 +3,7 @@
 module Api
   # API endpoint for monitoring and dashboard metrics
   class MonitoringController < ApplicationController
+    skip_before_action :authenticate_user!
     before_action :authenticate_api_request, only: [ :metrics ]
 
     # GET /api/monitoring/metrics

--- a/app/controllers/api/queue_controller.rb
+++ b/app/controllers/api/queue_controller.rb
@@ -4,6 +4,7 @@ module Api
   # API controller for queue monitoring and management
   # Provides endpoints for real-time queue status, control operations, and job management
   class QueueController < ApplicationController
+    skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token
     before_action :authenticate_queue_access!
     before_action :set_job, only: [ :retry_job, :clear_job ]

--- a/app/controllers/api/sync_sessions_controller.rb
+++ b/app/controllers/api/sync_sessions_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class SyncSessionsController < ApplicationController
+    skip_before_action :authenticate_user!
     before_action :set_sync_session, only: [ :status ]
     skip_before_action :verify_authenticity_token, if: :json_request?
 

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class CategoriesController < ApplicationController
+      skip_before_action :authenticate_user!
       skip_before_action :verify_authenticity_token
 
       def index

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -1,4 +1,5 @@
 class Api::WebhooksController < ApplicationController
+  skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
   before_action :authenticate_api_token
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Authentication
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern unless Rails.env.test?
 

--- a/app/controllers/ux_mockups_controller.rb
+++ b/app/controllers/ux_mockups_controller.rb
@@ -1,4 +1,5 @@
 class UxMockupsController < ApplicationController
+  skip_before_action :authenticate_user!
   layout "mockup", except: :index
 
   def index

--- a/spec/controllers/application_controller_auth_spec.rb
+++ b/spec/controllers/application_controller_auth_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :controller, unit: true do
+  controller do
+    def index
+      render plain: "OK"
+    end
+  end
+
+  describe "Authentication inclusion", unit: true do
+    it "includes the Authentication concern" do
+      expect(ApplicationController.ancestors).to include(Authentication)
+    end
+
+    it "has authenticate_user! as a before_action" do
+      callbacks = ApplicationController._process_action_callbacks.select { |c| c.kind == :before }
+      filter_names = callbacks.map(&:filter)
+      expect(filter_names).to include(:authenticate_user!)
+    end
+  end
+
+  describe "unauthenticated access", unit: true do
+    it "redirects to login page when not authenticated" do
+      get :index
+      expect(response).to redirect_to(admin_login_path)
+    end
+
+    it "sets an alert flash message" do
+      get :index
+      expect(flash[:alert]).to eq("Please sign in to continue.")
+    end
+
+    it "stores the requested location for post-login redirect" do
+      get :index
+      expect(session[:return_to]).to eq("/anonymous")
+    end
+  end
+
+  describe "authenticated access", unit: true do
+    let!(:admin_user) do
+      AdminUser.create!(
+        name: "Auth Test User",
+        email: "auth-test@example.com",
+        password: "SecurePassword123!",
+        role: "admin"
+      )
+    end
+
+    before do
+      admin_user.regenerate_session_token unless admin_user.session_token.present?
+      session[:admin_session_token] = admin_user.reload.session_token
+      allow(AdminUser).to receive(:find_by_valid_session)
+        .with(admin_user.session_token)
+        .and_return(admin_user)
+    end
+
+    it "allows access with a valid session" do
+      get :index
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("OK")
+    end
+
+    it "exposes current_user helper" do
+      get :index
+      expect(controller.send(:current_user)).to eq(admin_user)
+    end
+
+    it "reports user as signed in" do
+      get :index
+      expect(controller.send(:user_signed_in?)).to be true
+    end
+  end
+
+  describe "controllers that skip authentication", unit: true do
+    let(:controllers_with_skip) do
+      [
+        Admin::SessionsController,
+        Admin::BaseController,
+        Api::BaseController,
+        Api::WebhooksController,
+        Api::HealthController,
+        Api::ClientErrorsController,
+        Api::QueueController,
+        Api::MonitoringController,
+        Api::SyncSessionsController,
+        Api::V1::CategoriesController,
+        UxMockupsController
+      ]
+    end
+
+    it "each has skip_before_action for authenticate_user!" do
+      controllers_with_skip.each do |controller_class|
+        callbacks = controller_class._process_action_callbacks.select do |c|
+          c.kind == :before && c.filter == :authenticate_user!
+        end
+
+        # If the callback exists, it should be skipped (no callback found means it was removed by skip)
+        # OR the callback is present but the controller has its own auth
+        # The most reliable check: the :authenticate_user! before_action should NOT be active
+        has_active_auth = callbacks.any? { |c| !c.instance_variable_get(:@if)&.any? && !c.instance_variable_get(:@unless)&.any? }
+
+        # Better approach: check that the filter chain does NOT include an active authenticate_user!
+        active_filters = controller_class._process_action_callbacks.select { |c|
+          c.kind == :before && c.filter == :authenticate_user!
+        }
+
+        # skip_before_action removes the callback from the chain entirely
+        expect(active_filters).to be_empty,
+          "Expected #{controller_class.name} to skip :authenticate_user! but it was found in the callback chain"
+      end
+    end
+  end
+
+  describe "controllers that require authentication", unit: true do
+    let(:controllers_requiring_auth) do
+      [
+        ExpensesController,
+        BudgetsController,
+        CategoriesController,
+        EmailAccountsController,
+        SyncConflictsController,
+        SyncPerformanceController,
+        SyncSessionsController,
+        BulkCategorizationsController,
+        BulkCategorizationActionsController
+      ]
+    end
+
+    it "each inherits authenticate_user! from ApplicationController" do
+      controllers_requiring_auth.each do |controller_class|
+        callbacks = controller_class._process_action_callbacks.select { |c|
+          c.kind == :before && c.filter == :authenticate_user!
+        }
+
+        expect(callbacks).not_to be_empty,
+          "Expected #{controller_class.name} to have :authenticate_user! before_action but it was not found"
+      end
+    end
+  end
+
+  describe "controllers inheriting through Api::BaseController", unit: true do
+    let(:api_v1_controllers) do
+      [
+        Api::V1::BaseController,
+        Api::V1::CategorizationController,
+        Api::V1::PatternsController
+      ]
+    end
+
+    it "each skips authenticate_user! (inherited from Api::BaseController)" do
+      api_v1_controllers.each do |controller_class|
+        active_filters = controller_class._process_action_callbacks.select { |c|
+          c.kind == :before && c.filter == :authenticate_user!
+        }
+
+        expect(active_filters).to be_empty,
+          "Expected #{controller_class.name} to skip :authenticate_user! but it was found in the callback chain"
+      end
+    end
+  end
+
+  describe "controllers inheriting through Admin::BaseController", unit: true do
+    it "Analytics::PatternDashboardController skips authenticate_user!" do
+      active_filters = Analytics::PatternDashboardController._process_action_callbacks.select { |c|
+        c.kind == :before && c.filter == :authenticate_user!
+      }
+
+      expect(active_filters).to be_empty,
+        "Expected Analytics::PatternDashboardController to skip :authenticate_user!"
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe ApplicationController, type: :controller, unit: true do
     end
   end
 
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+  end
+
   describe "browser version requirements", unit: true do
     it "allows modern browsers" do
       # Set a modern user agent that supports required features

--- a/spec/controllers/budgets_controller_unit_spec.rb
+++ b/spec/controllers/budgets_controller_unit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BudgetsController, type: :controller, unit: true do
   let(:category) { build_stubbed(:category) }
 
   before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
     allow(EmailAccount).to receive_message_chain(:active, :first).and_return(email_account)
   end
 

--- a/spec/controllers/concerns/api_caching_spec.rb
+++ b/spec/controllers/concerns/api_caching_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe ApiCaching, type: :controller, unit: true do
   end
 
   before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+
     routes.draw do
       get 'index' => 'anonymous#index'
       post 'index' => 'anonymous#index'

--- a/spec/controllers/concerns/api_configuration_spec.rb
+++ b/spec/controllers/concerns/api_configuration_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe ApiConfiguration, type: :controller, unit: true do
   end
 
   before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+
     routes.draw do
       get 'index' => 'anonymous#index'
       get 'paginated_list' => 'anonymous#paginated_list'

--- a/spec/controllers/concerns/sync_authorization_spec.rb
+++ b/spec/controllers/concerns/sync_authorization_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe SyncAuthorization, type: :controller, unit: true do
   end
 
   before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+
     routes.draw do
       get 'index' => 'anonymous#index'
       get 'show/:id' => 'anonymous#show'

--- a/spec/controllers/concerns/sync_error_handling_spec.rb
+++ b/spec/controllers/concerns/sync_error_handling_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe SyncErrorHandling, type: :controller, unit: true do
   end
 
   before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+
     routes.draw do
       get 'not_found' => 'anonymous#not_found'
       get 'validation_error' => 'anonymous#validation_error'

--- a/spec/controllers/email_accounts_controller_spec.rb
+++ b/spec/controllers/email_accounts_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe EmailAccountsController, type: :controller, unit: true do
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+  end
+
   let(:email_account) { create(:email_account) }
   let(:valid_attributes) {
     {

--- a/spec/controllers/sync_performance_controller_spec.rb
+++ b/spec/controllers/sync_performance_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe SyncPerformanceController, type: :controller do
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+  end
+
   describe "GET #index" do
     let!(:sync_session) { create(:sync_session) }
     let!(:email_account) { create(:email_account) }

--- a/spec/requests/budgets_spec.rb
+++ b/spec/requests/budgets_spec.rb
@@ -28,7 +28,17 @@ RSpec.describe "Budgets", type: :request, integration: true do
     }
   end
 
+  let(:admin_user) do
+    AdminUser.create!(
+      name: "Budget Test Admin",
+      email: "budget-admin@test.com",
+      password: "AdminPassword123!",
+      role: "admin"
+    )
+  end
+
   before do
+    sign_in_admin(admin_user)
     # Ensure we have an active email account
     allow(EmailAccount).to receive_message_chain(:active, :first).and_return(email_account)
   end

--- a/spec/requests/sync_sessions_spec.rb
+++ b/spec/requests/sync_sessions_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe "SyncSessions", type: :request, integration: true do
   let!(:email_account1) { create(:email_account, :bac, active: true) }
   let!(:email_account2) { create(:email_account, :gmail, active: true, email: "gmail_#{SecureRandom.hex(4)}@example.com") }
   let!(:inactive_account) { create(:email_account, active: false, email: "inactive_#{SecureRandom.hex(4)}@example.com") }
+  let(:admin_user) do
+    AdminUser.create!(
+      name: "Sync Test Admin",
+      email: "sync-admin-#{SecureRandom.hex(4)}@test.com",
+      password: "AdminPassword123!",
+      role: "admin"
+    )
+  end
 
   # Clean up before and after to ensure complete test isolation
   before(:each) do
+    sign_in_admin(admin_user)
     # Clean up any existing sync sessions to ensure test isolation
     # Need to delete in proper order due to foreign key constraints
     ConflictResolution.delete_all if defined?(ConflictResolution)


### PR DESCRIPTION
## Summary
- Fixes: S-01, S-12, S-17–S-21, UX-001
- Phase: 0 (Emergency)

## Changes
- Added `include Authentication` to `ApplicationController` — all controllers now require session auth by default
- Added `skip_before_action :authenticate_user!` to 11 controllers that handle their own auth (API token, admin sessions, health checks)
- Created 12-example test suite verifying auth enforcement across all controllers
- Updated 10 existing test files with proper auth mocking
- Fixed `parallel_tests.rb` for Rails 8.1 frozen hash compatibility

## Controllers with skip (handle own auth)
Admin::SessionsController, Admin::BaseController, Api::BaseController, Api::WebhooksController, Api::HealthController, Api::ClientErrorsController, Api::QueueController, Api::MonitoringController, Api::SyncSessionsController, Api::V1::CategoriesController, UxMockupsController

## Controllers now requiring auth (no skip)
ExpensesController, BudgetsController, CategoriesController, EmailAccountsController, SyncConflictsController, SyncPerformanceController, SyncSessionsController, UndoHistoriesController, BulkCategorizationsController, BulkCategorizationActionsController

## Test plan
- [x] New specs pass (12 examples, 0 failures)
- [x] Existing specs pass (`bundle exec rspec --tag unit` — 7274 examples, 0 failures)
- [x] Brakeman clean (0 warnings)
- [ ] Manual verification: visit any protected page without session → redirects to login