### PR TITLE
feat(expenses): delete confirmation modal, status toggle fix, date preset UX (PER-435)

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -374,7 +374,7 @@ class ExpensesController < ApplicationController
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace("expense_#{@expense.id}_status", partial: "expenses/status_badge", locals: { expense: @expense }),
-            turbo_stream.replace("expense_#{@expense.id}_actions", partial: "expenses/inline_actions", locals: { expense: @expense })
+            turbo_stream.update("expense_#{@expense.id}_actions", partial: "expenses/kebab_menu", locals: { expense: @expense })
           ]
         end
         format.json { render json: { success: true, expense: expense_json(@expense) } }

--- a/app/javascript/controllers/date_preset_controller.js
+++ b/app/javascript/controllers/date_preset_controller.js
@@ -4,20 +4,27 @@ import { Controller } from "@hotwired/stimulus"
  * Date Preset Controller
  * Quick date range selection pills for expense filtering.
  * Calculates date ranges for common periods and auto-submits the filter form.
+ * Custom date fields are hidden unless "Personalizado" is selected or dates are in URL.
  */
 export default class extends Controller {
   static targets = ["preset", "startDate", "endDate", "customDates", "form"]
+
+  connect() {
+    // If URL has date params that don't match the default "this_month" preset,
+    // detect and highlight the correct preset or show custom dates
+    this.syncPresetFromUrl()
+  }
 
   select(event) {
     const period = event.currentTarget.dataset.datePresetPeriod
     this.highlightPreset(event.currentTarget)
 
     if (period === "custom") {
-      this.customDatesTarget.classList.remove("hidden")
+      this.showCustomDates()
       return
     }
 
-    this.customDatesTarget.classList.add("hidden")
+    this.hideCustomDates()
     const { start, end } = this.calculateDates(period)
     this.startDateTarget.value = start
     this.endDateTarget.value = end
@@ -68,5 +75,50 @@ export default class extends Controller {
       p.className = "px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer transition-colors"
     })
     active.className = "px-3 py-1.5 rounded-full text-xs font-medium bg-teal-700 text-white shadow-sm cursor-pointer"
+  }
+
+  showCustomDates() {
+    if (this.hasCustomDatesTarget) {
+      this.customDatesTarget.classList.remove("hidden")
+    }
+  }
+
+  hideCustomDates() {
+    if (this.hasCustomDatesTarget) {
+      this.customDatesTarget.classList.add("hidden")
+    }
+  }
+
+  /**
+   * On connect, check URL params to determine which preset should be active.
+   * If dates don't match any preset, highlight "Personalizado" and show date fields.
+   */
+  syncPresetFromUrl() {
+    const params = new URLSearchParams(window.location.search)
+    const startDate = params.get("start_date")
+    const endDate = params.get("end_date")
+
+    if (!startDate && !endDate) return
+
+    // Check if dates match any preset
+    const presets = ["this_month", "last_month", "this_quarter", "year_to_date"]
+    let matched = false
+
+    for (const period of presets) {
+      const { start, end } = this.calculateDates(period)
+      if (startDate === start && endDate === end) {
+        const btn = this.presetTargets.find(p => p.dataset.datePresetPeriod === period)
+        if (btn) this.highlightPreset(btn)
+        matched = true
+        break
+      }
+    }
+
+    if (!matched) {
+      // Dates don't match any preset — highlight "Personalizado" and show date fields
+      const customBtn = this.presetTargets.find(p => p.dataset.datePresetPeriod === "custom")
+      if (customBtn) this.highlightPreset(customBtn)
+      this.showCustomDates()
+    }
   }
 }

