### PR TITLE
chore(broadcast): remove debug puts statements

### DIFF
--- a/app/services/broadcast_reliability_service.rb
+++ b/app/services/broadcast_reliability_service.rb
@@ -45,10 +45,8 @@ module Services
     # @param user_id [String] Optional user ID for rate limiting
     # @return [Boolean] Success status
     def broadcast_with_retry(channel:, target:, data:, priority: :medium, attempt: 1, request_ip: nil, user_id: nil)
-      puts "[BROADCAST_DEBUG] Starting broadcast_with_retry with priority: #{priority}"
       Rails.logger.debug "[BROADCAST_DEBUG] Starting broadcast_with_retry with priority: #{priority}"
       validate_priority!(priority)
-      puts "[BROADCAST_DEBUG] Priority validated"
       Rails.logger.debug "[BROADCAST_DEBUG] Priority validated"
 
       # Security validation and rate limiting (only on first attempt)

--- a/spec/services/broadcast_reliability_service_spec.rb
+++ b/spec/services/broadcast_reliability_service_spec.rb
@@ -408,3 +408,25 @@ RSpec.describe Services::BroadcastReliabilityService, type: :service, integratio
     end
   end
 end
+
+RSpec.describe Services::BroadcastReliabilityService, "stdout output",
+               type: :service, unit: true, needs_broadcasting: true do
+  let(:sync_session) { create(:sync_session) }
+
+  before do
+    allow(Services::BroadcastFeatureFlags).to receive(:enabled?).and_return(false)
+    allow(SyncStatusChannel).to receive(:broadcast_to)
+    allow(Services::BroadcastAnalytics).to receive(:record_success)
+  end
+
+  it "does not write to stdout during broadcast_with_retry" do
+    expect {
+      described_class.broadcast_with_retry(
+        channel: SyncStatusChannel,
+        target: sync_session,
+        data: { status: "test" },
+        priority: :medium
+      )
+    }.not_to output.to_stdout
+  end
+end


### PR DESCRIPTION
## Summary
- Remove `puts` debug statements from `BroadcastReliabilityService` (lines 48, 51)
- Retain `Rails.logger.debug` calls for proper logging

## QA Audit Refs
P-13 (HIGH)

## Test plan
- [x] New unit test: verifies no stdout output during `broadcast_with_retry`
- [x] All existing broadcast reliability tests pass
- [x] RuboCop clean
- [x] Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)