### PR TITLE
feat: nav reorganization, dashboard URL, currency symbols, sync/conflict improvements

### DIFF
--- a/app/controllers/sync_conflicts_controller.rb
+++ b/app/controllers/sync_conflicts_controller.rb
@@ -10,7 +10,7 @@ class SyncConflictsController < ApplicationController
     end
 
     # Exclude 100% duplicate matches — they are auto-handled and just noise
-    @conflicts = @conflicts.where.not(conflict_type: "duplicate")
+    @conflicts = @conflicts.actionable
 
     # Apply filters
     @conflicts = @conflicts.where(status: params[:status]) if params[:status].present?
@@ -27,7 +27,7 @@ class SyncConflictsController < ApplicationController
     end
 
     # Exclude 100% duplicates from stats too
-    base_scope = base_scope.where.not(conflict_type: "duplicate")
+    base_scope = base_scope.actionable
 
     # Apply same filters as main query for stats
     base_scope = base_scope.where(status: params[:status]) if params[:status].present?

--- a/app/controllers/sync_conflicts_controller.rb
+++ b/app/controllers/sync_conflicts_controller.rb
@@ -9,6 +9,9 @@ class SyncConflictsController < ApplicationController
       SyncConflict.includes(:existing_expense, :new_expense)
     end
 
+    # Exclude 100% duplicate matches — they are auto-handled and just noise
+    @conflicts = @conflicts.where.not(conflict_type: "duplicate")
+
     # Apply filters
     @conflicts = @conflicts.where(status: params[:status]) if params[:status].present?
     @conflicts = @conflicts.where(conflict_type: params[:type]) if params[:type].present?
@@ -22,6 +25,9 @@ class SyncConflictsController < ApplicationController
     else
       SyncConflict.all
     end
+
+    # Exclude 100% duplicates from stats too
+    base_scope = base_scope.where.not(conflict_type: "duplicate")
 
     # Apply same filters as main query for stats
     base_scope = base_scope.where(status: params[:status]) if params[:status].present?

--- a/app/controllers/sync_performance_controller.rb
+++ b/app/controllers/sync_performance_controller.rb
@@ -1,6 +1,6 @@
 require "csv"
 
-class SyncPerformanceController < ApplicationController
+class SyncPerformanceController < Admin::BaseController
   before_action :set_date_range, only: [ :index, :export ]
 
   def index

--- a/app/controllers/sync_sessions_controller.rb
+++ b/app/controllers/sync_sessions_controller.rb
@@ -31,12 +31,6 @@ class SyncSessionsController < ApplicationController
       session[:sync_session_id] = @sync_session.id
 
       respond_to do |format|
-        format.turbo_stream do
-          # Handle turbo stream requests - update the widget in place
-          prepare_widget_data
-          render turbo_stream: turbo_stream.replace("sync_status_widget",
-            partial: "sync_sessions/unified_widget")
-        end
         format.html do
           redirect_to sync_sessions_path, notice: t("sync_sessions.flash.started")
         end
@@ -126,13 +120,6 @@ class SyncSessionsController < ApplicationController
 
   def handle_creation_error(result)
     respond_to do |format|
-      format.turbo_stream do
-        @error_message = result.message || "Error al crear la sincronización"
-        @active_sync_session = nil
-        @last_completed_sync = SyncSession.completed.recent.first
-        render turbo_stream: turbo_stream.replace("sync_status_widget",
-          partial: "sync_sessions/unified_widget")
-      end
       format.html do
         case result.error
         when :sync_limit_exceeded

--- a/app/javascript/controllers/nav_dropdown_controller.js
+++ b/app/javascript/controllers/nav_dropdown_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Nav Dropdown Controller
+ * Simple dropdown menu for navigation grouping.
+ * Click to toggle, click outside or Escape to close.
+ */
+export default class extends Controller {
+  static targets = ["menu", "button"]
+
+  connect() {
+    this.closeHandler = this.closeOnClickOutside.bind(this)
+    this.keydownHandler = this.handleKeydown.bind(this)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeHandler)
+    document.removeEventListener("keydown", this.keydownHandler)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+
+    if (this.menuTarget.classList.contains("hidden")) {
+      this.open()
+    } else {
+      this.close()
+    }
+  }
+
+  open() {
+    this.menuTarget.classList.remove("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "true")
+    document.addEventListener("click", this.closeHandler)
+    document.addEventListener("keydown", this.keydownHandler)
+  }
+
+  close() {
+    this.menuTarget.classList.add("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "false")
+    document.removeEventListener("click", this.closeHandler)
+    document.removeEventListener("keydown", this.keydownHandler)
+  }
+
+  closeOnClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.close()
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape") {
+      this.close()
+      this.buttonTarget.focus()
+    }
+  }
+}

--- a/app/javascript/controllers/sync_sessions_controller.js
+++ b/app/javascript/controllers/sync_sessions_controller.js
@@ -22,10 +22,17 @@ class SyncSessionsController extends Controller {
   connect() {
     if (this.sessionIdValue) {
       this.subscribeToChannel()
+      // Polling fallback — Action Cable async adapter doesn't work cross-process.
+      // Poll every 5 seconds while sync is active to keep the UI updated.
+      this.pollInterval = setInterval(() => this.pollStatus(), 5000)
     }
   }
 
   disconnect() {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval)
+      this.pollInterval = null
+    }
     this.disconnectChannel()
   }
 
@@ -39,7 +46,7 @@ class SyncSessionsController extends Controller {
     // Update progress text
     if (this.hasProgressTextTarget) {
       const percentage = data.progress_percentage || 0
-      this.progressTextTarget.textContent = `Progreso: ${percentage}%`
+      this.progressTextTarget.textContent = `${t("sync_sessions.progress")}: ${percentage}%`
     }
 
     // Update processed count
@@ -49,7 +56,7 @@ class SyncSessionsController extends Controller {
 
     // Update detected expenses
     if (this.hasDetectedCountTarget) {
-      this.detectedCountTarget.textContent = `${data.detected_expenses || 0} gastos`
+      this.detectedCountTarget.textContent = `${data.detected_expenses || 0} ${t("sync_sessions.expenses_label")}`
     }
 
     // Update the session row in the history table
@@ -95,7 +102,7 @@ class SyncSessionsController extends Controller {
       // Update status badge
       const statusBadge = accountCard.querySelector('[data-status-badge]')
       if (statusBadge) {
-        statusBadge.textContent = data.status === 'processing' ? 'Procesando' : data.status
+        statusBadge.textContent = data.status === 'processing' ? t("sync_sessions.processing") : data.status
         statusBadge.className = data.status === 'processing'
           ? 'text-xs px-2 py-1 rounded-full bg-teal-100 text-teal-700'
           : 'text-xs px-2 py-1 rounded-full bg-emerald-100 text-emerald-700'
@@ -108,7 +115,7 @@ class SyncSessionsController extends Controller {
         const processed = document.createElement('span')
         processed.textContent = `${data.processed || 0} / ${data.total || 0}`
         const detected = document.createElement('span')
-        detected.textContent = `${data.detected || 0} gastos`
+        detected.textContent = `${data.detected || 0} ${t("sync_sessions.expenses_label")}`
         countsElement.appendChild(processed)
         countsElement.appendChild(detected)
       }
@@ -131,10 +138,13 @@ class SyncSessionsController extends Controller {
       }
     }
 
-    // Show completion notification
+    // Show completion notification and reload after a short delay
+    // so the history table and stats refresh with final data
     this.showNotification(t("sync.notifications.completed", { detected: 0, processed: 0 }), "success")
 
-    // Don't reload - let user continue viewing real-time updates
+    setTimeout(() => {
+      window.location.reload()
+    }, 2000)
   }
 
   handleFailure(data) {
@@ -146,6 +156,48 @@ class SyncSessionsController extends Controller {
     if (this.hasProgressBarTarget) {
       this.progressBarTarget.classList.add('bg-rose-600')
       this.progressBarTarget.classList.remove('bg-amber-600')
+    }
+  }
+
+  async pollStatus() {
+    if (!this.sessionIdValue) return
+
+    try {
+      const response = await fetch(`/sync_sessions/status?sync_session_id=${this.sessionIdValue}`, {
+        headers: { "Accept": "application/json" }
+      })
+
+      if (!response.ok) return
+
+      const data = await response.json()
+
+      if (data.status === "completed" || data.status === "failed") {
+        clearInterval(this.pollInterval)
+        this.pollInterval = null
+
+        if (data.status === "completed") {
+          this.handleCompletion(data)
+        } else {
+          this.handleFailure(data)
+        }
+      } else {
+        this.updateProgress(data)
+
+        if (data.accounts && Array.isArray(data.accounts)) {
+          data.accounts.forEach(account => {
+            this.updateAccount({
+              account_id: account.id || account.account_id,
+              status: account.status,
+              progress: account.progress,
+              processed: account.processed,
+              total: account.total,
+              detected: account.detected
+            })
+          })
+        }
+      }
+    } catch (error) {
+      // Silently fail — Action Cable is the primary mechanism
     }
   }
 }

--- a/app/javascript/controllers/sync_sessions_controller.js
+++ b/app/javascript/controllers/sync_sessions_controller.js
@@ -197,7 +197,7 @@ class SyncSessionsController extends Controller {
         }
       }
     } catch (error) {
-      // Silently fail — Action Cable is the primary mechanism
+      console.debug("[SyncSessions] Poll failed:", error)
     }
   }
 }

--- a/app/javascript/services/i18n.js
+++ b/app/javascript/services/i18n.js
@@ -26,6 +26,11 @@ const translations = {
         resume: "Reanudar"
       }
     },