--- a/app/javascript/controllers/delete_confirmation_controller.js
+++ b/app/javascript/controllers/delete_confirmation_controller.js
@@ -1,0 +1,77 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Delete Confirmation Controller
+ * Manages a styled modal for single-expense delete confirmation.
+ * Listens for "expense:request-delete" events dispatched by kebab menu.
+ */
+export default class extends Controller {
+  static targets = ["modal", "overlay", "panel", "merchantName", "amount", "deleteButton"]
+
+  connect() {
+    this.expensePath = null
+    this.keydownHandler = this.handleKeydown.bind(this)
+    this.openHandler = this.handleOpenRequest.bind(this)
+    window.addEventListener("expense:request-delete", this.openHandler)
+  }
+
+  disconnect() {
+    window.removeEventListener("expense:request-delete", this.openHandler)
+    document.removeEventListener("keydown", this.keydownHandler)
+  }
+
+  handleOpenRequest(event) {
+    const { expensePath, merchantName, amount } = event.detail
+
+    this.expensePath = expensePath
+    this.merchantNameTarget.textContent = merchantName || ""
+    this.amountTarget.textContent = amount || ""
+
+    // Show modal
+    this.modalTarget.classList.remove("hidden")
+    this.modalTarget.setAttribute("aria-hidden", "false")
+    requestAnimationFrame(() => {
+      this.overlayTarget.classList.remove("opacity-0")
+      this.panelTarget.classList.remove("translate-y-4", "opacity-0")
+      this.panelTarget.classList.add("translate-y-0", "opacity-100")
+    })
+
+    document.addEventListener("keydown", this.keydownHandler)
+    this.deleteButtonTarget.focus()
+  }
+
+  close() {
+    this.overlayTarget.classList.add("opacity-0")
+    this.panelTarget.classList.add("translate-y-4", "opacity-0")
+    this.panelTarget.classList.remove("translate-y-0", "opacity-100")
+
+    setTimeout(() => {
+      this.modalTarget.classList.add("hidden")
+      this.modalTarget.setAttribute("aria-hidden", "true")
+    }, 150)
+
+    document.removeEventListener("keydown", this.keydownHandler)
+    this.expensePath = null
+  }
+
+  confirm() {
+    if (!this.expensePath) return
+
+    // Submit delete via Turbo
+    const link = document.createElement("a")
+    link.href = this.expensePath
+    link.dataset.turboMethod = "delete"
+    link.style.display = "none"
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+
+    this.close()
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/kebab_menu_controller.js
+++ b/app/javascript/controllers/kebab_menu_controller.js
@@ -71,4 +71,15 @@ export default class extends Controller {
       this.close()
     }
   }
+
+  requestDelete(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    this.close()
+
+    const { expensePath, merchantName, amount } = event.currentTarget.dataset
+    window.dispatchEvent(new CustomEvent("expense:request-delete", {
+      detail: { expensePath, merchantName, amount }
+    }))
+  }
 }

--- a/app/views/expenses/_delete_confirmation_modal.html.erb
+++ b/app/views/expenses/_delete_confirmation_modal.html.erb
@@ -1,0 +1,81 @@
+<%# Shared delete confirmation modal for single expense deletion.
+    Rendered once at page level, populated dynamically via Stimulus. %>
+<div data-controller="delete-confirmation"
+     data-delete-confirmation-expense-path-value="">
+
+  <div data-delete-confirmation-target="modal"
+       class="hidden fixed inset-0 z-[70] overflow-y-auto"
+       aria-labelledby="delete_confirmation_title"
+       aria-hidden="true"
+       role="dialog">
+
+    <%# Overlay %>
+    <div data-delete-confirmation-target="overlay"
+         data-action="click->delete-confirmation#close"
+         class="fixed inset-0 bg-slate-900 bg-opacity-50 transition-opacity opacity-0"></div>
+
+    <%# Panel %>
+    <div class="flex min-h-screen items-center justify-center p-4">
+      <div data-delete-confirmation-target="panel"
+           class="relative transform overflow-hidden rounded-xl bg-white shadow-xl transition-all translate-y-4 opacity-0 sm:w-full sm:max-w-md">
+
+        <%# Header %>
+        <div class="bg-rose-600 px-6 py-4">
+          <div class="flex items-center justify-between">
+            <h3 id="delete_confirmation_title" class="text-lg font-semibold text-white">
+              <%= t("expenses.delete_modal.title", default: "Eliminar Gasto") %>
+            </h3>
+            <button type="button"
+                    data-action="click->delete-confirmation#close"
+                    class="rounded-lg bg-rose-500 p-1 text-white hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-white cursor-pointer"
+                    aria-label="<%= t("expenses.bulk.close_modal", default: "Cerrar") %>">
+              <svg aria-hidden="true" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <%# Body %>
+        <div class="px-6 py-5">
+          <div class="flex items-start gap-4">
+            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center">
+              <svg class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+              </svg>
+            </div>
+            <div>
+              <p class="text-sm text-slate-700">
+                <%= t("expenses.delete_modal.message", default: "¿Estás seguro de que deseas eliminar este gasto?") %>
+              </p>
+              <div class="mt-3 rounded-lg bg-slate-50 border border-slate-200 p-3">
+                <p class="text-sm font-medium text-slate-900" data-delete-confirmation-target="merchantName"></p>
+                <p class="text-sm text-slate-600 mt-0.5" data-delete-confirmation-target="amount"></p>
+              </div>
+              <p class="mt-3 text-xs text-slate-500">
+                <%= t("expenses.delete_modal.warning", default: "Esta acción no se puede deshacer.") %>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <%# Footer %>
+        <div class="bg-slate-50 px-6 py-4">
+          <div class="flex justify-end gap-3">
+            <button type="button"
+                    data-action="click->delete-confirmation#close"
+                    class="rounded-lg bg-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-500 cursor-pointer">
+              <%= t("expenses.bulk.cancel_button", default: "Cancelar") %>
+            </button>
+            <button type="button"
+                    data-delete-confirmation-target="deleteButton"
+                    data-action="click->delete-confirmation#confirm"
+                    class="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-500 cursor-pointer">
+              <%= t("expenses.delete_modal.confirm_button", default: "Eliminar Gasto") %>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -159,7 +159,7 @@
     </div>
 
     <%# Kebab Menu %>
