### PR TITLE
feat(expenses): UX overhaul — date presets, kebab menu, table density (PER-426-429)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -105,7 +105,14 @@
       "Bash(cp app/views/expenses/index.html.erb /tmp/pr-review-224/source/app/views/expenses/index.html.erb)",
       "Bash(mkdir -p /tmp/pr-review-224/source/app/views/expenses)",
       "Bash(git branch:*)",
-      "Bash(psql -U esoto -d postgres -c \"SELECT count\\(*\\) FROM pg_stat_activity WHERE datname LIKE ''''expense_tracker_test%'''';\")"
+      "Bash(psql -U esoto -d postgres -c \"SELECT count\\(*\\) FROM pg_stat_activity WHERE datname LIKE ''''expense_tracker_test%'''';\")",
+      "Bash(python3 /Users/esoto/.claude/plugins/cache/ui-ux-pro-max-skill/ui-ux-pro-max/2.5.0/.claude/skills/ui-ux-pro-max/scripts/search.py \"finance expense tracker dashboard personal\" --design-system -p \"Expense Tracker\")",
+      "Bash(python3 /Users/esoto/.claude/plugins/cache/ui-ux-pro-max-skill/ui-ux-pro-max/2.5.0/.claude/skills/ui-ux-pro-max/scripts/search.py \"dashboard analytics metrics KPI\" --domain ux -n 15)",
+      "Bash(python3 /Users/esoto/.claude/plugins/cache/ui-ux-pro-max-skill/ui-ux-pro-max/2.5.0/.claude/skills/ui-ux-pro-max/scripts/search.py \"trend comparison proportion real-time\" --domain chart -n 10)",
+      "Bash(python3 /Users/esoto/.claude/plugins/cache/ui-ux-pro-max-skill/ui-ux-pro-max/2.5.0/.claude/skills/ui-ux-pro-max/scripts/search.py \"finance expense budget personal tracker\" --domain product -n 10)",
+      "mcp__linear__list_teams",
+      "mcp__linear__list_projects",
+      "mcp__linear__save_issue"
     ],
     "deny": []
   }

--- a/app/javascript/controllers/date_preset_controller.js
+++ b/app/javascript/controllers/date_preset_controller.js
@@ -1,0 +1,71 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Date Preset Controller
+ * Quick date range selection pills for expense filtering.
+ * Calculates date ranges for common periods and auto-submits the filter form.
+ */
+export default class extends Controller {
+  static targets = ["preset", "startDate", "endDate", "customDates", "form"]
+
+  select(event) {
+    const period = event.currentTarget.dataset.datePresetPeriod
+    this.highlightPreset(event.currentTarget)
+
+    if (period === "custom") {
+      this.customDatesTarget.classList.remove("hidden")
+      return
+    }
+
+    this.customDatesTarget.classList.add("hidden")
+    const { start, end } = this.calculateDates(period)
+    this.startDateTarget.value = start
+    this.endDateTarget.value = end
+    this.formTarget.requestSubmit()
+  }
+
+  calculateDates(period) {
+    const today = new Date()
+    let start, end
+
+    switch (period) {
+      case "this_month":
+        start = new Date(today.getFullYear(), today.getMonth(), 1)
+        end = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+        break
+      case "last_month":
+        start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+        end = new Date(today.getFullYear(), today.getMonth(), 0)
+        break
+      case "this_quarter": {
+        const q = Math.floor(today.getMonth() / 3) * 3
+        start = new Date(today.getFullYear(), q, 1)
+        end = new Date(today.getFullYear(), q + 3, 0)
+        break
+      }
+      case "year_to_date":
+        start = new Date(today.getFullYear(), 0, 1)
+        end = today
+        break
+      default:
+        start = today
+        end = today
+    }
+
+    return {
+      start: this.formatDate(start),
+      end: this.formatDate(end)
+    }
+  }
+
+  formatDate(date) {
+    return date.toISOString().split("T")[0]
+  }
+
+  highlightPreset(active) {
+    this.presetTargets.forEach(p => {
+      p.className = "px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"
+    })
+    active.className = "px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer"
+  }
+}

--- a/app/javascript/controllers/date_preset_controller.js
+++ b/app/javascript/controllers/date_preset_controller.js
@@ -59,7 +59,8 @@ export default class extends Controller {
   }
 
   formatDate(date) {
-    return date.toISOString().split("T")[0]
+    const pad = n => String(n).padStart(2, "0")
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
   }
 
   highlightPreset(active) {

--- a/app/javascript/controllers/kebab_menu_controller.js
+++ b/app/javascript/controllers/kebab_menu_controller.js
@@ -1,0 +1,71 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Kebab Menu Controller
+ * Three-dot dropdown menu for expense row actions.
+ * Handles positioning, click-outside-to-close, and viewport overflow.
+ */
+export default class extends Controller {
+  static targets = ["menu"]
+  static values = { open: { type: Boolean, default: false } }
+
+  connect() {
+    this.closeHandler = this.closeOnClickOutside.bind(this)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeHandler)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+
+    if (this.openValue) {
+      this.close()
+    } else {
+      this.open(event.currentTarget)
+    }
+  }
+
+  open(trigger) {
+    // Close any other open kebab menus
+    document.querySelectorAll("[data-kebab-menu-open-value='true']").forEach(el => {
+      const controller = this.application.getControllerForElementAndIdentifier(el, "kebab-menu")
+      if (controller && controller !== this) controller.close()
+    })
+
+    this.openValue = true
+    this.menuTarget.classList.remove("hidden")
+
+    // Position the dropdown
+    const rect = trigger.getBoundingClientRect()
+    this.menuTarget.style.position = "fixed"
+    this.menuTarget.style.top = `${rect.bottom + 4}px`
+    this.menuTarget.style.left = `${rect.right - 176}px` // 176px = w-44
+
+    // Adjust if overflowing viewport bottom
+    requestAnimationFrame(() => {
+      const menuRect = this.menuTarget.getBoundingClientRect()
+      if (menuRect.bottom > window.innerHeight) {
+        this.menuTarget.style.top = `${rect.top - menuRect.height - 4}px`
+      }
+      if (menuRect.left < 0) {
+        this.menuTarget.style.left = "8px"
+      }
+    })
+
+    document.addEventListener("click", this.closeHandler)
+  }
+
+  close() {
+    this.openValue = false
+    this.menuTarget.classList.add("hidden")
+    document.removeEventListener("click", this.closeHandler)
+  }
+
+  closeOnClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.close()
+    }
+  }
+}

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -102,9 +102,9 @@
       DESKTOP LAYOUT (visible on md+)
       Table-row style: date | merchant | category | amount | bank | status | actions
       ——————————————————————————————————————————————————————————— %>
-  <div class="hidden md:grid md:grid-cols-[40px_120px_1fr_200px_120px_100px_120px_auto] md:items-center md:gap-0">
+  <div class="hidden md:grid md:grid-cols-[40px_100px_1fr_160px_120px_100px_40px] md:items-center md:gap-0">
     <%# Checkbox %>
-    <div class="checkbox-cell px-4 py-4 flex items-center">
+    <div class="checkbox-cell px-3 py-2.5 flex items-center">
       <input type="checkbox"
              data-batch-selection-target="checkbox"
              data-action="change->batch-selection#toggleSelection click->batch-selection#toggleSelection:stop"
@@ -114,181 +114,51 @@
     </div>
 
     <%# Date %>
-    <div class="px-6 py-4 text-sm text-slate-900 whitespace-nowrap">
+    <div class="px-3 py-2.5 text-[13px] text-slate-600 tabular-nums whitespace-nowrap">
       <%= expense.transaction_date.strftime("%d/%m/%Y") %>
     </div>
 
-    <%# Merchant + Description %>
-    <div class="px-6 py-4 text-sm text-slate-900">
-      <div class="font-medium">
+    <%# Merchant + Bank (stacked) %>
+    <div class="px-3 py-2.5">
+      <div class="text-[13px] font-medium text-slate-900 truncate">
         <% if expense.merchant_name? %>
           <%= expense.merchant_name %>
         <% else %>
-          <span class="text-rose-600 italic">⚠️ Sin comercio (verificar)</span>
+          <span class="text-rose-600 italic"><%= t("expenses.card.no_merchant", default: "Sin comercio") %></span>
         <% end %>
       </div>
-      <% if expense.description? && expense.description != expense.merchant_name %>
-        <div class="text-slate-500 text-xs expense-description"><%= expense.description %></div>
-      <% end %>
+      <div class="text-xs text-slate-400"><%= expense.bank_name %></div>
     </div>
 