+    sync_sessions: {
+      progress: "Progreso",
+      expenses_label: "gastos",
+      processing: "Procesando"
+    },
     expenses: {
       notifications: {
         category_updated: "Categoría actualizada",
@@ -432,6 +437,11 @@ const translations = {
         pause: "Pause",
         resume: "Resume"
       }
+    },
+    sync_sessions: {
+      progress: "Progress",
+      expenses_label: "expenses",
+      processing: "Processing"
     },
     expenses: {
       notifications: {

--- a/app/models/sync_conflict.rb
+++ b/app/models/sync_conflict.rb
@@ -42,6 +42,7 @@ class SyncConflict < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :for_session, ->(session_id) { where(sync_session_id: session_id) }
   scope :with_expenses, -> { includes(:existing_expense, :new_expense) }
+  scope :actionable, -> { where.not(conflict_type: "duplicate") }
 
   # Callbacks
   before_validation :calculate_similarity_score, if: :should_calculate_similarity?

--- a/app/services/conflict_detection_service.rb
+++ b/app/services/conflict_detection_service.rb
@@ -284,6 +284,14 @@ module Services
   end
 
   def create_conflict(existing_expense:, new_expense_data:, conflict_type:, similarity_score:, differences:)
+    # Skip creating conflict records for obvious duplicates (≥95% similarity).
+    # These are noise — the existing expense is always kept and the duplicate is discarded.
+    if conflict_type == "duplicate" && similarity_score >= 95.0
+      Rails.logger.info "[ConflictDetection] Skipped obvious duplicate (#{similarity_score}%): " \
+                        "existing=##{existing_expense.id} merchant=#{existing_expense.merchant_name}"
+      return nil
+    end
+
     # Create temporary expense for new data (will be saved if resolution keeps it)
     # Ensure all required fields are present
     expense_attrs = new_expense_data.merge(

--- a/app/views/bulk_categorizations/_expense_groups.html.erb
+++ b/app/views/bulk_categorizations/_expense_groups.html.erb
@@ -33,7 +33,7 @@
               <%= group[:count] %> gasto<%= "s" if group[:count] != 1 %>
             </span>
             <span class="text-sm font-semibold text-slate-900">
-              ₡<%= number_with_delimiter(group[:total_amount].to_i) %>
+              <%= currency_symbol(group[:expenses].first) %><%= number_with_delimiter(group[:total_amount].to_i) %>
             </span>
           </div>
         </div>
@@ -148,7 +148,7 @@
 
               <div class="flex items-center space-x-3">
                 <span class="text-sm font-semibold text-slate-900">
-                  ₡<%= number_with_delimiter(expense.amount.to_i) %>
+                  <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
                 </span>
 
                 <!-- Individual Category Override -->

--- a/app/views/bulk_categorizations/_preview_modal.html.erb
+++ b/app/views/bulk_categorizations/_preview_modal.html.erb
@@ -39,7 +39,7 @@
             <p class="text-sm text-slate-600">Gastos</p>
           </div>
           <div class="text-center">
-            <p class="text-2xl font-bold text-slate-900">₡<%= number_with_delimiter(preview[:total_amount].to_i) %></p>
+            <p class="text-2xl font-bold text-slate-900"><%= currency_symbol(preview[:expenses].first) %><%= number_with_delimiter(preview[:total_amount].to_i) %></p>
             <p class="text-sm text-slate-600">Monto Total</p>
           </div>
           <div class="text-center">
@@ -60,7 +60,7 @@
                 </p>
               </div>
               <span class="text-sm font-semibold text-slate-900">
-                ₡<%= number_with_delimiter(expense.amount.to_i) %>
+                <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
               </span>
             </div>
           <% end %>

--- a/app/views/dashboard/_insights_row.html.erb
+++ b/app/views/dashboard/_insights_row.html.erb
@@ -16,7 +16,7 @@
           <span class="text-lg flex-shrink-0" aria-hidden="true"><%= insight[:icon] %></span>
           <span class="text-sm font-medium">
             <% if insight[:link_path].present? %>
-              <%= link_to insight[:message], insight[:link_path], class: "underline hover:no-underline" %>
+              <%= link_to insight[:message], insight[:link_path], class: "underline hover:no-underline", data: { turbo_frame: "_top" } %>
             <% else %>
               <%= insight[:message] %>
             <% end %>

--- a/app/views/dashboard/_metric_cards.html.erb
+++ b/app/views/dashboard/_metric_cards.html.erb
@@ -90,7 +90,7 @@
   <%= link_to budgets_path, id: "budget-remaining-card",
        class: "bg-white rounded-xl shadow-sm border border-slate-200 p-6 transition-all duration-200 hover:shadow-lg hover:border-teal-300 cursor-pointer relative block no-underline",
        aria: { label: "#{t('dashboard.v2.budget_remaining', default: 'Budget Remaining')} — #{budget_formatted_remaining}" },
-       data: { controller: "animated-metric", animated_metric_container_target: "container", animated_metric_to_value: budget_remaining, animated_metric_prefix_value: "₡" } do %>
+       data: { turbo_frame: "_top", controller: "animated-metric", animated_metric_container_target: "container", animated_metric_to_value: budget_remaining, animated_metric_prefix_value: "₡" } do %>
 
     <div class="flex items-center justify-between mb-3">
       <div class="p-2 rounded-lg <%= budget_classes[:bg] %>">
@@ -157,7 +157,7 @@
   <%= link_to bulk_categorizations_path, id: "uncategorized-card",
        class: "bg-white rounded-xl shadow-sm border border-slate-200 p-6 transition-all duration-200 hover:shadow-lg hover:border-teal-300 cursor-pointer relative block no-underline",
        aria: { label: "#{t('dashboard.v2.uncategorized', default: 'Uncategorized')} — #{@uncategorized_count}" },
-       data: { controller: "animated-metric", animated_metric_container_target: "container", animated_metric_to_value: @uncategorized_count } do %>
+       data: { turbo_frame: "_top", controller: "animated-metric", animated_metric_container_target: "container", animated_metric_to_value: @uncategorized_count } do %>
 
     <div class="flex items-center justify-between mb-3">
       <div class="p-2 rounded-lg <%= uncategorized_warning ? 'bg-amber-50' : 'bg-slate-100' %>">

--- a/app/views/dashboard/_period_selector.html.erb
+++ b/app/views/dashboard/_period_selector.html.erb
@@ -19,7 +19,7 @@
     <% periods.each do |p| %>
       <% active = current_period == p[:key] %>
       <%= link_to p[:label],
-            dashboard_v2_path(period: p[:key]),
+            dashboard_page_path(period: p[:key]),
             data: {
               turbo_frame: "dashboard-body",
               period_selector_target: "tab",

--- a/app/views/dashboard/_recent_activity.html.erb
+++ b/app/views/dashboard/_recent_activity.html.erb
@@ -23,14 +23,14 @@
           </div>
         </div>
         <span class="text-sm font-medium text-slate-900 tabular-nums whitespace-nowrap ml-4">
-          <%= number_to_currency(expense.amount, unit: "₡") %>
+          <%= number_to_currency(expense.amount, unit: currency_symbol(expense)) %>
         </span>
       </div>
     <% end %>
   </div>
 
   <div class="mt-4 pt-4 border-t border-slate-100">
-    <%= link_to expenses_path, class: "text-sm font-medium text-teal-700 hover:text-teal-800" do %>
+    <%= link_to expenses_path, class: "text-sm font-medium text-teal-700 hover:text-teal-800", data: { turbo_frame: "_top" } do %>
       <%= t("dashboard.v2.view_all_expenses", default: "View all expenses") %> &rarr;
     <% end %>
   </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6" data-controller="dashboard-v2">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
   <%# === Header === %>
   <%= render "dashboard/header" %>
 

--- a/app/views/expenses/_expense_card.html.erb
+++ b/app/views/expenses/_expense_card.html.erb
@@ -44,7 +44,7 @@
 
       <%# Amount — right aligned %>
       <span class="text-sm font-bold text-slate-900 flex-shrink-0">
-        ₡<%= number_with_delimiter(expense.amount.to_i) %>
+        <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
       </span>
     </div>
 

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -57,7 +57,7 @@
       </span>
 
       <span class="text-sm font-bold text-slate-900 flex-shrink-0">
-        ₡<%= number_with_delimiter(expense.amount.to_i) %>
+        <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
       </span>
     </div>
 
@@ -148,7 +148,7 @@
 
     <%# Amount %>
     <div class="px-3 py-2.5 text-right text-[13px] font-medium text-slate-900 tabular-nums whitespace-nowrap">
-      ₡<%= number_with_delimiter(expense.amount.to_i) %>
+      <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
     </div>
 
     <%# Status %>

--- a/app/views/expenses/_expense_row.html.erb
+++ b/app/views/expenses/_expense_row.html.erb
@@ -183,7 +183,7 @@
   </td>
 
   <td class="px-6 py-4 whitespace-nowrap text-sm font-bold text-slate-900">
-    <%= defined?(currency_symbol) ? currency_symbol(expense) : "₡" %><%= number_with_delimiter(expense.amount.to_i) %>
+    <%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>
   </td>
 
   <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900" <% if local_assigns[:context] != 'dashboard' %>data-view-toggle-target="expandedColumns"<% else %>data-dashboard-expenses-target="expandedColumns"<% end %>>

--- a/app/views/expenses/_kebab_menu.html.erb
+++ b/app/views/expenses/_kebab_menu.html.erb
@@ -58,7 +58,7 @@
             data-action="click->kebab-menu#requestDelete"
             data-expense-path="<%= expense_path(expense) %>"
             data-merchant-name="<%= expense.merchant_name || t('expenses.card.no_merchant') %>"
-            data-amount="₡<%= number_with_delimiter(expense.amount.to_i) %>">
+            data-amount="<%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
       </svg>

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -19,7 +19,7 @@
 
     <!-- Amount Display -->
     <div class="text-center py-6 bg-slate-50 rounded-lg mb-6">
-      <div class="text-4xl font-bold text-slate-900 mb-2">₡<%= number_with_delimiter(@expense.amount.to_i) %></div>
+      <div class="text-4xl font-bold text-slate-900 mb-2"><%= currency_symbol(@expense) %><%= number_with_delimiter(@expense.amount.to_i) %></div>
       <div class="text-lg text-slate-600">
         <% if @expense.merchant_name? %>
         <%= @expense.merchant_name %>

--- a/app/views/layouts/_nav_links.html.erb
+++ b/app/views/layouts/_nav_links.html.erb
@@ -2,29 +2,34 @@
 <% mobile = local_assigns.fetch(:mobile, false) %>
 <% base_class = mobile ? "text-slate-600 hover:text-teal-700 hover:bg-slate-50 px-3 py-2 rounded-md text-sm font-medium" : "text-slate-600 hover:text-teal-700 px-3 py-2 rounded-md text-sm font-medium" %>
 
-<%= link_to t("nav.dashboard"), dashboard_v2_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path == dashboard_v2_path || request.path == '/'}",
-    'aria-current': ((request.path == dashboard_v2_path || request.path == '/') ? 'page' : nil) %>
+<%# ── Primary navigation links ── %>
+<%= link_to t("nav.dashboard"), dashboard_page_path,
+    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path == dashboard_page_path || request.path == '/'}",
+    'aria-current': ((request.path == dashboard_page_path || request.path == '/') ? 'page' : nil) %>
 <%= link_to t("nav.expenses"), expenses_path,
     class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path == expenses_path}",
     'aria-current': (request.path == expenses_path ? 'page' : nil) %>
-<%= link_to t("nav.categorize"), bulk_categorizations_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/bulk_categorizations')}",
-    'aria-current': (request.path.start_with?('/bulk_categorizations') ? 'page' : nil) %>
-<%= link_to t("nav.analytics"), analytics_pattern_dashboard_index_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/analytics')}",
-    'aria-current': (request.path.start_with?('/analytics') ? 'page' : nil) %>
-<%= link_to t("nav.accounts"), email_accounts_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path == email_accounts_path}",
-    'aria-current': (request.path == email_accounts_path ? 'page' : nil) %>
-<%= link_to t("nav.sync"), sync_sessions_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/sync_sessions')}",
-    'aria-current': (request.path.start_with?('/sync_sessions') ? 'page' : nil) %>
-<%= link_to t("nav.patterns"), admin_patterns_path,
-    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/admin')}",
-    'aria-current': (request.path.start_with?('/admin') ? 'page' : nil) %>
+<%= link_to t("nav.budgets"), budgets_path,
+    class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/budgets')}",
+    'aria-current': (request.path.start_with?('/budgets') ? 'page' : nil) %>
+<%# Bulk categorization removed from nav — single-expense categorization via edit page %>
+<%# ── Settings dropdown (desktop) / Settings section (mobile) ── %>
+<% settings_active = request.path == email_accounts_path || request.path.start_with?('/sync_sessions') || request.path.start_with?('/sync_conflicts') %>
 
 <% if mobile %>
+  <div class="pt-2 mt-2 border-t border-slate-200">
+    <span class="px-3 py-1 text-xs font-semibold text-slate-400 uppercase tracking-wider"><%= t("nav.settings") %></span>
+    <%= link_to t("nav.accounts"), email_accounts_path,
+        class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path == email_accounts_path}",
+        'aria-current': (request.path == email_accounts_path ? 'page' : nil) %>
+    <%= link_to t("nav.sync"), sync_sessions_path,
+        class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/sync_sessions')}",
+        'aria-current': (request.path.start_with?('/sync_sessions') ? 'page' : nil) %>
+    <%= link_to t("nav.conflicts"), sync_conflicts_path,
+        class: "#{base_class} #{'bg-teal-50 text-teal-700' if request.path.start_with?('/sync_conflicts')}",
+        'aria-current': (request.path.start_with?('/sync_conflicts') ? 'page' : nil) %>
+  </div>
+
   <div class="pt-2 mt-2 border-t border-slate-200">
     <%= link_to t("nav.new_expense"), new_expense_path,
         class: "bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm block text-center",
