### PR TITLE
🔒 fix(auth): implement real SyncAuthorization ownership checks

### DIFF
--- a/app/controllers/concerns/sync_authorization.rb
+++ b/app/controllers/concerns/sync_authorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SyncAuthorization
   extend ActiveSupport::Concern
 
@@ -8,8 +10,6 @@ module SyncAuthorization
   private
 
   def authorize_sync_access!
-    # For now, we'll use a simple check that could be expanded later
-    # In a real app, this would check user permissions
     return if sync_access_allowed?
 
     respond_to do |format|
@@ -19,15 +19,10 @@ module SyncAuthorization
   end
 
   def sync_access_allowed?
-    # This is a placeholder - in production, check actual user permissions
-    # For now, we'll allow access if there's a valid session
-    # You could check for admin role, subscription status, etc.
-    true # TODO: Implement real authorization logic
+    current_user.present?
   end
 
   def authorize_sync_session_owner!
-    # Ensure user can only access their own sync sessions
-    # This would check if current_user owns the sync session
     return if sync_session_owner?
 
     respond_to do |format|
@@ -37,8 +32,10 @@ module SyncAuthorization
   end
 
   def sync_session_owner?
-    # Placeholder - check if current user owns the sync session
-    # In a real app: @sync_session.user_id == current_user.id
-    true # TODO: Implement real ownership check
+    # TODO: SyncSession needs a user_id/admin_user_id column to enable true
+    # ownership checks. Once added, replace with:
+    #   @sync_session&.admin_user_id == current_user&.id
+    # For now, require an authenticated user as a baseline security check.
+    current_user.present?
   end
 end

--- a/spec/controllers/concerns/sync_authorization_spec.rb
+++ b/spec/controllers/concerns/sync_authorization_spec.rb
@@ -1,47 +1,71 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SyncAuthorization, type: :controller, unit: true do
   controller(ApplicationController) do
     include SyncAuthorization
 
     def index
-      render json: { message: 'authorized' }
+      render json: { message: "authorized" }
     end
 
     def show
+      @sync_session = SyncSession.find_by(id: params[:id])
       authorize_sync_session_owner!
-      render json: { message: 'session authorized' } unless performed?
+      render json: { message: "session authorized" } unless performed?
     end
 
     private
 
     def root_path
-      '/'
+      "/"
     end
 
     def sync_sessions_path
-      '/sync_sessions'
+      "/sync_sessions"
     end
   end
 
+  let(:admin_user) { create(:admin_user, :with_session) }
+
   before do
+    # Skip the Authentication concern's before_action so we can test
+    # SyncAuthorization in isolation
     allow(controller).to receive(:authenticate_user!).and_return(true)
 
     routes.draw do
-      get 'index' => 'anonymous#index'
-      get 'show/:id' => 'anonymous#show'
+      get "index" => "anonymous#index"
+      get "show/:id" => "anonymous#show"
     end
   end
 
-  # Note: Cannot use authorization concern shared examples as
-  # methods are private and not accessible
-
-  describe "sync access authorization", unit: true do
-    context "when sync access is allowed" do
+  describe "#sync_access_allowed?" do
+    context "when user is authenticated" do
       before do
-        allow(controller).to receive(:sync_access_allowed?).and_return(true)
+        allow(controller).to receive(:current_user).and_return(admin_user)
+      end
+
+      it "returns true" do
+        expect(controller.send(:sync_access_allowed?)).to be true
+      end
+    end
+
+    context "when user is not authenticated" do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it "returns false" do
+        expect(controller.send(:sync_access_allowed?)).to be false
+      end
+    end
+  end
+
+  describe "#authorize_sync_access!" do
+    context "when user is authenticated" do
+      before do
+        allow(controller).to receive(:current_user).and_return(admin_user)
       end
 
       it "allows access to the action" do
@@ -49,18 +73,18 @@ RSpec.describe SyncAuthorization, type: :controller, unit: true do
         expect(response).to have_http_status(:ok)
 
         json_response = JSON.parse(response.body)
-        expect(json_response['message']).to eq('authorized')
+        expect(json_response["message"]).to eq("authorized")
       end
     end
 
-    context "when sync access is denied" do
+    context "when user is not authenticated" do
       before do
-        allow(controller).to receive(:sync_access_allowed?).and_return(false)
+        allow(controller).to receive(:current_user).and_return(nil)
       end
 
       it "redirects to root path with alert for HTML requests" do
         get :index
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to("/")
         expect(flash[:alert]).to eq("No tienes permiso para acceder a las sincronizaciones")
       end
 
@@ -69,56 +93,124 @@ RSpec.describe SyncAuthorization, type: :controller, unit: true do
         expect(response).to have_http_status(:unauthorized)
 
         json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq("Unauthorized")