-    <%# Category %>
-    <div class="px-6 py-4 text-sm whitespace-nowrap">
-      <div class="expense-category-cell relative">
-        <div class="flex items-center gap-3">
-          <% if expense.category %>
-            <div class="w-8 h-8 rounded-full flex items-center justify-center text-white font-bold text-xs flex-shrink-0"
-                 style="background-color: <%= expense.category.color %>;"
-                 title="<%= expense.category.name %>">
-              <%= expense.category.name.first.upcase %>
-            </div>
-          <% else %>
-            <div class="w-8 h-8 rounded-full flex items-center justify-center bg-slate-400 text-white font-bold text-xs flex-shrink-0"
-                 title="Sin categoría">
-              ?
-            </div>
-          <% end %>
-
-          <turbo-frame id="expense_<%= expense.id %>_category" class="flex-1">
-            <%= render "expenses/category_with_confidence", expense: expense %>
-          </turbo-frame>
-        </div>
-
-        <%# Inline Quick Actions %>
-        <div class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 inline-actions-container"
-             data-<%= controller_name %>-target="actionsContainer"
-             data-view-toggle-target="expandedColumns">
-
-          <%# Quick Categorize Button %>
-          <div class="relative">
-            <button type="button"
-                    class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-white border border-slate-200 hover:bg-teal-50 hover:border-teal-300 transition-colors"
-                    data-action="click-><%= controller_name %>#toggleCategoryDropdown"
-                    title="<%= t('expenses.inline_actions.change_category_tooltip') %>"
-                    aria-label="<%= t('expenses.inline_actions.change_category_tooltip') %>">
-              <svg aria-hidden="true" class="w-4 h-4 text-teal-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
-              </svg>
-            </button>
-
-            <%# Category Dropdown %>
-            <div class="category-dropdown-menu w-48 bg-white rounded-lg shadow-lg border border-slate-200 hidden overflow-hidden"
-                 data-<%= controller_name %>-target="categoryDropdown">
-              <div class="py-1 max-h-64 overflow-y-auto">
-                <% (local_assigns[:categories] || Category.all.order(:name)).each do |category| %>
-                <button type="button"
-                        class="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2"
-                        data-action="click-><%= controller_name %>#selectCategory"
-                        data-category-id="<%= category.id %>"
-                        data-category-name="<%= category.name %>"
-                        role="option">
-                  <span class="inline-block w-3 h-3 rounded-full" style="background-color: <%= category.color %>"></span>
-                  <%= category.name %>
-                </button>
-                <% end %>
-              </div>
-            </div>
-          </div>
-
-          <%# Mark as Reviewed Button %>
-          <button type="button"
-                  class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-white border border-slate-200 hover:bg-emerald-50 hover:border-emerald-300 transition-colors"
-                  data-<%= controller_name %>-target="statusButton"
-                  data-action="click-><%= controller_name %>#toggleStatus"
-                  title="<%= expense.status == 'pending' ? t('expenses.inline_actions.mark_reviewed_tooltip') : t('expenses.inline_actions.mark_pending_tooltip') %>"
-                  aria-label="<%= expense.status == 'pending' ? t('expenses.inline_actions.mark_reviewed_tooltip') : t('expenses.inline_actions.mark_pending_tooltip') %>">
-            <% if expense.status == 'pending' %>
-            <svg aria-hidden="true" class="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <% else %>
-            <svg aria-hidden="true" class="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <% end %>
-          </button>
-
-          <%# Duplicate Button %>
-          <button type="button"
-                  class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-white border border-slate-200 hover:bg-amber-50 hover:border-amber-300 transition-colors"
-                  data-<%= controller_name %>-target="duplicateButton"
-                  data-action="click-><%= controller_name %>#duplicateExpense"
-                  title="<%= t('expenses.inline_actions.duplicate_tooltip') %>"
-                  aria-label="<%= t('expenses.inline_actions.duplicate_tooltip') %>">
-            <svg aria-hidden="true" class="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-            </svg>
-          </button>
-
-          <%# Delete Button %>
-          <div class="relative">
-            <button type="button"
-                    class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-white border border-slate-200 hover:bg-rose-50 hover:border-rose-300 transition-colors"
-                    data-action="click-><%= controller_name %>#showDeleteConfirmation"
-                    title="<%= t('expenses.actions.delete_title') %>"
-                    aria-label="<%= t('expenses.actions.delete_aria') %>">
-              <svg aria-hidden="true" class="w-4 h-4 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-              </svg>
-            </button>
-
-            <%# Delete Confirmation Modal %>
-            <div class="delete-confirmation-modal w-56 bg-white rounded-lg shadow-xl border-2 border-rose-200 p-4 hidden"
-                 data-<%= controller_name %>-target="deleteConfirmation">
-              <div class="flex items-start gap-3 mb-3">
-                <div class="flex-shrink-0 w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center">
-                  <svg aria-hidden="true" class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                  </svg>
-                </div>
-                <div class="flex-1">
-                  <h3 class="text-sm font-semibold text-slate-900"><%= t("expenses.inline_actions.confirm_deletion_title") %></h3>
-                  <p class="text-xs text-slate-600 mt-1"><%= t("expenses.inline_actions.confirm_deletion_message") %></p>
-                </div>
-              </div>
-              <div class="flex gap-2">
-                <button type="button"
-                        class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
-                        data-action="click-><%= controller_name %>#confirmDelete">
-                  <%= t("expenses.inline_actions.confirm_button") %>
-                </button>
-                <button type="button"
-                        class="flex-1 px-3 py-1.5 text-xs font-medium text-slate-700 bg-slate-100 rounded-lg hover:bg-slate-200 transition-colors"
-                        data-action="click-><%= controller_name %>#cancelDelete">
-                  <%= t("expenses.inline_actions.cancel_button") %>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <%# Amount %>
-    <div class="px-6 py-4 text-sm font-bold text-slate-900 whitespace-nowrap">
-      ₡<%= number_with_delimiter(expense.amount.to_i) %>
-    </div>
-
-    <%# Bank %>
-    <div class="px-6 py-4 text-sm text-slate-900 whitespace-nowrap" data-view-toggle-target="expandedColumns">
-      <span class="inline-flex px-2 py-1 text-xs font-medium rounded-full
-                   <%= expense.bank_name == 'BAC' ? 'bg-rose-100 text-rose-700' : 'bg-slate-100 text-slate-700' %>">
-        <%= expense.bank_name %>
+    <%# Category (compact: color dot + name) %>
+    <div class="px-3 py-2.5 text-[13px]">
+      <span class="inline-flex items-center gap-1.5">
+        <% if expense.category %>
+          <% safe_color = (expense.category.color.to_s.match?(/\A#[0-9a-fA-F]{3,6}\z/) ? expense.category.color : "#64748b") %>
+          <span class="w-2 h-2 rounded-full shrink-0" style="background-color: <%= safe_color %>"></span>
+          <span class="text-slate-700"><%= expense.category.name %></span>
+        <% else %>
+          <span class="w-2 h-2 rounded-full shrink-0 bg-slate-400"></span>
+          <span class="text-slate-500"><%= t("expenses.card.no_category", default: "Sin categoria") %></span>
+        <% end %>
       </span>
     </div>
 
+    <%# Amount %>
+    <div class="px-3 py-2.5 text-right text-[13px] font-medium text-slate-900 tabular-nums whitespace-nowrap">
+      ₡<%= number_with_delimiter(expense.amount.to_i) %>
+    </div>
+
     <%# Status %>
-    <div class="px-6 py-4 text-sm whitespace-nowrap" data-view-toggle-target="expandedColumns">
+    <div class="px-3 py-2.5 text-center">
       <turbo-frame id="expense_<%= expense.id %>_status">
         <%= render "expenses/status_badge", expense: expense %>
       </turbo-frame>
     </div>
 
-    <%# Actions %>
-    <div class="px-6 py-4 text-sm font-medium space-x-2 whitespace-nowrap" data-view-toggle-target="expandedColumns">
-      <turbo-frame id="expense_<%= expense.id %>_actions">
-        <%= render "expenses/inline_actions", expense: expense %>
-      </turbo-frame>
+    <%# Kebab Menu %>
+    <div class="px-2 py-2.5 text-center">
+      <%= render "expenses/kebab_menu", expense: expense %>
     </div>
   </div>
 

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -130,18 +130,20 @@
       <div class="text-xs text-slate-400"><%= expense.bank_name %></div>
     </div>
 
-    <%# Category (compact: color dot + name) %>
+    <%# Category (compact: color dot + name, with Turbo Frame for updates) %>
     <div class="px-3 py-2.5 text-[13px]">
-      <span class="inline-flex items-center gap-1.5">
-        <% if expense.category %>
-          <% safe_color = (expense.category.color.to_s.match?(/\A#[0-9a-fA-F]{3,6}\z/) ? expense.category.color : "#64748b") %>
-          <span class="w-2 h-2 rounded-full shrink-0" style="background-color: <%= safe_color %>"></span>
-          <span class="text-slate-700"><%= expense.category.name %></span>
-        <% else %>
-          <span class="w-2 h-2 rounded-full shrink-0 bg-slate-400"></span>
-          <span class="text-slate-500"><%= t("expenses.card.no_category", default: "Sin categoria") %></span>
-        <% end %>
-      </span>
+      <turbo-frame id="expense_<%= expense.id %>_category">
+        <span class="inline-flex items-center gap-1.5">
+          <% if expense.category %>
+            <% safe_color = (expense.category.color.to_s.match?(/\A#[0-9a-fA-F]{3,6}\z/) ? expense.category.color : "#64748b") %>
+            <span class="w-2 h-2 rounded-full shrink-0" style="background-color: <%= safe_color %>"></span>
+            <span class="text-slate-700"><%= expense.category.name %></span>
+          <% else %>
+            <span class="w-2 h-2 rounded-full shrink-0 bg-slate-400"></span>
+            <span class="text-slate-500"><%= t("expenses.card.no_category", default: "Sin categoria") %></span>
+          <% end %>
+        </span>
+      </turbo-frame>
     </div>
 
     <%# Amount %>

--- a/app/views/expenses/_kebab_menu.html.erb
+++ b/app/views/expenses/_kebab_menu.html.erb
@@ -1,0 +1,65 @@
+<%# Kebab (three-dot) menu for expense row actions
+    Locals: expense (Expense)
+%>
+<div data-controller="kebab-menu" class="relative">
+  <button type="button"
+          data-action="click->kebab-menu#toggle"
+          class="p-1.5 rounded-md hover:bg-slate-100 text-slate-400 hover:text-slate-600 cursor-pointer transition-colors"
+          aria-label="<%= t('expenses.actions.menu_label', default: 'Acciones') %> — <%= expense.merchant_name %>">
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+    </svg>
+  </button>
+
+  <div data-kebab-menu-target="menu"
+       class="hidden fixed bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-50 w-44"
+       role="menu"
+       aria-label="<%= t('expenses.actions.menu_label', default: 'Acciones') %>">
+
+    <%# Categorize %>
+    <%= link_to "#", class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+        data: { action: "click->inline-actions#toggleCategoryDropdown" } do %>
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
+      </svg>
+      <%= t("expenses.actions.categorize", default: "Categorizar") %>
+    <% end %>
+
+    <%# Mark as processed/pending %>
+    <%= link_to update_status_expense_path(expense), method: :patch, class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+        data: { turbo_method: :patch, turbo_confirm: nil } do %>
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <%= expense.status == "processed" ? t("expenses.actions.mark_pending", default: "Marcar Pendiente") : t("expenses.actions.mark_processed", default: "Marcar Procesado") %>
+    <% end %>
+
+    <%# Duplicate %>
+    <%= link_to duplicate_expense_path(expense), method: :post, class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+        data: { turbo_method: :post } do %>
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+      </svg>
+      <%= t("expenses.actions.duplicate", default: "Duplicar") %>
+    <% end %>
+
+    <%# Edit %>
+    <%= link_to edit_expense_path(expense), class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem" do %>
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
+      </svg>
+      <%= t("expenses.actions.edit", default: "Editar") %>
+    <% end %>
+
+    <div class="border-t border-slate-100 my-1"></div>
+
+    <%# Delete (destructive — separated) %>
+    <%= link_to expense_path(expense), method: :delete, class: "w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+        data: { turbo_method: :delete, turbo_confirm: t("expenses.actions.delete_confirm", default: "¿Eliminar este gasto?") } do %>
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+      </svg>
+      <%= t("expenses.actions.delete", default: "Eliminar") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/expenses/_kebab_menu.html.erb
+++ b/app/views/expenses/_kebab_menu.html.erb
@@ -1,10 +1,13 @@
 <%# Kebab (three-dot) menu for expense row actions
     Locals: expense (Expense)
 %>
+<% next_status = expense.status == "processed" ? "pending" : "processed" %>
 <div data-controller="kebab-menu" class="relative">
   <button type="button"
           data-action="click->kebab-menu#toggle"
           class="p-1.5 rounded-md hover:bg-slate-100 text-slate-400 hover:text-slate-600 cursor-pointer transition-colors"
+          aria-haspopup="true"
+          aria-expanded="false"
           aria-label="<%= t('expenses.actions.menu_label', default: 'Acciones') %> — <%= expense.merchant_name %>">
     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
       <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
@@ -12,30 +15,33 @@
   </button>
 
   <div data-kebab-menu-target="menu"
-       class="hidden fixed bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-50 w-44"
+       class="hidden fixed bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-[60] w-44"
        role="menu"
        aria-label="<%= t('expenses.actions.menu_label', default: 'Acciones') %>">
 
-    <%# Categorize %>
-    <%= link_to "#", class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
-        data: { action: "click->inline-actions#toggleCategoryDropdown" } do %>
+    <%# Categorize — links to edit page with category focus %>
+    <%= link_to edit_expense_path(expense, focus: "category"), class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem" do %>
       <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
       </svg>
       <%= t("expenses.actions.categorize", default: "Categorizar") %>
     <% end %>
 
-    <%# Mark as processed/pending %>
-    <%= link_to update_status_expense_path(expense), method: :patch, class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
-        data: { turbo_method: :patch, turbo_confirm: nil } do %>
+    <%# Mark as processed/pending — includes status param %>
+    <%= link_to update_status_expense_path(expense, status: next_status),
+        class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors",
+        role: "menuitem",
+        data: { turbo_method: :patch } do %>
       <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
       </svg>
-      <%= expense.status == "processed" ? t("expenses.actions.mark_pending", default: "Marcar Pendiente") : t("expenses.actions.mark_processed", default: "Marcar Procesado") %>
+      <%= next_status == "processed" ? t("expenses.actions.mark_processed", default: "Marcar Procesado") : t("expenses.actions.mark_pending", default: "Marcar Pendiente") %>
     <% end %>
 
     <%# Duplicate %>
-    <%= link_to duplicate_expense_path(expense), method: :post, class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+    <%= link_to duplicate_expense_path(expense),
+        class: "w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors",
+        role: "menuitem",
         data: { turbo_method: :post } do %>
       <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
@@ -54,7 +60,9 @@
     <div class="border-t border-slate-100 my-1"></div>
 
     <%# Delete (destructive — separated) %>
-    <%= link_to expense_path(expense), method: :delete, class: "w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors", role: "menuitem",
+    <%= link_to expense_path(expense),
+        class: "w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors",
+        role: "menuitem",
         data: { turbo_method: :delete, turbo_confirm: t("expenses.actions.delete_confirm", default: "¿Eliminar este gasto?") } do %>
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -62,7 +62,7 @@
         <button type="button" data-date-preset-target="preset" data-date-preset-period="this_quarter" data-action="click->date-preset#select"
                 class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_this_quarter", default: "Este Trimestre") %></button>
         <button type="button" data-date-preset-target="preset" data-date-preset-period="year_to_date" data-action="click->date-preset#select"
-                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_year_to_date", default: "Ano Completo") %></button>
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_year_to_date", default: "Año Completo") %></button>
         <button type="button" data-date-preset-target="preset" data-date-preset-period="custom" data-action="click->date-preset#select"
                 class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_custom", default: "Personalizado") %></button>
       </div>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -17,7 +17,7 @@
   </div>
 <% end %>
 
-<div class="space-y-6 overflow-x-hidden" data-controller="accessibility-enhanced">
+<div class="space-y-6" data-controller="accessibility-enhanced">
   <!-- Filter Chips Display -->
   <div data-controller="filter-chips"
        data-filter-chips-base-url-value="/expenses"
@@ -50,8 +50,23 @@
       </div>
     </div>
 
-    <!-- Filters -->
-    <div data-controller="collapsible">
+    <!-- Filters with Date Presets -->
+    <div data-controller="collapsible date-preset">
+      <%# Quick Date Presets %>
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <span class="text-xs font-medium text-slate-500 uppercase tracking-wider mr-1"><%= t("expenses.index.period_label", default: "Periodo") %>:</span>
+        <button type="button" data-date-preset-target="preset" data-date-preset-period="this_month" data-action="click->date-preset#select"
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer"><%= t("expenses.index.preset_this_month", default: "Este Mes") %></button>
+        <button type="button" data-date-preset-target="preset" data-date-preset-period="last_month" data-action="click->date-preset#select"
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_last_month", default: "Mes Anterior") %></button>
+        <button type="button" data-date-preset-target="preset" data-date-preset-period="this_quarter" data-action="click->date-preset#select"
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_this_quarter", default: "Este Trimestre") %></button>
+        <button type="button" data-date-preset-target="preset" data-date-preset-period="year_to_date" data-action="click->date-preset#select"
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_year_to_date", default: "Ano Completo") %></button>
+        <button type="button" data-date-preset-target="preset" data-date-preset-period="custom" data-action="click->date-preset#select"
+                class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"><%= t("expenses.index.preset_custom", default: "Personalizado") %></button>
+      </div>
+
       <%# Mobile filter toggle %>
       <div class="md:hidden mb-3">
         <button type="button"
@@ -77,7 +92,8 @@
                       class: "space-y-4 md:space-y-0 md:flex md:gap-4",
                       local: true,
                       data: {
-                        "filter-persistence-target": "filterForm"
+                        "filter-persistence-target": "filterForm",
+                        "date-preset-target": "form"
                       } do |form| %>
         <div class="flex-1">
           <%= form.select :category, options_from_collection_for_select(Category.all, :name, :name, params[:category]),
@@ -91,17 +107,19 @@
                 {}, { class: "w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500",
                       data: { "filter-persistence-target": "filterInput" } } %>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-wrap gap-2" data-date-preset-target="customDates">
           <%= form.date_field :start_date, value: params[:start_date], placeholder: t("expenses.index.start_date_placeholder"),
                 class: "flex-1 min-w-0 rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500",
-                data: { "filter-persistence-target": "filterInput" } %>
+                data: { "filter-persistence-target": "filterInput", "date-preset-target": "startDate" } %>
           <%= form.date_field :end_date, value: params[:end_date], placeholder: t("expenses.index.end_date_placeholder"),
                 class: "flex-1 min-w-0 rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500",
-                data: { "filter-persistence-target": "filterInput" } %>
+                data: { "filter-persistence-target": "filterInput", "date-preset-target": "endDate" } %>
         </div>
         <div class="flex flex-wrap gap-2">
-          <%= form.submit t("common.filter"), class: "bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg shadow-sm" %>
-          <%= link_to t("expenses.index.clear_filters"), expenses_path, class: "bg-slate-200 hover:bg-slate-300 text-slate-700 px-4 py-2 rounded-lg" %>
+          <%= form.submit t("common.filter"), class: "bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg shadow-sm cursor-pointer" %>
+          <%= link_to t("expenses.index.clear_filters"), expenses_path,
+                class: "bg-slate-200 hover:bg-slate-300 text-slate-700 px-4 py-2 rounded-lg cursor-pointer",
+                data: { action: "click->filter-persistence#clearStorage" } %>
         </div>
         <% end %>
       </div>
@@ -205,23 +223,22 @@
       </div>
     </div>
 
-    <!-- Desktop column headers (hidden on mobile) -->
-    <div class="hidden md:grid md:grid-cols-[40px_120px_1fr_200px_120px_100px_120px_auto] bg-slate-50 border-b border-slate-200 px-0">
+    <!-- Desktop column headers (hidden on mobile, sticky) -->
+    <div class="hidden md:grid md:grid-cols-[40px_100px_1fr_160px_120px_100px_40px] bg-slate-50 border-b border-slate-200 sticky top-0 z-10">
       <!-- Master Checkbox Column -->
-      <div class="checkbox-header hidden px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">
+      <div class="px-3 py-2.5 text-left">
         <input type="checkbox"
                data-batch-selection-target="masterCheckbox"
                data-action="change->batch-selection#toggleMasterSelection"
                class="h-4 w-4 text-teal-600 focus:ring-teal-500 border-slate-300 rounded"
                aria-label="Seleccionar todos los gastos visibles">
       </div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_date") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_merchant") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_category") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_amount") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider" data-view-toggle-target="expandedColumns"><%= t("expenses.index.table_header_bank") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider" data-view-toggle-target="expandedColumns"><%= t("expenses.index.table_header_status") %></div>
-      <div class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider" data-view-toggle-target="expandedColumns"><%= t("expenses.index.table_header_actions") %></div>
+      <div class="px-3 py-2.5 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_date") %></div>
+      <div class="px-3 py-2.5 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_merchant") %></div>
+      <div class="px-3 py-2.5 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_category") %></div>
+      <div class="px-3 py-2.5 text-right text-xs font-semibold text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_amount") %></div>
+      <div class="px-3 py-2.5 text-center text-xs font-semibold text-slate-500 uppercase tracking-wider"><%= t("expenses.index.table_header_status") %></div>
+      <div class="px-2 py-2.5"></div>
     </div>
 
     <!-- Unified expense items list (single loop — eliminates double render) -->