@@ -39,6 +44,61 @@
     <% end %>
   </div>
 <% else %>
+  <%# Desktop settings dropdown %>
+  <div class="relative" data-controller="nav-dropdown">
+    <button type="button"
+            class="inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer <%= settings_active ? 'bg-teal-50 text-teal-700' : 'text-slate-600 hover:text-teal-700' %>"
+            data-nav-dropdown-target="button"
+            data-action="click->nav-dropdown#toggle"
+            aria-haspopup="true"
+            aria-expanded="false">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+      </svg>
+      <%= t("nav.settings") %>
+      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </button>
+
+    <div class="hidden absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-50 w-48"
+         data-nav-dropdown-target="menu"
+         role="menu"
+         aria-label="<%= t('nav.settings') %>">
+      <%= link_to email_accounts_path,
+          class: "block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors #{'bg-teal-50 text-teal-700' if request.path == email_accounts_path}",
+          role: "menuitem" do %>
+        <span class="flex items-center gap-2">
+          <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+          </svg>
+          <%= t("nav.accounts") %>
+        </span>
+      <% end %>
+      <%= link_to sync_sessions_path,
+          class: "block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors #{'bg-teal-50 text-teal-700' if request.path.start_with?('/sync_sessions')}",
+          role: "menuitem" do %>
+        <span class="flex items-center gap-2">
+          <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+          </svg>
+          <%= t("nav.sync") %>
+        </span>
+      <% end %>
+      <%= link_to sync_conflicts_path,
+          class: "block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors #{'bg-teal-50 text-teal-700' if request.path.start_with?('/sync_conflicts')}",
+          role: "menuitem" do %>
+        <span class="flex items-center gap-2">
+          <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+          </svg>
+          <%= t("nav.conflicts") %>
+        </span>
+      <% end %>
+    </div>
+  </div>
+
   <div class="flex items-center gap-1 border-l border-slate-200 ml-2 pl-3">
     <% I18n.available_locales.each do |loc| %>
       <%= button_to locale_path(locale: loc), method: :patch, class: "text-xs px-2 py-1 rounded transition-colors #{I18n.locale == loc ? 'bg-teal-100 text-teal-700 font-semibold' : 'text-slate-400 hover:text-teal-700 hover:bg-slate-50'}", 'aria-label': t("nav.switch_language", language: loc.to_s.upcase) do %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="<%= I18n.locale %>">
   <head>
     <title><%= content_for(:title) || "Administrador - Expense Tracker" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -31,7 +31,7 @@
     <!-- Admin Navigation -->
     <nav class="bg-white shadow-sm border-b border-slate-200"
          role="navigation"
-         aria-label="Navegación de administrador">
+         aria-label="<%= t('admin.nav.aria_label') %>">
       <div class="max-w-7xl mx-auto px-4">
         <div class="flex justify-between items-center py-4">
           <div class="flex items-center space-x-4">
@@ -40,17 +40,26 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
               </svg>
             </div>
-            <span class="text-xl font-bold text-slate-900">Admin - Expense Tracker</span>
+            <span class="text-xl font-bold text-slate-900"><%= t("admin.nav.title") %></span>
           </div>
 
           <div class="flex items-center space-x-3">
-            <%= link_to "Patrones", admin_patterns_path,
+            <%= link_to t("admin.nav.patterns"), admin_patterns_path,
+                class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/patterns') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
+                'aria-current': (request.path.start_with?('/admin/patterns') ? 'page' : nil) %>
+            <%= link_to t("admin.nav.composite_patterns"), admin_composite_patterns_path,
+                class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/composite_patterns') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
+                'aria-current': (request.path.start_with?('/admin/composite_patterns') ? 'page' : nil) %>
+            <%= link_to t("admin.nav.analytics"), analytics_pattern_dashboard_index_path,
+                class: "text-sm font-medium transition-colors #{request.path.start_with?('/analytics') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
+                'aria-current': (request.path.start_with?('/analytics') ? 'page' : nil) %>
+            <%= link_to t("admin.nav.sync_performance"), sync_performance_path,
+                class: "text-sm font-medium transition-colors #{request.path.start_with?('/sync_performance') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
+                'aria-current': (request.path.start_with?('/sync_performance') ? 'page' : nil) %>
+            <span class="border-l border-slate-200 h-4"></span>
+            <%= link_to t("admin.nav.back_to_app"), expenses_path,
                 class: "text-sm font-medium text-slate-600 hover:text-teal-700 transition-colors" %>
-            <%= link_to "Patrones Compuestos", admin_composite_patterns_path,
-                class: "text-sm font-medium text-slate-600 hover:text-teal-700 transition-colors" %>
-            <%= link_to "← Volver a la App", expenses_path,
-                class: "text-sm font-medium text-slate-600 hover:text-teal-700 transition-colors" %>
-            <%= link_to "Cerrar Sesión",
+            <%= link_to t("admin.nav.logout"),
                 admin_logout_path,
                 data: { turbo_method: :delete },
                 class: "text-sm font-medium text-rose-600 hover:text-rose-700 transition-colors" %>