-    <div class="px-2 py-2.5 text-center">
+    <div id="expense_<%= expense.id %>_actions" class="px-2 py-2.5 text-center">
       <%= render "expenses/kebab_menu", expense: expense %>
     </div>
   </div>

--- a/app/views/expenses/_kebab_menu.html.erb
+++ b/app/views/expenses/_kebab_menu.html.erb
@@ -51,15 +51,18 @@
 
     <div class="border-t border-slate-100 my-1"></div>
 
-    <%# Delete (destructive — separated) %>
-    <%= link_to expense_path(expense),
-        class: "w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors",
-        role: "menuitem",
-        data: { turbo_method: :delete, turbo_confirm: t("expenses.actions.delete_confirm") } do %>
+    <%# Delete (opens confirmation modal) %>
+    <button type="button"
+            class="w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 flex items-center gap-2 cursor-pointer transition-colors"
+            role="menuitem"
+            data-action="click->kebab-menu#requestDelete"
+            data-expense-path="<%= expense_path(expense) %>"
+            data-merchant-name="<%= expense.merchant_name || t('expenses.card.no_merchant') %>"
+            data-amount="₡<%= number_with_delimiter(expense.amount.to_i) %>">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
       </svg>
       <%= t("expenses.actions.delete") %>
-    <% end %>
+    </button>
   </div>
 </div>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -107,17 +107,21 @@
               {}, { class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 cursor-pointer",
                     data: { "filter-persistence-target": "filterInput" } } %>
       </div>
-      <div class="flex-1 min-w-[140px]" data-date-preset-target="customDates">
-        <%= form.label :start_date, t("expenses.index.start_date_label", default: "Desde"), class: "block text-xs font-medium text-slate-600 mb-1" %>
-        <%= form.date_field :start_date, value: params[:start_date],
-              class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500",
-              data: { "filter-persistence-target": "filterInput", "date-preset-target": "startDate" } %>
-      </div>
-      <div class="flex-1 min-w-[140px]" data-date-preset-target="customDatesEnd">
-        <%= form.label :end_date, t("expenses.index.end_date_label", default: "Hasta"), class: "block text-xs font-medium text-slate-600 mb-1" %>
-        <%= form.date_field :end_date, value: params[:end_date],
-              class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500",
-              data: { "filter-persistence-target": "filterInput", "date-preset-target": "endDate" } %>
+      <%# Custom date fields — hidden by default, shown when "Personalizado" preset is selected %>
+      <div class="contents <%= 'hidden' unless params[:start_date].present? || params[:end_date].present? %>"
+           data-date-preset-target="customDates">
+        <div class="flex-1 min-w-[140px]">
+          <%= form.label :start_date, t("expenses.index.start_date_label", default: "Desde"), class: "block text-xs font-medium text-slate-600 mb-1" %>
+          <%= form.date_field :start_date, value: params[:start_date],
+                class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500",
+                data: { "filter-persistence-target": "filterInput", "date-preset-target": "startDate" } %>
+        </div>
+        <div class="flex-1 min-w-[140px]">
+          <%= form.label :end_date, t("expenses.index.end_date_label", default: "Hasta"), class: "block text-xs font-medium text-slate-600 mb-1" %>
+          <%= form.date_field :end_date, value: params[:end_date],
+                class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500",
+                data: { "filter-persistence-target": "filterInput", "date-preset-target": "endDate" } %>
+        </div>
       </div>
       <div class="flex gap-2">
         <%= form.submit t("common.filter"), class: "px-4 py-2 bg-teal-700 text-white text-sm font-medium rounded-lg hover:bg-teal-800 shadow-sm cursor-pointer transition-colors" %>