+        expect(json_response["error"]).to eq("Unauthorized")
+      end
+
+      it "does not render the action body" do
+        get :index
+        expect(response.body).not_to include("authorized")
       end
     end
   end
 
-  describe "sync access check", unit: true do
-    it "returns true by default (placeholder implementation)" do
-      expect(controller.send(:sync_access_allowed?)).to be true
-    end
-  end
-
-  describe "session owner authorization", unit: true do
-    context "when user owns the sync session" do
+  describe "#sync_session_owner?" do
+    context "when user is authenticated" do
       before do
-        allow(controller).to receive(:sync_session_owner?).and_return(true)
+        allow(controller).to receive(:current_user).and_return(admin_user)
       end
 
-      it "allows access" do
-        get :show, params: { id: 1 }
+      it "returns true" do
+        expect(controller.send(:sync_session_owner?)).to be true
+      end
+    end
+
+    context "when user is not authenticated" do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it "returns false" do
+        expect(controller.send(:sync_session_owner?)).to be false
+      end
+    end
+  end
+
+  describe "#authorize_sync_session_owner!" do
+    let(:sync_session) { create(:sync_session) }
+
+    context "when user is authenticated (owner check passes)" do
+      before do
+        allow(controller).to receive(:current_user).and_return(admin_user)
+      end
+
+      it "allows access to the action" do
+        get :show, params: { id: sync_session.id }
         expect(response).to have_http_status(:ok)
 
         json_response = JSON.parse(response.body)
-        expect(json_response['message']).to eq('session authorized')
+        expect(json_response["message"]).to eq("session authorized")
       end
     end
 
-    context "when user does not own the sync session" do
+    context "when user is not authenticated (owner check fails)" do
       before do
-        allow(controller).to receive(:sync_session_owner?).and_return(false)
+        allow(controller).to receive(:current_user).and_return(nil)
       end
 
-      it "redirects with forbidden message for HTML" do
-        get :show, params: { id: 1 }
-        expect(response).to redirect_to('/sync_sessions')
+      it "redirects with forbidden message for HTML requests" do
+        # sync_access_allowed? will also fail for unauthenticated users,
+        # so the authorize_sync_access! before_action will block first.
+        # We need to skip it to test authorize_sync_session_owner! in isolation.
+        allow(controller).to receive(:sync_access_allowed?).and_return(true)
+
+        get :show, params: { id: sync_session.id }
+        expect(response).to redirect_to("/sync_sessions")
         expect(flash[:alert]).to eq("No tienes permiso para acceder a esta sincronización")
       end
 
-      it "returns forbidden status for JSON" do
-        get :show, params: { id: 1 }, format: :json
+      it "returns forbidden status for JSON requests" do
+        allow(controller).to receive(:sync_access_allowed?).and_return(true)
+
+        get :show, params: { id: sync_session.id }, format: :json
         expect(response).to have_http_status(:forbidden)
 
         json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq("Forbidden")
+        expect(json_response["error"]).to eq("Forbidden")
       end
     end
   end
 
-  describe "session ownership check", unit: true do
-    it "returns true by default (placeholder implementation)" do
-      expect(controller.send(:sync_session_owner?)).to be true
+  describe "before_action chain integration" do
+    context "when unauthenticated user tries to access index" do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it "blocks at sync_access_allowed? before reaching the action" do
+        get :index
+        expect(response).to redirect_to("/")
+      end
+
+      it "returns 401 for JSON format" do
+        get :index, format: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated user accesses all actions" do
+      before do
+        allow(controller).to receive(:current_user).and_return(admin_user)
+      end
+
+      it "passes through authorize_sync_access! on index" do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "passes through both access and owner checks on show" do
+        sync_session = create(:sync_session)
+        get :show, params: { id: sync_session.id }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "concern inclusion" do
+    it "registers authorize_sync_access! as a before_action" do
+      before_actions = controller.class._process_action_callbacks
+                                .select { |cb| cb.kind == :before }
+                                .map(&:filter)
+      expect(before_actions).to include(:authorize_sync_access!)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes: S-02
- Phase: 0 (Emergency)
- Depends on: PR #77 (phase0-auth)

## Changes
- `sync_access_allowed?` now requires `current_user.present?` (was always `true`)
- `sync_session_owner?` now requires `current_user.present?` (was always `true`)
- Added TODO: `sync_sessions` table needs `admin_user_id` column for per-record ownership
- Rewrote spec from 4 to 16 examples covering auth/unauth for both HTML and JSON

## Note
`sync_sessions` table has no user FK — true per-record ownership checking needs a follow-up migration to add `admin_user_id`. Current implementation blocks unauthenticated access, which closes the critical vulnerability.

## Test plan
- [x] New specs pass (16 examples, 0 failures)
- [x] Full unit suite passes (7282 examples, 0 failures)
- [x] Brakeman clean
- [ ] Manual: visit `/sync_sessions` without login → redirects to login