--- a/app/views/sync_performance/index.html.erb
+++ b/app/views/sync_performance/index.html.erb
@@ -242,7 +242,8 @@
                 </div>
                 <div class="flex items-center">
                   <div class="w-24 bg-slate-200 rounded-full h-2 mr-3">
-                    <div class="bg-teal-700 h-2 rounded-full" style="width: <%= (peak[:count].to_f / @peak_times[:peak_hours].first[:count] * 100).round %>%"></div>
+                    <% max_count = @peak_times[:peak_hours].first[:count].to_f %>
+                    <div class="bg-teal-700 h-2 rounded-full" style="width: <%= max_count > 0 ? (peak[:count].to_f / max_count * 100).round : 0 %>%"></div>
                   </div>
                   <span class="text-sm font-medium text-slate-900"><%= peak[:count] %></span>
                 </div>

--- a/app/views/sync_sessions/index.html.erb
+++ b/app/views/sync_sessions/index.html.erb
@@ -1,78 +1,80 @@
 <%= turbo_stream_from "sync_sessions_index" %>
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <!-- Header con gradiente -->
+  <%# Header with gradient %>
   <div class="bg-gradient-to-r from-teal-700 to-teal-600 rounded-xl shadow-lg p-8 text-white mb-8">
     <h1 class="text-3xl font-bold mb-2"><%= t("sync_sessions.index.title") %></h1>
-    <p class="text-teal-100">Gestiona y monitorea las sincronizaciones de tus cuentas de email</p>
-    <!-- Stats summary -->
+    <p class="text-teal-100"><%= t("sync_sessions.index.subtitle") %></p>
+    <%# Stats summary %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
       <div class="bg-white/10 rounded-lg p-4">
-        <p class="text-teal-100 text-sm">Cuentas Activas</p>
+        <p class="text-teal-100 text-sm"><%= t("sync_sessions.index.active_accounts") %></p>
         <p class="text-2xl font-bold"><%= @active_accounts_count %></p>
       </div>
       <div class="bg-white/10 rounded-lg p-4">
-        <p class="text-teal-100 text-sm">Sincronizaciones Hoy</p>
+        <p class="text-teal-100 text-sm"><%= t("sync_sessions.index.syncs_today") %></p>
         <p class="text-2xl font-bold"><%= @today_sync_count %></p>
       </div>
       <div class="bg-white/10 rounded-lg p-4">
-        <p class="text-teal-100 text-sm">Gastos Detectados (Mes)</p>
+        <p class="text-teal-100 text-sm"><%= t("sync_sessions.index.expenses_detected_month") %></p>
         <p class="text-2xl font-bold"><%= @monthly_expenses_detected %></p>
       </div>
     </div>
   </div>
 
-  <!-- Active sync session -->
-  <% if @active_session %>
-    <div class="bg-amber-50 border-2 border-amber-200 rounded-xl p-6 mb-8"
-         data-controller="sync-sessions"
-         data-sync-sessions-session-id-value="<%= @active_session.id %>"
-         data-sync-sessions-session-token-value="<%= @active_session.session_token %>">
-      <div class="flex items-center justify-between mb-4">
-        <div class="flex items-center gap-3">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-600"></div>
-          <h2 class="text-xl font-semibold text-slate-900"><%= t("sync_sessions.index.in_progress") %></h2>
-        </div>
-        <%= button_to t("common.cancel"), cancel_sync_session_path(@active_session), method: :post,
-            class: "bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium py-2 px-4 rounded-lg shadow-sm" %>
-      </div>
-
-      <!-- Progress bar -->
-      <div class="mb-4">
-        <div class="flex justify-between text-sm text-slate-600 mb-2">
-          <span data-sync-sessions-target="progressText">Progreso: <%= @active_session.progress_percentage %>%</span>
-          <span data-sync-sessions-target="processedCount"><%= @active_session.processed_emails %> / <%= @active_session.total_emails %> emails</span>
-        </div>
-        <div class="w-full bg-slate-200 rounded-full h-3">
-          <div class="bg-amber-600 h-3 rounded-full transition-all duration-500"
-               data-sync-sessions-target="progressBar"
-               style="width: <%= @active_session.progress_percentage %>%"></div>
-        </div>
-      </div>
-
-      <!-- Active accounts grid -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <% @active_session.sync_session_accounts.includes(:email_account).each do |account| %>
-          <div class="bg-white rounded-lg p-4 border border-slate-200"
-               data-sync-sessions-target="accountCard"
-               data-account-id="<%= account.email_account.id %>">
-            <div class="flex items-center justify-between mb-2">
-              <span class="text-sm font-medium text-slate-900"><%= account.email_account.bank_name %></span>
-              <%= render "sync_sessions/account_status_badge", account: account %>
-            </div>
-            <p class="text-xs text-slate-600 mb-2"><%= account.email_account.email %></p>
-            <div class="flex justify-between text-xs text-slate-500" data-account-counts>
-              <span><%= account.processed_emails %> / <%= account.total_emails %></span>
-              <span><%= account.detected_expenses %> gastos</span>
-            </div>
+  <%# Active sync session %>
+  <div id="sync_active_session">
+    <% if @active_session %>
+      <div class="bg-amber-50 border-2 border-amber-200 rounded-xl p-6 mb-8"
+           data-controller="sync-sessions"
+           data-sync-sessions-session-id-value="<%= @active_session.id %>"
+           data-sync-sessions-session-token-value="<%= @active_session.session_token %>">
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center gap-3">
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-600"></div>
+            <h2 class="text-xl font-semibold text-slate-900"><%= t("sync_sessions.index.in_progress") %></h2>
           </div>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
+          <%= button_to t("common.cancel"), cancel_sync_session_path(@active_session), method: :post,
+              class: "bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium py-2 px-4 rounded-lg shadow-sm" %>
+        </div>
 
-  <!-- Quick actions -->
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-    <!-- Sync all -->
+        <%# Progress bar %>
+        <div class="mb-4">
+          <div class="flex justify-between text-sm text-slate-600 mb-2">
+            <span data-sync-sessions-target="progressText"><%= t("sync_sessions.index.progress") %>: <%= @active_session.progress_percentage %>%</span>
+            <span data-sync-sessions-target="processedCount"><%= @active_session.processed_emails %> / <%= @active_session.total_emails %> <%= t("sync_sessions.index.emails") %></span>
+          </div>
+          <div class="w-full bg-slate-200 rounded-full h-3">
+            <div class="bg-amber-600 h-3 rounded-full transition-all duration-500"
+                 data-sync-sessions-target="progressBar"
+                 style="width: <%= @active_session.progress_percentage %>%"></div>
+          </div>
+        </div>
+
+        <%# Active accounts grid %>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <% @active_session.sync_session_accounts.includes(:email_account).each do |account| %>
+            <div class="bg-white rounded-lg p-4 border border-slate-200"
+                 data-sync-sessions-target="accountCard"
+                 data-account-id="<%= account.email_account.id %>">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium text-slate-900"><%= account.email_account.bank_name %></span>
+                <%= render "sync_sessions/account_status_badge", account: account %>
+              </div>
+              <p class="text-xs text-slate-600 mb-2"><%= account.email_account.email %></p>
+              <div class="flex justify-between text-xs text-slate-500" data-account-counts>
+                <span><%= account.processed_emails %> / <%= account.total_emails %></span>
+                <span><%= account.detected_expenses %> <%= t("sync_sessions.index.expenses_label") %></span>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Quick actions %>
+  <div id="sync_quick_actions" class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+    <%# Sync all %>
     <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
       <div class="flex items-center mb-4">
         <div class="bg-teal-100 p-3 rounded-lg">
@@ -80,15 +82,15 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
         </div>
-        <h3 class="text-lg font-semibold text-slate-900 ml-3">Sincronizar Todo</h3>
+        <h3 class="text-lg font-semibold text-slate-900 ml-3"><%= t("sync_sessions.index.sync_all") %></h3>
       </div>
-      <p class="text-sm text-slate-600 mb-4">Sincroniza todas las cuentas activas</p>
-      <%= button_to "Iniciar Sincronización", sync_sessions_path, method: :post,
+      <p class="text-sm text-slate-600 mb-4"><%= t("sync_sessions.index.sync_all_description") %></p>
+      <%= button_to t("sync_sessions.index.start_sync"), sync_sessions_path, method: :post,
           class: "w-full bg-teal-700 hover:bg-teal-800 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-colors",
           disabled: @active_session.present? %>
     </div>
 
-    <!-- Last sync info -->
+    <%# Last sync info %>
     <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
       <div class="flex items-center mb-4">
         <div class="bg-slate-100 p-3 rounded-lg">
@@ -99,14 +101,14 @@
         <h3 class="text-lg font-semibold text-slate-900 ml-3"><%= t("sync_sessions.index.last_sync_title") %></h3>
       </div>
       <% if @last_completed_session && @last_completed_session.completed_at %>
-        <p class="text-sm text-slate-600"><%= time_ago_in_words(@last_completed_session.completed_at) %> atrás</p>
-        <p class="text-2xl font-bold text-slate-900 mt-2"><%= @last_completed_session.detected_expenses %> gastos</p>
+        <p class="text-sm text-slate-600"><%= t("sync_sessions.index.time_ago", time: time_ago_in_words(@last_completed_session.completed_at)) %></p>
+        <p class="text-2xl font-bold text-slate-900 mt-2"><%= t("sync_sessions.index.expenses_count", count: @last_completed_session.detected_expenses) %></p>
       <% else %>
-        <p class="text-sm text-slate-600">No hay sincronizaciones previas</p>
+        <p class="text-sm text-slate-600"><%= t("sync_sessions.index.no_previous_syncs") %></p>
       <% end %>
     </div>
 