@@ -248,7 +265,7 @@
     </div>
 
     <!-- Batch Selection Toolbar -->
-    <div class="hidden fixed bottom-0 left-0 right-0 bg-white border-t-2 border-teal-600 shadow-lg z-40 px-6 py-4"
+    <div class="hidden fixed bottom-0 left-0 right-0 bg-white border-t-2 border-teal-600 shadow-lg z-50 px-6 py-4"
          data-batch-selection-target="selectionToolbar">
       <div class="max-w-7xl mx-auto flex items-center justify-between">
         <div class="flex items-center gap-4">

--- a/docs/mockups/expenses-index-v2.html
+++ b/docs/mockups/expenses-index-v2.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gastos — Expense Tracker Mockup</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwindcss.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: { 50: '#F0FDFA', 100: '#CCFBF1', 700: '#0F766E', 800: '#115E59' },
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    /* Tabular numbers for financial data */
+    .tabular-nums { font-variant-numeric: tabular-nums; }
+    /* Sticky header */
+    .sticky-header th { position: sticky; top: 0; z-index: 10; }
+    /* Kebab dropdown */
+    .kebab-menu { display: none; }
+    .kebab-menu.active { display: block; }
+    /* Smooth transitions */
+    .transition-colors { transition: background-color 150ms ease, color 150ms ease; }
+    /* Row highlight on selection */
+    .row-selected { background-color: #F0FDFA !important; }
+    /* Mobile card */
+    @media (max-width: 767px) {
+      .desktop-table { display: none; }
+      .mobile-cards { display: block; }
+    }
+    @media (min-width: 768px) {
+      .desktop-table { display: block; }
+      .mobile-cards { display: none; }
+    }
+  </style>
+</head>
+<body class="bg-slate-50 min-h-screen">
+
+  <!-- ============================================ -->
+  <!-- NAV (simplified for mockup)                  -->
+  <!-- ============================================ -->
+  <nav class="bg-white border-b border-slate-200 px-4 py-3">
+    <div class="max-w-7xl mx-auto flex items-center justify-between">
+      <div class="flex items-center gap-6">
+        <span class="text-lg font-bold text-teal-700">Expense Tracker</span>
+        <a href="#" class="text-slate-600 hover:text-teal-700 text-sm font-medium">Dashboard</a>
+        <a href="#" class="text-teal-700 font-semibold text-sm border-b-2 border-teal-700 pb-0.5">Gastos</a>
+        <a href="#" class="text-slate-600 hover:text-teal-700 text-sm font-medium">Presupuestos</a>
+        <a href="#" class="text-slate-600 hover:text-teal-700 text-sm font-medium">Categorizar</a>
+        <a href="#" class="text-slate-600 hover:text-teal-700 text-sm font-medium">Cuentas</a>
+      </div>
+      <a href="#" class="bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm cursor-pointer">+ Nuevo Gasto</a>
+    </div>
+  </nav>
+
+  <main class="max-w-7xl mx-auto px-4 py-6 pb-24">
+
+    <!-- ============================================ -->
+    <!-- HEADER: Title + Summary Stats                -->
+    <!-- ============================================ -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-6">
+      <div class="flex flex-col md:flex-row md:justify-between md:items-center gap-4">
+        <div>
+          <h1 class="text-2xl font-bold text-slate-900">Gastos</h1>
+          <p class="text-sm text-slate-500 mt-1">Administra y filtra todos tus gastos</p>
+        </div>
+        <div class="flex gap-3">
+          <div class="bg-teal-50 rounded-lg px-4 py-2 text-center min-w-[100px]">
+            <div class="text-xl font-bold text-teal-700 tabular-nums">&#8353;1,245,800</div>
+            <div class="text-xs text-slate-500">Total</div>
+          </div>
+          <div class="bg-emerald-50 rounded-lg px-4 py-2 text-center min-w-[80px]">
+            <div class="text-xl font-bold text-emerald-600 tabular-nums">156</div>
+            <div class="text-xs text-slate-500">Gastos</div>
+          </div>
+          <div class="bg-amber-50 rounded-lg px-4 py-2 text-center min-w-[80px]">
+            <div class="text-xl font-bold text-amber-600 tabular-nums">12</div>
+            <div class="text-xs text-slate-500">Categorias</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- FILTERS: Quick Presets + Dropdowns + Clear   -->
+    <!-- ============================================ -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4 mb-6">
+      <!-- Quick Date Presets -->
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <span class="text-xs font-medium text-slate-500 uppercase tracking-wider mr-1">Periodo:</span>
+        <button onclick="selectPreset(this)" class="date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer">Este Mes</button>
+        <button onclick="selectPreset(this)" class="date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">Mes Anterior</button>
+        <button onclick="selectPreset(this)" class="date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">Este Trimestre</button>
+        <button onclick="selectPreset(this)" class="date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">Ano Completo</button>
+        <button onclick="selectPreset(this)" class="date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">Personalizado</button>
+      </div>
+
+      <!-- Filter Row -->
+      <div class="flex flex-wrap items-end gap-3">
+        <!-- Category -->
+        <div class="flex-1 min-w-[140px]">
+          <label class="block text-xs font-medium text-slate-600 mb-1">Categoria</label>
+          <select class="w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 cursor-pointer">
+            <option value="">Todas</option>
+            <option>Alimentacion</option>
+            <option>Transporte</option>
+            <option>Entretenimiento</option>
+            <option>Salud</option>
+            <option>Servicios</option>
+            <option>Compras</option>
+          </select>
+        </div>
+        <!-- Bank -->
+        <div class="flex-1 min-w-[140px]">
+          <label class="block text-xs font-medium text-slate-600 mb-1">Banco</label>
+          <select class="w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 cursor-pointer">
+            <option value="">Todos</option>
+            <option>BAC</option>
+            <option>BCR</option>
+            <option>Scotiabank</option>
+            <option>Promerica</option>
+          </select>
+        </div>
+        <!-- Custom Date From -->
+        <div class="flex-1 min-w-[140px]" id="customDateFrom" style="display:none">
+          <label class="block text-xs font-medium text-slate-600 mb-1">Desde</label>
+          <input type="date" class="w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500">
+        </div>
+        <!-- Custom Date To -->
+        <div class="flex-1 min-w-[140px]" id="customDateTo" style="display:none">
+          <label class="block text-xs font-medium text-slate-600 mb-1">Hasta</label>
+          <input type="date" class="w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500">
+        </div>
+        <!-- Buttons -->
+        <div class="flex gap-2">
+          <button class="px-4 py-2 bg-teal-700 text-white text-sm font-medium rounded-lg hover:bg-teal-800 shadow-sm cursor-pointer transition-colors">
+            Filtrar
+          </button>
+          <button onclick="clearFilters()" class="px-4 py-2 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 border border-slate-300 cursor-pointer transition-colors">
+            Limpiar
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- TABLE: Desktop                               -->
+    <!-- ============================================ -->
+    <div class="desktop-table bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+      <table class="w-full text-sm">
+        <thead class="sticky-header">
+          <tr class="bg-slate-50 border-b border-slate-200">
+            <th class="w-10 px-3 py-3 text-left">
+              <input type="checkbox" id="masterCheckbox" onchange="toggleAll(this)" class="rounded border-slate-300 text-teal-700 focus:ring-teal-500 cursor-pointer" aria-label="Seleccionar todos">
+            </th>
+            <th class="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer hover:text-slate-700" onclick="sortBy('date')">
+              Fecha <span class="text-slate-400">&#x25BC;</span>
+            </th>
+            <th class="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer hover:text-slate-700">
+              Comercio
+            </th>
+            <th class="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer hover:text-slate-700">
+              Categoria
+            </th>
+            <th class="px-3 py-3 text-right text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer hover:text-slate-700" onclick="sortBy('amount')">
+              Monto
+            </th>
+            <th class="px-3 py-3 text-center text-xs font-semibold text-slate-500 uppercase tracking-wider">
+              Estado
+            </th>
+            <th class="w-10 px-3 py-3"></th>
+          </tr>
+        </thead>
+        <tbody id="expenseTableBody">
+          <!-- Rows injected by JS -->
+        </tbody>
+      </table>
+
+      <!-- Pagination -->
+      <div class="flex items-center justify-between px-4 py-3 border-t border-slate-200 bg-slate-50">
+        <p class="text-xs text-slate-500">Mostrando <span class="font-medium text-slate-700">1</span> a <span class="font-medium text-slate-700">10</span> de <span class="font-medium text-slate-700">156</span> gastos</p>
+        <div class="flex gap-1">
+          <button class="px-3 py-1.5 text-xs rounded-md bg-slate-200 text-slate-400 cursor-not-allowed" disabled>Anterior</button>
+          <button class="px-3 py-1.5 text-xs rounded-md bg-teal-700 text-white font-medium shadow-sm">1</button>
+          <button class="px-3 py-1.5 text-xs rounded-md bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">2</button>
+          <button class="px-3 py-1.5 text-xs rounded-md bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">3</button>
+          <span class="px-2 py-1.5 text-xs text-slate-400">...</span>
+          <button class="px-3 py-1.5 text-xs rounded-md bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">16</button>
+          <button class="px-3 py-1.5 text-xs rounded-md bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors">Siguiente</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- MOBILE CARDS                                 -->
+    <!-- ============================================ -->
+    <div class="mobile-cards space-y-3">
+      <div id="mobileCardContainer">
+        <!-- Cards injected by JS -->
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ============================================ -->
+  <!-- BULK ACTIONS TOOLBAR (fixed bottom)          -->
+  <!-- z-50 ensures it's above everything           -->
+  <!-- ============================================ -->
+  <div id="bulkToolbar" class="fixed bottom-0 left-0 right-0 bg-white border-t-2 border-teal-600 shadow-lg z-50 transform translate-y-full transition-transform duration-200" style="transition: transform 200ms ease-out;">
+    <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-teal-100 text-teal-700 text-sm font-bold" id="selectedCount">0</span>
+        <span class="text-sm font-medium text-slate-700"><span id="selectedLabel">0</span> gastos seleccionados</span>
+        <button onclick="clearSelection()" class="text-xs text-slate-500 hover:text-slate-700 underline cursor-pointer">Deseleccionar</button>
+      </div>
+      <div class="flex items-center gap-2">
+        <button class="px-4 py-2 bg-teal-700 text-white text-sm font-medium rounded-lg hover:bg-teal-800 shadow-sm cursor-pointer transition-colors">
+          <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
+          Categorizar
+        </button>
+        <button class="px-4 py-2 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 border border-slate-300 cursor-pointer transition-colors">
+          <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+          Cambiar Estado
+        </button>
+        <button class="px-4 py-2 bg-rose-50 text-rose-700 text-sm font-medium rounded-lg hover:bg-rose-100 border border-rose-200 cursor-pointer transition-colors">
+          <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+          Eliminar
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================ -->
+  <!-- KEBAB DROPDOWN TEMPLATE                      -->
+  <!-- ============================================ -->
+  <div id="kebabDropdown" class="kebab-menu fixed bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-50 w-44" style="display:none">
+    <button class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors">
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
+      Categorizar
+    </button>
+    <button class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors">
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      Marcar Procesado
+    </button>
+    <button class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors">
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+      Duplicar
+    </button>
+    <button class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 cursor-pointer transition-colors">
+      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
+      Editar
+    </button>
+    <div class="border-t border-slate-100 my-1"></div>
+    <button class="w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+      Eliminar
+    </button>
+  </div>
+
+  <script>
+    // ==========================================
+    // SAMPLE DATA
+    // ==========================================
+    const expenses = [
+      { id: 1, date: '08/04/2026', merchant: 'Auto Mercado Escazu', category: 'Alimentacion', categoryColor: '#0F766E', amount: 45320, status: 'processed', bank: 'BAC' },
+      { id: 2, date: '07/04/2026', merchant: 'Uber Costa Rica', category: 'Transporte', categoryColor: '#7C3AED', amount: 8750, status: 'processed', bank: 'BAC' },
+      { id: 3, date: '07/04/2026', merchant: 'Netflix', category: 'Entretenimiento', categoryColor: '#EC4899', amount: 6500, status: 'pending', bank: 'Scotiabank' },
+      { id: 4, date: '06/04/2026', merchant: 'Farmacia Fischel', category: 'Salud', categoryColor: '#06B6D4', amount: 12800, status: 'processed', bank: 'BCR' },
+      { id: 5, date: '06/04/2026', merchant: 'ICE Electricidad', category: 'Servicios', categoryColor: '#F59E0B', amount: 28450, status: 'processed', bank: 'BCR' },
+      { id: 6, date: '05/04/2026', merchant: 'Walmart Heredia', category: 'Compras', categoryColor: '#8B5CF6', amount: 67200, status: 'pending', bank: 'BAC' },
+      { id: 7, date: '05/04/2026', merchant: 'Gasolinera Total', category: 'Transporte', categoryColor: '#7C3AED', amount: 22000, status: 'processed', bank: 'Promerica' },
+      { id: 8, date: '04/04/2026', merchant: 'Restaurante Nuestra Tierra', category: 'Alimentacion', categoryColor: '#0F766E', amount: 18500, status: 'processed', bank: 'BAC' },
+      { id: 9, date: '03/04/2026', merchant: 'Amazon CR', category: 'Compras', categoryColor: '#8B5CF6', amount: 95000, status: 'pending', bank: 'Scotiabank' },
+      { id: 10, date: '02/04/2026', merchant: 'Kolbi Celular', category: 'Servicios', categoryColor: '#F59E0B', amount: 15600, status: 'processed', bank: 'BCR' },
+    ];
+
+    const selectedIds = new Set();
+
+    // ==========================================
+    // RENDER TABLE
+    // ==========================================
+    function renderTable() {
+      const tbody = document.getElementById('expenseTableBody');
+      const mobileContainer = document.getElementById('mobileCardContainer');
+
+      tbody.innerHTML = expenses.map(exp => `
+        <tr class="border-b border-slate-100 hover:bg-slate-50 transition-colors ${selectedIds.has(exp.id) ? 'row-selected' : ''}" data-id="${exp.id}">
+          <td class="px-3 py-2.5">
+            <input type="checkbox" ${selectedIds.has(exp.id) ? 'checked' : ''} onchange="toggleRow(${exp.id}, this)" class="rounded border-slate-300 text-teal-700 focus:ring-teal-500 cursor-pointer" aria-label="Seleccionar gasto ${exp.id}">
+          </td>
+          <td class="px-3 py-2.5 text-slate-600 tabular-nums text-[13px]">${exp.date}</td>
+          <td class="px-3 py-2.5">
+            <div class="font-medium text-slate-900 text-[13px] truncate max-w-[200px]">${exp.merchant}</div>
+            <div class="text-xs text-slate-400">${exp.bank}</div>
+          </td>
+          <td class="px-3 py-2.5">
+            <span class="inline-flex items-center gap-1.5">
+              <span class="w-2 h-2 rounded-full shrink-0" style="background-color: ${exp.categoryColor}"></span>
+              <span class="text-[13px] text-slate-700">${exp.category}</span>
+            </span>
+          </td>
+          <td class="px-3 py-2.5 text-right font-medium text-slate-900 tabular-nums text-[13px]">&#8353;${exp.amount.toLocaleString('es-CR')}</td>
+          <td class="px-3 py-2.5 text-center">
+            ${exp.status === 'processed'
+              ? '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200"><svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Procesado</span>'
+              : '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200"><svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>Pendiente</span>'
+            }
+          </td>
+          <td class="px-3 py-2.5 text-center">
+            <button onclick="toggleKebab(event, ${exp.id})" class="p-1.5 rounded-md hover:bg-slate-100 text-slate-400 hover:text-slate-600 cursor-pointer transition-colors" aria-label="Acciones para ${exp.merchant}">
+              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/></svg>
+            </button>
+          </td>
+        </tr>
+      `).join('');
+
+      // Mobile cards
+      mobileContainer.innerHTML = expenses.map(exp => `
+        <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4 ${selectedIds.has(exp.id) ? 'ring-2 ring-teal-300' : ''}" data-id="${exp.id}">
+          <div class="flex items-center justify-between mb-2">
+            <div class="flex items-center gap-3">
+              <input type="checkbox" ${selectedIds.has(exp.id) ? 'checked' : ''} onchange="toggleRow(${exp.id}, this)" class="rounded border-slate-300 text-teal-700 focus:ring-teal-500 cursor-pointer">
+              <div>
+                <p class="font-medium text-slate-900 text-sm">${exp.merchant}</p>
+                <p class="text-xs text-slate-500">${exp.date} &middot; ${exp.bank}</p>
+              </div>
+            </div>
+            <div class="text-right">
+              <p class="font-bold text-slate-900 tabular-nums">&#8353;${exp.amount.toLocaleString('es-CR')}</p>
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="inline-flex items-center gap-1.5">
+              <span class="w-2 h-2 rounded-full" style="background-color: ${exp.categoryColor}"></span>
+              <span class="text-xs text-slate-600">${exp.category}</span>
+            </span>
+            <div class="flex items-center gap-2">
+              ${exp.status === 'processed'
+                ? '<span class="text-xs text-emerald-600 font-medium">Procesado</span>'
+                : '<span class="text-xs text-amber-600 font-medium">Pendiente</span>'
+              }
+              <button onclick="toggleKebab(event, ${exp.id})" class="p-1.5 rounded-md hover:bg-slate-100 text-slate-400 cursor-pointer" aria-label="Acciones">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      `).join('');
+    }
+
+    // ==========================================
+    // SELECTION
+    // ==========================================
+    function toggleRow(id, checkbox) {
+      if (checkbox.checked) {
+        selectedIds.add(id);
+      } else {
+        selectedIds.delete(id);
+      }
+      updateBulkToolbar();
+      renderTable();
+    }
+
+    function toggleAll(masterCheckbox) {
+      if (masterCheckbox.checked) {
+        expenses.forEach(e => selectedIds.add(e.id));
+      } else {
+        selectedIds.clear();
+      }
+      updateBulkToolbar();
+      renderTable();
+    }
+
+    function clearSelection() {
+      selectedIds.clear();
+      document.getElementById('masterCheckbox').checked = false;
+      updateBulkToolbar();
+      renderTable();
+    }
+
+    function updateBulkToolbar() {
+      const toolbar = document.getElementById('bulkToolbar');
+      const count = selectedIds.size;
+      document.getElementById('selectedCount').textContent = count;
+      document.getElementById('selectedLabel').textContent = count;
+
+      if (count > 0) {
+        toolbar.style.transform = 'translateY(0)';
+      } else {
+        toolbar.style.transform = 'translateY(100%)';
+      }
+    }
+
+    // ==========================================
+    // KEBAB MENU
+    // ==========================================
+    let activeKebab = null;
+
+    function toggleKebab(event, id) {
+      event.stopPropagation();
+      const dropdown = document.getElementById('kebabDropdown');
+      const btn = event.currentTarget;
+      const rect = btn.getBoundingClientRect();
+
+      if (activeKebab === id) {
+        dropdown.style.display = 'none';
+        activeKebab = null;
+        return;
+      }
+
+      activeKebab = id;
+      dropdown.style.display = 'block';
+      dropdown.style.top = (rect.bottom + 4) + 'px';
+      dropdown.style.left = (rect.right - 176) + 'px'; // 176 = w-44
+
+      // Ensure dropdown doesn't overflow viewport
+      const dropRect = dropdown.getBoundingClientRect();
+      if (dropRect.bottom > window.innerHeight) {
+        dropdown.style.top = (rect.top - dropRect.height - 4) + 'px';
+      }
+    }
+
+    document.addEventListener('click', () => {
+      document.getElementById('kebabDropdown').style.display = 'none';
+      activeKebab = null;
+    });
+
+    // ==========================================
+    // DATE PRESETS
+    // ==========================================
+    function selectPreset(btn) {
+      document.querySelectorAll('.date-preset').forEach(b => {
+        b.className = 'date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors';
+      });
+      btn.className = 'date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer';
+
+      const isCustom = btn.textContent.trim() === 'Personalizado';
+      document.getElementById('customDateFrom').style.display = isCustom ? 'block' : 'none';
+      document.getElementById('customDateTo').style.display = isCustom ? 'block' : 'none';
+    }
+
+    function clearFilters() {
+      // Reset presets
+      document.querySelectorAll('.date-preset').forEach((b, i) => {
+        if (i === 0) {
+          b.className = 'date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer';
+        } else {
+          b.className = 'date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors';
+        }
+      });
+      // Reset selects
+      document.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+      // Hide custom dates
+      document.getElementById('customDateFrom').style.display = 'none';
+      document.getElementById('customDateTo').style.display = 'none';
+    }
+
+    function sortBy(col) {
+      // Placeholder — just shows the concept
+      console.log('Sort by:', col);
+    }
+
+    // ==========================================
+    // INIT
+    // ==========================================
+    renderTable();
+  </script>
+</body>
+</html>

--- a/docs/plans/2026-04-08-expenses-page-ux-improvements.md
+++ b/docs/plans/2026-04-08-expenses-page-ux-improvements.md
@@ -1,0 +1,36 @@
+# Expenses Page UX Improvements — Implementation Plan
+
+**Goal:** Fix critical bugs and improve usability of the expenses index page
+
+**UX Source:** UI/UX Pro Max skill — Data-Dense Dashboard + Financial Dashboard + Personal Finance Tracker patterns
+
+## Design Principles (from UX/UI Pro Max)
+
+- **Data-Dense Dashboard**: Row hover highlighting, 36px row height, sticky headers, sortable columns, 12-14px data font, 8px grid gaps
+- **Financial Dashboard**: Currency formatting, sticky headers, status via color + text, audit trail pattern
+- **Minimalism + Accessible**: WCAG AA minimum, color not the only indicator, visible focus states
+
+## Tickets
+
+### BUG FIXES (Critical)
+
+| # | Title | Description | Complexity |
+|---|-------|-------------|------------|
+| 1 | Fix bulk actions toolbar visibility | Toolbar renders at bottom but clips/fades — likely z-index stacking context issue. The toolbar is `fixed z-40` but a parent with `overflow-hidden` clips it. Debug and fix CSS. | Easy |
+| 2 | Fix clear filters button | Clear button doesn't reset applied filters. Debug `filter-persistence-controller` — likely sessionStorage not being cleared, or form reset not triggering submission. | Easy |
+
+### UX IMPROVEMENTS (High Priority)
+
+| # | Title | Description | Complexity |
+|---|-------|-------------|------------|
+| 3 | Add date filter quick presets | Add segmented quick-select above date pickers: `[ This Month | Last Month | This Quarter | Year to Date | Custom ]`. Selecting a preset auto-populates dates and submits. "Custom" reveals the date pickers. Follows same pattern as dashboard period selector. | Easy |
+| 4 | Replace inline row actions with kebab menu | Move categorize/status/duplicate/delete actions behind a three-dot (kebab) menu per row. On click, show a small dropdown. This prevents action buttons from overlapping expense data in both compact and expanded views. UX Pro Max recommends: actions on hover/click, not always visible. | Medium |
+| 5 | Improve table density and spacing | Apply Data-Dense Dashboard pattern: 36px row height (currently ~60px), 12-14px data text, 8px gaps, sticky column headers. Compact mode is default. Expanded mode adds bank + status columns but keeps kebab menu — never shows inline buttons. | Medium |
+
+### POLISH (Medium Priority)
+
+| # | Title | Description | Complexity |
+|---|-------|-------------|------------|
+| 6 | Add row hover highlighting | Subtle `hover:bg-slate-50` on table rows for visual tracking. Currently no row hover. Data-Dense Dashboard pattern requires this. | Easy |
+| 7 | Add column sorting | Sortable columns for date, merchant, amount, category. Click header to toggle asc/desc. Arrow indicator on active sort. Financial Dashboard pattern recommends this. | Medium |
+| 8 | Improve mobile card actions | Mobile action drawer buttons are small. Increase touch targets to 44px minimum. Simplify to 4 primary actions: Categorize, Status, Edit, Delete. | Easy |

--- a/docs/plans/2026-04-09-expenses-page-ux.md
+++ b/docs/plans/2026-04-09-expenses-page-ux.md
@@ -1,0 +1,211 @@
+# Expenses Page UX Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix bugs and apply Data-Dense Dashboard UX pattern to expenses index page
+
+**Architecture:** Modify existing ERB views + Stimulus controllers. No new models or services. Changes to: index.html.erb, _expense_item.html.erb, filter-persistence-controller.js, batch-selection-controller.js, new date-preset-controller.js, new kebab-menu-controller.js. Mockup reference: `docs/mockups/expenses-index-v2.html`
+
+**Tech Stack:** Rails 8.1, Hotwire (Turbo + Stimulus), Tailwind CSS, Import Maps
+
+**Linear Tickets:** PER-426 (bugs), PER-427 (date presets), PER-428 (kebab menu), PER-429 (table styling)
+
+---
+
+### Task 1: Fix bulk actions toolbar visibility (PER-426 part 1)
+
+**Files:**
+- Modify: `app/views/expenses/index.html.erb:20` — remove `overflow-x-hidden` from container
+- Modify: `app/views/expenses/index.html.erb:251` — change toolbar z-index from `z-40` to `z-50`
+- Test: `spec/requests/per419_expenses_index_standalone_spec.rb` — add assertion for toolbar visibility
+
+**Step 1: Write failing test**
+
+Add to `spec/requests/per419_expenses_index_standalone_spec.rb`:
+```ruby
+it "bulk selection toolbar has z-50 for visibility" do
+  get expenses_path
+  expect(response.body).to include("z-50")
+  expect(response.body).not_to include("overflow-x-hidden")
+end
+```
+
+**Step 2: Run test — verify fail**
+Run: `bundle exec rspec spec/requests/per419_expenses_index_standalone_spec.rb -e "z-50"`
+
+**Step 3: Fix the CSS**
+- Line 20: change `overflow-x-hidden` to remove it (or use `overflow-x-clip` which doesn't create stacking context)
+- Line 251: change `z-40` to `z-50`
+
+**Step 4: Run test — verify pass**
+
+**Step 5: Commit**
+```
+fix(expenses): fix bulk toolbar z-index and remove overflow-hidden clipping
+```
+
+---
+
+### Task 2: Fix clear filters button (PER-426 part 2)
+
+**Files:**
+- Modify: `app/views/expenses/index.html.erb:104` — clear filters link
+- Modify: `app/javascript/controllers/filter_persistence_controller.js` — add clearStorage method
+- Test: request spec
+
+**Step 1: Investigate the clear button**
+The clear button is `link_to expenses_path` (line 104) which navigates to `/expenses` without params. BUT `filter-persistence-controller` auto-restores from sessionStorage, so the cleared URL gets re-populated. The fix: add `data-action="click->filter-persistence#clearStorage"` to the clear button, and implement `clearStorage()` in the controller.
+
+**Step 2: Write failing test**
+```ruby
+it "clear filters link includes data-action for filter persistence clear" do
+  get expenses_path
+  expect(response.body).to include("filter-persistence#clearStorage")
+end
+```
+
+**Step 3: Implement fix**
+- Add `data: { action: "click->filter-persistence#clearStorage" }` to the clear link
+- Add `clearStorage()` method to filter_persistence_controller.js that clears sessionStorage keys
+
+**Step 4: Verify pass + commit**
+
+---
+
+### Task 3: Add date filter quick presets (PER-427)
+
+**Files:**
+- Create: `app/javascript/controllers/date_preset_controller.js`
+- Modify: `app/views/expenses/index.html.erb` — add preset pills above filter form
+- Test: request spec
+
+**Step 1: Create Stimulus controller**
+```javascript
+// date_preset_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["preset", "startDate", "endDate", "customDates", "form"]
+
+  select(event) {
+    const period = event.currentTarget.dataset.period
+    this.highlightPreset(event.currentTarget)
+
+    if (period === "custom") {
+      this.customDatesTarget.classList.remove("hidden")
+      return
+    }
+
+    this.customDatesTarget.classList.add("hidden")
+    const { start, end } = this.calculateDates(period)
+    this.startDateTarget.value = start
+    this.endDateTarget.value = end
+    this.formTarget.requestSubmit()
+  }
+
+  calculateDates(period) {
+    const today = new Date()
+    let start, end
+    switch (period) {
+      case "this_month":
+        start = new Date(today.getFullYear(), today.getMonth(), 1)
+        end = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+        break
+      case "last_month":
+        start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+        end = new Date(today.getFullYear(), today.getMonth(), 0)
+        break
+      case "this_quarter":
+        const q = Math.floor(today.getMonth() / 3) * 3
+        start = new Date(today.getFullYear(), q, 1)
+        end = new Date(today.getFullYear(), q + 3, 0)
+        break
+      case "year_to_date":
+        start = new Date(today.getFullYear(), 0, 1)
+        end = today
+        break
+    }
+    return {
+      start: start.toISOString().split("T")[0],
+      end: end.toISOString().split("T")[0]
+    }
+  }
+
+  highlightPreset(active) {
+    this.presetTargets.forEach(p => {
+      p.className = "date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"
+    })
+    active.className = "date-preset px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer"
+  }
+}
+```
+
+**Step 2: Add preset pills to index.html.erb** — insert above the filter form, inside the filter-persistence div
+
+**Step 3: Write test + verify**
+
+**Step 4: Commit**
+
+---
+
+### Task 4: Replace inline actions with kebab menu (PER-428)
+
+**Files:**
+- Create: `app/javascript/controllers/kebab_menu_controller.js`
+- Create: `app/views/expenses/_kebab_menu.html.erb`
+- Modify: `app/views/expenses/_expense_item.html.erb` — replace inline action buttons with kebab button
+- Test: request spec
+
+**Step 1: Create kebab Stimulus controller**
+Simple controller: toggles a dropdown. Closes on click outside. Positions dropdown to avoid viewport overflow.
+
+**Step 2: Create kebab menu partial**
+Dropdown with: Categorizar, Marcar Procesado, Duplicar, Editar, separator, Eliminar (rose colored).
+
+**Step 3: Replace inline actions in _expense_item.html.erb**
+Remove the inline action buttons from the desktop grid columns. Add a kebab button as the last column. For mobile, replace the action drawer with the same kebab pattern.
+
+**Step 4: Write tests + verify**
+
+**Step 5: Commit**
+
+---
+
+### Task 5: Improve table density and styling (PER-429)
+
+**Files:**
+- Modify: `app/views/expenses/index.html.erb` — column headers
+- Modify: `app/views/expenses/_expense_item.html.erb` — row padding, font sizes, stacked merchant+bank
+- Test: visual verification via Playwright
+
+**Step 1: Reduce row padding**
+- Change `py-3` to `py-2` on rows
+- Change data text to `text-[13px]`
+- Add `tabular-nums` to amount columns
+
+**Step 2: Stack merchant + bank in one column**
+Show merchant name as primary, bank as secondary text below. Remove separate bank column.
+
+**Step 3: Add sticky headers**
+Add `sticky top-0 z-10` to column header row.
+
+**Step 4: Simplify column grid**
+New grid: `[40px_100px_1fr_160px_120px_100px_40px]` — checkbox, date, merchant+bank, category, amount, status, kebab
+
+**Step 5: Write test + verify + commit**
+
+---
+
+### Task 6: Final integration test + cleanup
+
+**Files:**
+- Test: `spec/requests/expenses_index_ux_spec.rb`
+- Run: full unit test suite
+
+**Step 1: Write integration spec**
+Cover: page renders, presets present, kebab menu markup, no inline action buttons, toolbar z-50, tabular-nums on amounts
+
+**Step 2: Run full suite**
+`bundle exec rspec --tag unit`
+
+**Step 3: Commit + push + PR**

--- a/spec/requests/per419_expenses_index_standalone_spec.rb
+++ b/spec/requests/per419_expenses_index_standalone_spec.rb
@@ -235,44 +235,44 @@ RSpec.describe "PER-419: Expenses index standalone verification", type: :request
       expect(response.body).to include('data-view-toggle-target="itemList"')
     end
 
-    it "renders the expanded columns targets for desktop headers" do
-      expect(response.body).to include('data-view-toggle-target="expandedColumns"')
+    it "renders the item list target" do
+      expect(response.body).to include('data-view-toggle-target="itemList"')
     end
   end
 
-  describe "inline actions on expense items" do
+  describe "kebab menu on expense items" do
     before { get expenses_path }
 
-    it "renders inline-actions expense-id value on expense rows" do
+    it "renders inline-actions controller on expense rows" do
       expect(response.body).to include("data-inline-actions-expense-id-value=\"#{expense.id}\"")
     end
 
-    it "renders inline-actions current-status value on expense rows" do
-      expect(response.body).to include('data-inline-actions-current-status-value="processed"')
+    it "renders kebab-menu controller on expense rows" do
+      expect(response.body).to include('data-controller="kebab-menu"')
     end
 
-    it "renders the category dropdown toggle action" do
-      expect(response.body).to include("click->inline-actions#toggleCategoryDropdown")
+    it "renders kebab toggle action" do
+      expect(response.body).to include("click->kebab-menu#toggle")
     end
 
-    it "renders the status toggle action" do
-      expect(response.body).to include("click->inline-actions#toggleStatus")
+    it "renders kebab dropdown with edit link" do
+      expect(response.body).to include("Editar")
     end
 
-    it "renders the duplicate action" do
-      expect(response.body).to include("click->inline-actions#duplicateExpense")
+    it "renders kebab dropdown with delete link" do
+      expect(response.body).to include("Eliminar")
     end
 
-    it "renders the delete confirmation action" do
-      expect(response.body).to include("click->inline-actions#showDeleteConfirmation")
+    it "renders kebab dropdown with categorize action" do
+      expect(response.body).to include("Categorizar")
     end
 
-    it "renders the category dropdown target" do
-      expect(response.body).to include('data-inline-actions-target="categoryDropdown"')
+    it "renders kebab dropdown with status toggle" do
+      expect(response.body).to match(/Marcar Procesado|Marcar Pendiente/)
     end
 
-    it "renders the delete confirmation target" do
-      expect(response.body).to include('data-inline-actions-target="deleteConfirmation"')
+    it "renders kebab dropdown with duplicate action" do
+      expect(response.body).to include("Duplicar")
     end
   end
 

--- a/spec/views/expenses/_expense_item.html.erb_spec.rb
+++ b/spec/views/expenses/_expense_item.html.erb_spec.rb
@@ -240,28 +240,24 @@ RSpec.describe "expenses/_expense_item.html.erb", type: :view, unit: true do
   describe "desktop row layout" do
     before { render_item(processed_expense) }
 
-    it "renders the inline-actions actionsContainer target" do
-      expect(rendered).to have_css('[data-inline-actions-target="actionsContainer"]', visible: :all)
+    it "renders the kebab menu controller" do
+      expect(rendered).to have_css('[data-controller="kebab-menu"]', visible: :all)
     end
 
-    it "renders the category dropdown for desktop" do
-      expect(rendered).to have_css('[data-inline-actions-target="categoryDropdown"]', visible: :all)
+    it "renders the kebab menu toggle button" do
+      expect(rendered).to have_css('[data-action="click->kebab-menu#toggle"]', visible: :all)
     end
 
-    it "renders the delete confirmation modal" do
-      expect(rendered).to have_css('[data-inline-actions-target="deleteConfirmation"]', visible: :all)
+    it "renders the kebab menu dropdown target" do
+      expect(rendered).to have_css('[data-kebab-menu-target="menu"]', visible: :all)
     end
 
-    it "renders expandedColumns targets for view toggle" do
-      expect(rendered).to have_css('[data-view-toggle-target="expandedColumns"]', visible: :all, minimum: 3)
+    it "renders category as compact color dot + name" do
+      expect(rendered).to have_css(".w-2.h-2.rounded-full", visible: :all)
     end
 
-    it "has category options in the desktop dropdown" do
-      expect(rendered).to have_css("[data-category-id='#{category.id}']", visible: :all)
-    end
-
-    it "has category name in the desktop dropdown" do
-      expect(rendered).to have_css("[data-category-name='Alimentación']", visible: :all)
+    it "renders the status badge" do
+      expect(rendered).to have_css("turbo-frame#expense_#{processed_expense.id}_status", visible: :all)
     end
   end
 
@@ -272,8 +268,8 @@ RSpec.describe "expenses/_expense_item.html.erb", type: :view, unit: true do
     context "when expense has a category" do
       before { render_item(processed_expense) }
 
-      it "renders the category turbo-frame with the correct ID" do
-        expect(rendered).to have_css("turbo-frame#expense_#{processed_expense.id}_category")
+      it "renders the category name" do
+        expect(rendered).to have_text("Alimentación")
       end
 
       it "renders the mobile category name span for Turbo Stream updates" do


### PR DESCRIPTION
## Summary

Major UX overhaul of the expenses index page based on UI/UX Pro Max analysis (Data-Dense Dashboard + Financial Dashboard patterns).

**Bug fixes:**
- Bulk actions toolbar now visible (removed `overflow-x-hidden` clipping, bumped to `z-50`)
- Clear filters button now clears sessionStorage via `filter-persistence#clearStorage`

**New features:**
- Quick date preset pills: Este Mes, Mes Anterior, Este Trimestre, Ano Completo, Personalizado — new `date-preset-controller`
- Kebab (three-dot) menu replacing inline row actions — new `kebab-menu-controller` + `_kebab_menu.html.erb` partial
- Delete action visually separated (rose colored) in dropdown

**Table improvements:**
- Compact ~40px rows (was ~60px), 13px data font
- Merchant + bank stacked in one column (removes separate bank column)
- 7-column grid (was 8) — simpler, less cramped
- Category as compact color dot + name (was large circle avatar)
- Sticky column headers with `z-10`
- `tabular-nums` on amounts for aligned numbers

## Tickets

- [PER-426](https://linear.app/personal-brand-esoto/issue/PER-426) — Fix bulk toolbar + clear filters
- [PER-427](https://linear.app/personal-brand-esoto/issue/PER-427) — Date filter presets
- [PER-428](https://linear.app/personal-brand-esoto/issue/PER-428) — Kebab menu
- [PER-429](https://linear.app/personal-brand-esoto/issue/PER-429) — Table density

## Test plan

- [x] All pre-commit checks pass (unit tests, RuboCop, Brakeman, Rails Best Practices)
- [x] 60 expenses index standalone specs pass
- [x] 42 expense item view specs updated and passing
- [x] HTML mockup reference: `docs/mockups/expenses-index-v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)