@@ -229,6 +233,7 @@
 </div>
 
 <%= render "bulk_operations_modal" %>
+<%= render "delete_confirmation_modal" %>
 
 <% if @scroll_to == "expense_list" %>
 <script nonce="<%= content_security_policy_nonce %>">

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -107,8 +107,8 @@
               {}, { class: "w-full rounded-lg border border-slate-300 text-sm py-2 px-3 text-slate-700 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 cursor-pointer",
                     data: { "filter-persistence-target": "filterInput" } } %>
       </div>
-      <%# Custom date fields — hidden by default, shown when "Personalizado" preset is selected %>
-      <div class="contents <%= 'hidden' unless params[:start_date].present? || params[:end_date].present? %>"
+      <%# Custom date fields — hidden by default, JS shows when "Personalizado" is active %>
+      <div class="contents hidden"
            data-date-preset-target="customDates">
         <div class="flex-1 min-w-[140px]">
           <%= form.label :start_date, t("expenses.index.start_date_label", default: "Desde"), class: "block text-xs font-medium text-slate-600 mb-1" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,11 @@ en:
       duplicate: "Duplicate"
       edit: "Edit"
       delete: "Delete"
+    delete_modal:
+      title: "Delete Expense"
+      message: "Are you sure you want to delete this expense?"
+      warning: "This action cannot be undone."
+      confirm_button: "Delete Expense"
 
     categories:
       food: "Food"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -229,6 +229,11 @@ es:
       duplicate: "Duplicar"
       edit: "Editar"
       delete: "Eliminar"
+    delete_modal:
+      title: "Eliminar Gasto"
+      message: "¿Estás seguro de que deseas eliminar este gasto?"
+      warning: "Esta acción no se puede deshacer."
+      confirm_button: "Eliminar Gasto"
 
     categories:
       food: "Alimentación"


### PR DESCRIPTION
## Summary
- **Delete modal**: Replace browser `confirm()` with styled rose-themed confirmation modal showing expense details (merchant + amount)
- **Status toggle fix**: Kebab menu now updates after status change via `turbo_stream.update` on the actions container
- **Date preset UX**: Hide custom date fields by default, show only when "Personalizado" is selected or dates are in URL params
- **i18n fix**: Corrected YAML nesting — action keys were accidentally nested under `delete_modal` instead of `actions`

## Changes
- New: `delete_confirmation_controller.js` — listens for `expense:request-delete` global event
- New: `_delete_confirmation_modal.html.erb` — styled modal with rose header, expense context, accessible
- Modified: `kebab_menu_controller.js` — added `requestDelete` action dispatching global event
- Modified: `date_preset_controller.js` — added `syncPresetFromUrl`, `showCustomDates`/`hideCustomDates`
- Modified: `expenses_controller.rb` — changed `turbo_stream.replace` to `turbo_stream.update` for kebab menu
- Modified: `_expense_item.html.erb` — added ID to kebab menu container for Turbo targeting
- Fixed: i18n key nesting in both `en.yml` and `es.yml`

## Playwright verification
- [x] Kebab menu shows "Marcar Procesado" for pending expenses (correct)
- [x] Delete button opens styled modal with merchant name + amount
- [x] Escape key closes the modal
- [x] Date fields hidden by default when preset is active
- [x] Spanish locale renders correctly throughout

## Test plan
- [x] 7,476 unit tests pass (0 failures)
- [x] RuboCop, Brakeman clean
- [ ] Manual: click status toggle → verify menu updates with new label
- [ ] Manual: click "Personalizado" → date fields appear
- [ ] Manual: confirm delete via modal → expense removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)