-    <!-- System health -->
+    <%# System health %>
     <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
       <div class="flex items-center mb-4">
         <div class="bg-emerald-100 p-3 rounded-lg">
@@ -114,19 +116,19 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
         </div>
-        <h3 class="text-lg font-semibold text-slate-900 ml-3">Estado del Sistema</h3>
+        <h3 class="text-lg font-semibold text-slate-900 ml-3"><%= t("sync_sessions.index.system_health") %></h3>
       </div>
-      <p class="text-sm text-slate-600">Todas las cuentas operativas</p>
-      <p class="text-2xl font-bold text-emerald-600 mt-2">Saludable</p>
+      <p class="text-sm text-slate-600"><%= t("sync_sessions.index.all_accounts_operational") %></p>
+      <p class="text-2xl font-bold text-emerald-600 mt-2"><%= t("sync_sessions.index.healthy") %></p>
     </div>
   </div>
 
-  <!-- Sync history -->
-  <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+  <%# Sync history %>
+  <div id="sync_history" class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
     <div class="flex items-center justify-between mb-6">
-      <h2 class="text-xl font-semibold text-slate-900">Historial de Sincronizaciones</h2>
+      <h2 class="text-xl font-semibold text-slate-900"><%= t("sync_sessions.index.sync_history") %></h2>
       <div class="flex items-center gap-2">
-        <span class="text-sm text-emerald-600">✓ Actualización en tiempo real activa</span>
+        <span class="text-sm text-emerald-600"><%= t("sync_sessions.index.realtime_active") %></span>
       </div>
     </div>
 
@@ -134,18 +136,18 @@
       <table class="min-w-full divide-y divide-slate-200">
         <thead>
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Iniciada</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Duración</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Estado</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Cuentas</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Emails</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Gastos</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Acciones</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.started") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.duration") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.status") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.accounts") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.emails") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.expenses") %></th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"><%= t("sync_sessions.index.table.actions") %></th>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-slate-200">
           <% @recent_sessions.each do |session| %>
-            <tr class="hover:bg-slate-50" data-session-id="<%= session.id %>">
+            <tr class="hover:bg-slate-50" id="<%= dom_id(session) %>" data-session-id="<%= session.id %>">
               <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">
                 <%= session.created_at.strftime("%d/%m %H:%M") %>
               </td>
@@ -159,7 +161,9 @@
                 <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <%= render "sync_sessions/session_status_badge", session: session %>
+                <turbo-frame id="<%= dom_id(session, :status) %>">
+                  <%= render "sync_sessions/session_status_badge", session: session %>
+                </turbo-frame>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">
                 <%= session.sync_session_accounts.count %>
@@ -178,7 +182,7 @@
                 <%= session.detected_expenses %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
-                <%= link_to "Ver Detalles", sync_session_path(session),
+                <%= link_to t("sync_sessions.index.table.view_details"), sync_session_path(session),
                     class: "text-teal-600 hover:text-teal-900 font-medium" %>
               </td>
             </tr>
@@ -188,5 +192,3 @@
     </div>
   </div>
 </div>
-
-<!-- Auto-refresh removed - using real-time Action Cable updates instead -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,11 +35,13 @@ en:
   nav:
     dashboard: "Dashboard"
     expenses: "Expenses"
+    budgets: "Budgets"
     categorize: "Categorize"
     analytics: "Analytics"
     accounts: "Accounts"
+    categories: "Categories"
     sync: "Synchronization"
-    patterns: "Patterns"
+    conflicts: "Conflicts"
     settings: "Settings"
     new_expense: "New Expense"
     new_expense_aria: "Create a new expense"
@@ -503,8 +505,35 @@ en:
   sync_sessions:
     index:
       title: "Synchronization Hub"
+      subtitle: "Manage and monitor your email account synchronizations"
       in_progress: "Synchronization in Progress"
+      active_accounts: "Active Accounts"
+      syncs_today: "Syncs Today"
+      expenses_detected_month: "Expenses Detected (Month)"
+      progress: "Progress"
+      emails: "emails"
+      expenses_label: "expenses"
+      sync_all: "Sync All"
+      sync_all_description: "Synchronize all active accounts"
+      start_sync: "Start Synchronization"
       last_sync_title: "Last Synchronization"
+      time_ago: "%{time} ago"
+      expenses_count: "%{count} expenses"
+      no_previous_syncs: "No previous synchronizations"
+      system_health: "System Health"
+      all_accounts_operational: "All accounts operational"
+      healthy: "Healthy"
+      sync_history: "Synchronization History"
+      realtime_active: "Real-time updates active"
+      table:
+        started: "Started"
+        duration: "Duration"
+        status: "Status"
+        accounts: "Accounts"
+        emails: "Emails"
+        expenses: "Expenses"
+        actions: "Actions"
+        view_details: "View Details"
 
     show:
       title: "Synchronization Details"
@@ -736,8 +765,17 @@ en:
     open_navigation_menu: "Open navigation menu"
     mobile_navigation_menu: "Mobile navigation menu"
 
-  # Admin Composite Patterns
+  # Admin
   admin:
+    nav:
+      aria_label: "Admin navigation"
+      title: "Admin - Expense Tracker"
+      patterns: "Patterns"
+      composite_patterns: "Composite Patterns"
+      analytics: "Analytics"
+      sync_performance: "Sync Performance"
+      back_to_app: "← Back to App"
+      logout: "Log Out"
     composite_patterns:
       new:
         title: "New Composite Pattern"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,11 +8,13 @@ es:
   nav:
     dashboard: "Dashboard"
     expenses: "Gastos"
+    budgets: "Presupuestos"
     categorize: "Categorizar"
-    analytics: "Analytics"
+    analytics: "Analíticas"
     accounts: "Cuentas"
+    categories: "Categorías"
     sync: "Sincronización"
-    patterns: "Patrones"
+    conflicts: "Conflictos"
     settings: "Configuración"
     new_expense: "Nuevo Gasto"
     new_expense_aria: "Crear un nuevo gasto"
@@ -481,8 +483,35 @@ es:
   sync_sessions:
     index:
       title: "Centro de Sincronización"
+      subtitle: "Gestiona y monitorea las sincronizaciones de tus cuentas de email"
       in_progress: "Sincronización en Progreso"
+      active_accounts: "Cuentas Activas"
+      syncs_today: "Sincronizaciones Hoy"
+      expenses_detected_month: "Gastos Detectados (Mes)"
+      progress: "Progreso"
+      emails: "emails"
+      expenses_label: "gastos"
+      sync_all: "Sincronizar Todo"
+      sync_all_description: "Sincroniza todas las cuentas activas"
+      start_sync: "Iniciar Sincronización"
       last_sync_title: "Última Sincronización"
+      time_ago: "%{time} atrás"
+      expenses_count: "%{count} gastos"
+      no_previous_syncs: "No hay sincronizaciones previas"
+      system_health: "Estado del Sistema"
+      all_accounts_operational: "Todas las cuentas operativas"
+      healthy: "Saludable"
+      sync_history: "Historial de Sincronizaciones"
+      realtime_active: "Actualización en tiempo real activa"
+      table:
+        started: "Iniciada"
+        duration: "Duración"
+        status: "Estado"
+        accounts: "Cuentas"
+        emails: "Emails"
+        expenses: "Gastos"
+        actions: "Acciones"
+        view_details: "Ver Detalles"
 
     show:
       title: "Detalles de Sincronización"
@@ -775,8 +804,17 @@ es:
     open_navigation_menu: "Abrir menú de navegación"
     mobile_navigation_menu: "Menú de navegación móvil"
 
-  # Admin Patterns
+  # Admin
   admin:
+    nav:
+      aria_label: "Navegación de administrador"
+      title: "Admin - Expense Tracker"
+      patterns: "Patrones"
+      composite_patterns: "Patrones Compuestos"
+      analytics: "Analíticas"
+      sync_performance: "Rendimiento Sync"
+      back_to_app: "← Volver a la App"
+      logout: "Cerrar Sesión"
     patterns:
       index:
         title: "Patrones de Categorización"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,8 @@ Rails.application.routes.draw do
   end
 
   # Performance monitoring dashboard
+  # TODO: Move to namespace :admin once controller is relocated to app/controllers/admin/
+  # Currently inherits Admin::BaseController but routes outside /admin/ namespace
   get "sync_performance", to: "sync_performance#index"
   get "sync_performance/export", to: "sync_performance#export"
   get "sync_performance/realtime", to: "sync_performance#realtime"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,8 +116,9 @@ Rails.application.routes.draw do
     post "bulk_update_status", action: :bulk_update_status, as: :bulk_update_status_expenses
     delete "bulk_destroy", action: :bulk_destroy, as: :bulk_destroy_expenses
   end
-  # Dashboard v2 — now the primary dashboard
-  get "dashboard-v2", to: "dashboard#show", as: :dashboard_v2
+  # Dashboard — primary dashboard
+  get "dashboard", to: "dashboard#show", as: :dashboard_page
+  get "dashboard-v2", to: redirect("/dashboard") # backwards compat
 
   # Old dashboard — temporary alias for one release cycle
   get "old-dashboard", to: "expenses#dashboard"

--- a/spec/controllers/application_controller_auth_spec.rb
+++ b/spec/controllers/application_controller_auth_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe ApplicationController, type: :controller, unit: true do
         CategoriesController,
         EmailAccountsController,
         SyncConflictsController,
-        SyncPerformanceController,
         SyncSessionsController,
         BulkCategorizationsController,
         BulkCategorizationActionsController,

--- a/spec/controllers/i18n_translations_spec.rb
+++ b/spec/controllers/i18n_translations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "I18n translations (PER-119)", unit: true do
     end
 
     it "provides an analytics nav label" do
-      expect(I18n.t("nav.analytics")).to eq("Analytics")
+      expect(I18n.t("nav.analytics")).to eq("Analíticas")
     end
 
     it "provides an accounts nav label" do
@@ -41,8 +41,21 @@ RSpec.describe "I18n translations (PER-119)", unit: true do
       expect(I18n.t("nav.sync")).to eq("Sincronización")
     end
 
-    it "provides a patterns nav label" do
-      expect(I18n.t("nav.patterns")).to eq("Patrones")
+    it "provides a budgets nav label" do
+      expect(I18n.t("nav.budgets")).to eq("Presupuestos")
+    end
+
+    it "provides a categories nav label" do
+      expect(I18n.t("nav.categories")).to eq("Categorías")
+    end
+
+    it "provides admin nav labels" do
+      expect(I18n.t("admin.nav.patterns")).to eq("Patrones")
+      expect(I18n.t("admin.nav.composite_patterns")).to eq("Patrones Compuestos")
+      expect(I18n.t("admin.nav.analytics")).to eq("Analíticas")
+      expect(I18n.t("admin.nav.sync_performance")).to eq("Rendimiento Sync")
+      expect(I18n.t("admin.nav.back_to_app")).to eq("← Volver a la App")
+      expect(I18n.t("admin.nav.logout")).to eq("Cerrar Sesión")
     end
 
     it "provides a new expense nav label" do

--- a/spec/controllers/sync_performance_controller_spec.rb
+++ b/spec/controllers/sync_performance_controller_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe SyncPerformanceController, type: :controller do
+  let(:admin_user) { create(:admin_user, :with_session) }
+
   before do
-    allow(controller).to receive(:authenticate_user!).and_return(true)
+    authenticate_admin_in_controller(admin_user)
   end
 
   describe "GET #index" do

--- a/spec/requests/dashboard_v2_charts_spec.rb
+++ b/spec/requests/dashboard_v2_charts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Dashboard V2 Charts", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2 charts section" do
+  describe "GET /dashboard charts section" do
     context "with category data" do
       let!(:email_account) { create(:email_account, active: true) }
       let!(:food_category) { create(:category, name: "Alimentación") }
@@ -42,14 +42,14 @@ RSpec.describe "Dashboard V2 Charts", type: :request, unit: true do
       end
 
       it "renders the charts row partial" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Category Breakdown")
       end
 
       it "renders the category horizontal bar chart" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         body = response.body
         # Chartkick bar_chart renders a script instantiating BarChart
@@ -57,20 +57,20 @@ RSpec.describe "Dashboard V2 Charts", type: :request, unit: true do
       end
 
       it "renders the monthly trend placeholder" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         body = response.body
         expect(body).to include("Monthly Trend")
       end
 
       it "includes the chart-skeleton controller wrapper" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include('data-controller="chart-skeleton"')
       end
 
       it "uses teal color for chart" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("#0F766E")
       end
@@ -78,14 +78,14 @@ RSpec.describe "Dashboard V2 Charts", type: :request, unit: true do
 
     context "without category data" do
       it "renders the empty state message" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("No hay datos de categorías")
       end
 
       it "does not render a bar chart when no data exists" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).not_to include('Chartkick["BarChart"]')
       end

--- a/spec/requests/dashboard_v2_header_spec.rb
+++ b/spec/requests/dashboard_v2_header_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     let!(:email_account) { create(:email_account, active: true) }
 
     context "header partial rendering" do
       it "renders the header with the dashboard title" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Dashboard")
       end
 
       it "renders a subtitle with the current month and year" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         # The subtitle uses I18n.l with :long format — just check for the year
         expect(response.body).to include(Date.current.year.to_s)
@@ -38,14 +38,14 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
       end
 
       it "displays time-ago text for last sync" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         # Uses i18n key with default "Last synced %{time} ago"
         expect(response.body).to match(/synced.*ago|sincronizado/i)
       end
 
       it "uses slate-500 styling for idle state" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("text-slate-500")
       end
@@ -57,19 +57,19 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
       end
 
       it "displays syncing text" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to match(/Syncing|Sincronizando/i)
       end
 
       it "includes a spinner with animate-spin" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("animate-spin")
       end
 
       it "uses teal-600 styling for active state" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("text-teal-600")
       end
@@ -77,13 +77,13 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
 
     context "sync status indicator — never synced state" do
       it "displays not synced yet text when no sync has occurred" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to match(/Not synced yet|No sincronizado/i)
       end
 
       it "uses slate-400 styling for never-synced state" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("text-slate-400")
       end
@@ -91,7 +91,7 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
 
     context "accessibility" do
       it "includes aria-live polite on the sync status region" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include('aria-live="polite"')
       end
@@ -99,7 +99,7 @@ RSpec.describe "Dashboard V2 Header", type: :request, unit: true do
 
     context "sync status section removed" do
       it "does not render the standalone sync status card with h2 heading" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         # The old standalone sync status section had an h2 with "Sync Status".
         # The header indicator replaces it — no h2 should remain.

--- a/spec/requests/dashboard_v2_insights_spec.rb
+++ b/spec/requests/dashboard_v2_insights_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Dashboard V2 Insights", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     context "when insights exist" do
       let!(:email_account) { create(:email_account, active: true) }
       let!(:category) { create(:category, name: "Food") }
@@ -31,14 +31,14 @@ RSpec.describe "Dashboard V2 Insights", type: :request, unit: true do
       end
 
       it "renders the insights row section" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include('aria-label="Actionable insights"')
       end
 
       it "displays uncategorized insight when uncategorized expenses exist" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("expenses need categorization")
       end
@@ -59,7 +59,7 @@ RSpec.describe "Dashboard V2 Insights", type: :request, unit: true do
       it "does not render the insights row when no insights exist" do
         # No uncategorized expenses, and total_amount with no budget means no budget insights
         allow_any_instance_of(Services::DashboardInsightsService).to receive(:insights).and_return([])
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).not_to include('aria-label="Actionable insights"')
       end
@@ -88,7 +88,7 @@ RSpec.describe "Dashboard V2 Insights", type: :request, unit: true do
       end
 
       it "renders spending projection insight" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         body = response.body

--- a/spec/requests/dashboard_v2_metric_cards_spec.rb
+++ b/spec/requests/dashboard_v2_metric_cards_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Dashboard V2 Metric Cards", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     context "with data" do
       let!(:email_account) { create(:email_account, active: true) }
       let!(:category) { create(:category, name: "Food") }
@@ -36,7 +36,7 @@ RSpec.describe "Dashboard V2 Metric Cards", type: :request, unit: true do
           merchant_name: "UncategorizedMerchant")
       end
 
-      before { get "/dashboard-v2" }
+      before { get "/dashboard" }
 
       it "renders the metric cards section" do
         expect(response).to have_http_status(:success)
@@ -127,7 +127,7 @@ RSpec.describe "Dashboard V2 Metric Cards", type: :request, unit: true do
     end
 
     context "without email account (empty state)" do
-      before { get "/dashboard-v2" }
+      before { get "/dashboard" }
 
       it "renders metric cards with zero values" do
         expect(response).to have_http_status(:success)
@@ -149,7 +149,7 @@ RSpec.describe "Dashboard V2 Metric Cards", type: :request, unit: true do
           merchant_name: "AllCategorizedMerchant")
       end
 
-      before { get "/dashboard-v2" }
+      before { get "/dashboard" }
 
       it "does not show warning styling for uncategorized when count is zero" do
         # When uncategorized_count is 0, the uncategorized card should not

--- a/spec/requests/dashboard_v2_period_selector_spec.rb
+++ b/spec/requests/dashboard_v2_period_selector_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
+RSpec.describe "Dashboard Period Selector", type: :request, unit: true do
   let(:admin_user) { create(:admin_user) }
 
   before do
@@ -13,7 +13,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     let!(:email_account) { create(:email_account, active: true) }
     let!(:category) { create(:category, name: "Food") }
     let!(:expense) do
@@ -26,7 +26,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
 
     context "period defaults" do
       it "defaults period to month when no param given" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("month")
       end
@@ -34,7 +34,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
 
     context "period selector rendering" do
       it "renders a period selector with 4 options" do
-        get "/dashboard-v2"
+        get "/dashboard"
         body = response.body
 
         expect(body).to include("This Month")
@@ -44,32 +44,32 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
       end
 
       it "highlights the active period with teal styling" do
-        get "/dashboard-v2"
+        get "/dashboard"
         # Default "month" should be active
         expect(response.body).to include("bg-teal-700")
       end
 
       it "renders inactive periods with slate styling" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("bg-slate-100")
       end
     end
 
     context "Turbo Frame wrapper" do
       it "wraps dashboard body in a turbo frame" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include('id="dashboard-body"')
       end
 
       it "period selector links target the dashboard-body frame" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include('data-turbo-frame="dashboard-body"')
       end
     end
 
     context "period=month (default)" do
       it "uses current month reference date" do
-        get "/dashboard-v2", params: { period: "month" }
+        get "/dashboard", params: { period: "month" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("month")
       end
@@ -77,7 +77,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
 
     context "period=last_month" do
       it "uses previous month reference date" do
-        get "/dashboard-v2", params: { period: "last_month" }
+        get "/dashboard", params: { period: "last_month" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("last_month")
       end
@@ -89,13 +89,13 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
           hash_including(reference_date: expected_date)
         ).and_call_original
 
-        get "/dashboard-v2", params: { period: "last_month" }
+        get "/dashboard", params: { period: "last_month" }
       end
     end
 
     context "period=quarter" do
       it "uses quarter period" do
-        get "/dashboard-v2", params: { period: "quarter" }
+        get "/dashboard", params: { period: "quarter" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("quarter")
       end
@@ -107,7 +107,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
           hash_including(period: :year)
         ).and_call_original
 
-        get "/dashboard-v2", params: { period: "year" }
+        get "/dashboard", params: { period: "year" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("year")
       end
@@ -115,19 +115,19 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
 
     context "invalid period" do
       it "normalizes unknown period values to month" do
-        get "/dashboard-v2", params: { period: "invalid" }
+        get "/dashboard", params: { period: "invalid" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("month")
       end
     end
 
     context "named route" do
-      it "responds to dashboard_v2_path helper" do
-        expect(dashboard_v2_path).to eq("/dashboard-v2")
+      it "responds to dashboard_page_path helper" do
+        expect(dashboard_page_path).to eq("/dashboard")
       end
 
       it "accepts period param in named route" do
-        expect(dashboard_v2_path(period: "year")).to eq("/dashboard-v2?period=year")
+        expect(dashboard_page_path(period: "year")).to eq("/dashboard?period=year")
       end
     end
 
@@ -135,7 +135,7 @@ RSpec.describe "Dashboard V2 Period Selector", type: :request, unit: true do
       before { EmailAccount.destroy_all }
 
       it "renders successfully with default period" do
-        get "/dashboard-v2", params: { period: "last_month" }
+        get "/dashboard", params: { period: "last_month" }
         expect(response).to have_http_status(:success)
         expect(assigns(:period)).to eq("last_month")
       end

--- a/spec/requests/dashboard_v2_recent_activity_spec.rb
+++ b/spec/requests/dashboard_v2_recent_activity_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Dashboard V2 Recent Activity", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     context "recent activity section" do
       let!(:email_account) { create(:email_account, active: true) }
       let!(:category) { create(:category, name: "Alimentacion", color: "#4ECDC4") }
@@ -33,30 +33,30 @@ RSpec.describe "Dashboard V2 Recent Activity", type: :request, unit: true do
       end
 
       it "renders the recent activity section" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Recent Expenses")
       end
 
       it "shows merchant names" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expenses.each do |expense|
           expect(response.body).to include(expense.merchant_name)
         end
       end
 
       it "shows formatted amounts with colon currency symbol" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("₡")
       end
 
       it "shows category badges" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("Alimentacion")
       end
 
       it "includes 'View all expenses' link" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("View all expenses")
         expect(response.body).to include(expenses_path)
       end
@@ -72,7 +72,7 @@ RSpec.describe "Dashboard V2 Recent Activity", type: :request, unit: true do
           )
         end
 
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:recent_expenses).size).to eq(8)
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe "Dashboard V2 Recent Activity", type: :request, unit: true do
       let!(:email_account) { create(:email_account, active: true) }
 
       it "shows empty state message when there are no expenses" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("No hay gastos recientes")
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe "Dashboard V2 Recent Activity", type: :request, unit: true do
       end
 
       it "shows 'Sin categoría' for expenses without a category" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("Sin categor")
       end
     end

--- a/spec/requests/dashboard_v2_spec.rb
+++ b/spec/requests/dashboard_v2_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Dashboard V2", type: :request, unit: true do
+RSpec.describe "Dashboard", type: :request, unit: true do
   let(:admin_user) { create(:admin_user) }
 
   before do
@@ -13,12 +13,12 @@ RSpec.describe "Dashboard V2", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2" do
+  describe "GET /dashboard" do
     context "when unauthenticated" do
       before { reset! }
 
       it "redirects to login" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response).to redirect_to(admin_login_path)
       end
     end
@@ -38,12 +38,12 @@ RSpec.describe "Dashboard V2", type: :request, unit: true do
       end
 
       it "renders successfully" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response).to have_http_status(:success)
       end
 
       it "includes monthly metrics" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response.body).to include("Month Total")
         expect(response.body).to include("Budget Remaining")
         expect(response.body).to include("Daily Average")
@@ -51,47 +51,47 @@ RSpec.describe "Dashboard V2", type: :request, unit: true do
       end
 
       it "limits recent expenses to 8" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:recent_expenses).size).to eq(8)
       end
 
       it "provides category breakdown limited to 10" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:category_breakdown)).to be_an(Array)
         expect(assigns(:category_breakdown).size).to be <= 10
       end
 
       it "provides monthly trend data limited to 6 months" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:monthly_trend)).to be_a(Hash)
         expect(assigns(:monthly_trend).size).to be <= 6
       end
 
       it "provides sync status" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:sync_status)).to include(:last_sync, :active)
       end
 
       it "provides daily average" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:daily_average)).to be_a(Float)
         expect(assigns(:daily_average)).to be > 0
       end
 
       it "provides uncategorized count" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:uncategorized_count)).to be_an(Integer)
       end
 
       it "provides budget data" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(assigns(:budgets)).to be_present
       end
     end
 
     context "without email account" do
       it "renders successfully with empty defaults" do
-        get "/dashboard-v2"
+        get "/dashboard"
         expect(response).to have_http_status(:success)
         expect(assigns(:monthly_metrics)[:total_amount]).to eq(0.0)
         expect(assigns(:daily_average)).to eq(0.0)
@@ -103,7 +103,7 @@ RSpec.describe "Dashboard V2", type: :request, unit: true do
       let!(:email_account) { create(:email_account, active: true) }
 
       it "has no filters, batch selection, or pagination" do
-        get "/dashboard-v2"
+        get "/dashboard"
         body = response.body
 
         # No expense management controls

--- a/spec/requests/dashboard_v2_trend_chart_spec.rb
+++ b/spec/requests/dashboard_v2_trend_chart_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Dashboard V2 Trend Chart", type: :request, unit: true do
       .and_return(double("intermediate", where: jobs_relation))
   end
 
-  describe "GET /dashboard-v2 trend chart section" do
+  describe "GET /dashboard trend chart section" do
     context "with trend data and budget" do
       let!(:email_account) { create(:email_account, active: true) }
       let!(:category) { create(:category, name: "Alimentación") }
@@ -40,50 +40,50 @@ RSpec.describe "Dashboard V2 Trend Chart", type: :request, unit: true do
       end
 
       it "renders the line chart with spending data" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include('Chartkick["LineChart"]')
       end
 
       it "renders the Monthly Trend heading" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("Monthly Trend")
       end
 
       it "includes teal color for spending line" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("#0F766E")
       end
 
       it "includes amber color for budget line" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("#D97706")
       end
 
       it "shows the budget line label" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("Budget")
       end
 
       it "shows the spending line label" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include("Spending")
       end
 
       it "includes the chart-skeleton controller wrapper" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).to include('data-controller="chart-skeleton"')
       end
 
       it "does not render the placeholder text" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).not_to include("Trend chart coming soon")
       end
@@ -105,7 +105,7 @@ RSpec.describe "Dashboard V2 Trend Chart", type: :request, unit: true do
       end
 
       it "renders the line chart with only spending data" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         body = response.body
         expect(body).to include('Chartkick["LineChart"]')
@@ -113,7 +113,7 @@ RSpec.describe "Dashboard V2 Trend Chart", type: :request, unit: true do
       end
 
       it "renders only one data series without a budget line" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         body = response.body
         # Chartkick renders series data as JSON with "name" keys
@@ -125,20 +125,20 @@ RSpec.describe "Dashboard V2 Trend Chart", type: :request, unit: true do
 
     context "without trend data" do
       it "renders the empty state message" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("No hay datos de tendencia")
       end
 
       it "does not render a line chart" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         expect(response.body).not_to include('Chartkick["LineChart"]')
       end
 
       it "renders the line chart icon in empty state" do
-        get "/dashboard-v2"
+        get "/dashboard"
 
         # SVG path element for line chart icon
         expect(response.body).to include("M3 17l6-6 4 4 8-8")

--- a/spec/requests/per207_sync_conflicts_select_all_spec.rb
+++ b/spec/requests/per207_sync_conflicts_select_all_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "SyncConflicts select-all page structure", type: :request, unit: 
       sync_session: sync_session,
       status: "pending",
       bulk_resolvable: true,
-      conflict_type: "duplicate"
+      conflict_type: "similar"
     )
   end
 

--- a/spec/requests/per421_bank_breakdown_relocation_spec.rb
+++ b/spec/requests/per421_bank_breakdown_relocation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "PER-421: Bank breakdown relocation", type: :request, unit: true 
     end
   end
 
-  describe "Dashboard v2 (GET /dashboard-v2)" do
+  describe "Dashboard v2 (GET /dashboard)" do
     before do
       # Mock SolidQueue::Job used by DashboardService#sync_info
       jobs_relation = double("jobs_relation", exists?: false, count: 0)
@@ -70,7 +70,7 @@ RSpec.describe "PER-421: Bank breakdown relocation", type: :request, unit: true 
     end
 
     it "does NOT contain bank breakdown" do
-      get dashboard_v2_path
+      get dashboard_page_path
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include(I18n.t("email_accounts.bank_breakdown.title"))
       expect(response.body).not_to include("bank-breakdown")

--- a/spec/requests/per422_route_swap_spec.rb
+++ b/spec/requests/per422_route_swap_spec.rb
@@ -26,9 +26,16 @@ RSpec.describe "PER-422: Route swap — new dashboard is root", type: :request, 
   end
 
   describe "dashboard path" do
-    it "still works as an alias" do
+    it "serves the primary dashboard" do
       get "/dashboard"
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "dashboard-v2 backwards compatibility" do
+    it "redirects /dashboard-v2 to /dashboard" do
+      get "/dashboard-v2"
+      expect(response).to redirect_to("/dashboard")
     end
   end
 

--- a/spec/requests/per422_route_swap_spec.rb
+++ b/spec/requests/per422_route_swap_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "PER-422: Route swap — new dashboard is root", type: :request, 
     it "serves the new dashboard at /" do
       get "/"
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("dashboard-v2")
+      expect(response.body).to include("dashboard")
     end
 
     it "renders DashboardController#show" do
@@ -25,9 +25,9 @@ RSpec.describe "PER-422: Route swap — new dashboard is root", type: :request, 
     end
   end
 
-  describe "dashboard-v2 path" do
+  describe "dashboard path" do
     it "still works as an alias" do
-      get "/dashboard-v2"
+      get "/dashboard"
       expect(response).to have_http_status(:success)
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe "PER-422: Route swap — new dashboard is root", type: :request, 
   describe "navigation links" do
     it "dashboard nav link points to new dashboard" do
       get "/"
-      expect(response.body).to include("dashboard-v2")
+      expect(response.body).to include("dashboard")
     end
   end
 end

--- a/spec/services/conflict_detection_service_spec.rb
+++ b/spec/services/conflict_detection_service_spec.rb
@@ -308,13 +308,14 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
         ActiveRecord::RecordInvalid.new(SyncConflict.new)
       )
 
+      # Use a non-duplicate type so it doesn't hit the early-return guard
       expect {
         service.send(
           :create_conflict,
           existing_expense: existing_expense,
           new_expense_data: new_expense_data,
-          conflict_type: 'duplicate',
-          similarity_score: 95.0,
+          conflict_type: 'needs_review',
+          similarity_score: 50.0,
           differences: {}
         )
       }.not_to change(Expense, :count)

--- a/spec/services/conflict_detection_service_spec.rb
+++ b/spec/services/conflict_detection_service_spec.rb
@@ -31,17 +31,15 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
     context 'when exact duplicate exists' do
       before { existing_expense }
 
-      it 'creates a duplicate conflict' do
+      it 'skips obvious duplicates with high similarity (>=95%)' do
         conflict = service.detect_conflict_for_expense(new_expense_data)
-
-        expect(conflict).to be_present
-        expect(conflict.conflict_type).to eq('duplicate')
-        expect(conflict.similarity_score).to be >= 90
+        expect(conflict).to be_nil
       end
 
-      it 'associates with the existing expense' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
-        expect(conflict.existing_expense).to eq(existing_expense)
+      it 'does not create a conflict record for obvious duplicates' do
+        expect {
+          service.detect_conflict_for_expense(new_expense_data)
+        }.not_to change(SyncConflict, :count)
       end
     end
 
@@ -62,12 +60,9 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
     context 'when conflict_type is duplicate' do
       before { existing_expense }
 
-      it 'saves the new expense with deleted_at set' do
+      it 'skips creating conflict for obvious duplicates' do
         conflict = service.detect_conflict_for_expense(new_expense_data)
-
-        expect(conflict).to be_present
-        expect(conflict.conflict_type).to eq('duplicate')
-        expect(conflict.new_expense.deleted_at).to be_present
+        expect(conflict).to be_nil
       end
     end
 
@@ -163,12 +158,12 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
         )
       end
 
-      it 'returns array of conflicts' do
+      it 'returns array (obvious duplicates are skipped)' do
         conflicts = service.detect_conflicts_batch(new_expenses_data)
 
         expect(conflicts).to be_an(Array)
-        expect(conflicts.size).to eq(1)
-        expect(conflicts.first).to be_a(SyncConflict)
+        # Obvious duplicates (>=95% similarity) are now skipped entirely
+        expect(conflicts.compact).to be_empty
       end
     end
   end
@@ -325,17 +320,31 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       }.not_to change(Expense, :count)
     end
 
-    it 'returns nil and adds an error when the transaction fails' do
-      allow_any_instance_of(SyncConflict).to receive(:save!).and_raise(
-        ActiveRecord::RecordInvalid.new(SyncConflict.new)
-      )
-
+    it 'skips obvious duplicates (>=95% similarity) without creating records' do
       result = service.send(
         :create_conflict,
         existing_expense: existing_expense,
         new_expense_data: new_expense_data,
         conflict_type: 'duplicate',
         similarity_score: 95.0,
+        differences: {}
+      )
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil and adds an error when the transaction fails' do
+      allow_any_instance_of(SyncConflict).to receive(:save!).and_raise(
+        ActiveRecord::RecordInvalid.new(SyncConflict.new)
+      )
+
+      # Use a non-duplicate type so it doesn't get skipped
+      result = service.send(
+        :create_conflict,
+        existing_expense: existing_expense,
+        new_expense_data: new_expense_data,
+        conflict_type: 'needs_review',
+        similarity_score: 50.0,
         differences: {}
       )
 

--- a/spec/views/layouts/navigation_mobile_spec.rb
+++ b/spec/views/layouts/navigation_mobile_spec.rb
@@ -69,12 +69,21 @@ RSpec.describe "Navigation mobile responsiveness", type: :controller, unit: true
     it "contains all navigation links in the desktop menu" do
       expect(nav_html).to include("Dashboard")
       expect(nav_html).to include("Gastos")
-      expect(nav_html).to include("Categorizar")
-      expect(nav_html).to include("Analytics")
+      expect(nav_html).to include("Presupuestos")
+      expect(nav_html).not_to include("Categorizar")
+      expect(nav_html).to include("Nuevo Gasto")
+    end
+
+    it "contains settings dropdown with config links" do
+      expect(nav_html).to include("Configuración")
       expect(nav_html).to include("Cuentas")
       expect(nav_html).to include("Sincronización")
-      expect(nav_html).to include("Patrones")
-      expect(nav_html).to include("Nuevo Gasto")
+      expect(nav_html).to include("Conflictos")
+    end
+
+    it "does not include admin-only links" do
+      expect(nav_html).not_to include("Patrones")
+      expect(nav_html).not_to include("Analíticas")
     end
   end
 
@@ -106,12 +115,19 @@ RSpec.describe "Navigation mobile responsiveness", type: :controller, unit: true
     it "contains all navigation links in the mobile menu" do
       expect(mobile_menu_html).to include("Dashboard")
       expect(mobile_menu_html).to include("Gastos")
-      expect(mobile_menu_html).to include("Categorizar")
-      expect(mobile_menu_html).to include("Analytics")
+      expect(mobile_menu_html).to include("Presupuestos")
+      expect(mobile_menu_html).to include("Nuevo Gasto")
+    end
+
+    it "contains settings section with config links" do
+      expect(mobile_menu_html).to include("Configuración")
       expect(mobile_menu_html).to include("Cuentas")
       expect(mobile_menu_html).to include("Sincronización")
-      expect(mobile_menu_html).to include("Patrones")
-      expect(mobile_menu_html).to include("Nuevo Gasto")
+    end
+
+    it "does not include admin-only links" do
+      expect(mobile_menu_html).not_to include("Patrones")
+      expect(mobile_menu_html).not_to include("Analíticas")
     end
 
     it "includes opacity transition classes for smooth animation" do
@@ -167,7 +183,7 @@ RSpec.describe "Navigation mobile responsiveness", type: :controller, unit: true
       desktop_match = nav_html.match(/class="hidden md:flex[^"]*".*?<\/div>/m)
       expect(desktop_match).to be_present
 
-      %w[Dashboard Gastos Categorizar Analytics Cuentas Sincronización Patrones].each do |link_text|
+      %w[Dashboard Gastos Presupuestos].each do |link_text|
         expect(desktop_match[0]).to include(link_text)
         expect(mobile_menu_html).to include(link_text)
       end


### PR DESCRIPTION
## Summary

- **Nav reorganization (PER-424):** Grouped main nav into Dashboard, Expenses, Budgets + Settings dropdown (Accounts, Sync, Conflicts). Moved admin pages (Patterns, Analytics, Sync Performance) to admin layout. Removed bulk categorization from nav. Added Budgets and Conflicts links.
- **Dashboard URL cleanup:** Renamed `/dashboard-v2` to `/dashboard` with backwards-compat redirect. Fixed turbo-frame trapped links (View all expenses, budget card, uncategorized card, insights).
- **Currency symbols (PER-436):** Replaced hardcoded `₡` with `currency_symbol(expense)` helper across all per-expense views. Supports `₡` (CRC), `$` (USD), `€` (EUR).
- **Sync improvements:** Full i18n for sync sessions page, polling fallback for real-time progress (Action Cable async adapter workaround), auto-reload on completion, sync performance division-by-zero fix.
- **Conflict detection:** Skip creating records for obvious duplicates (≥95% similarity), filter duplicates from index page, add Conflicts to nav.

## Test plan

- [ ] Verify nav shows Dashboard, Expenses, Budgets as flat links
- [ ] Verify Settings dropdown shows Accounts, Sync, Conflicts with icons
- [ ] Verify mobile nav shows same items with Settings section separator
- [ ] Verify admin layout shows Patterns, Composite Patterns, Analytics, Sync Performance
- [ ] Visit `/dashboard-v2` — should redirect to `/dashboard`
- [ ] Click "View all expenses" on dashboard — should navigate (not trapped in turbo-frame)
- [ ] Verify USD expenses show `$` symbol, CRC show `₡`
- [ ] Trigger a sync — progress should update every ~5 seconds via polling
- [ ] Visit `/sync_conflicts` — should only show non-duplicate conflicts
- [ ] Trigger sync with existing expenses — no new duplicate conflict records created for ≥95% matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)