### PR TITLE
fix: scoped job retries, AdminUser reference, remove sleeps (PER-439, PER-440, PER-452)

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,9 @@
 class ApplicationJob < ActiveJob::Base
-  # Configure default retry behavior for ActiveJob/Solid Queue
-  retry_on StandardError, wait: 10.seconds, attempts: 3
-
   # Automatically retry jobs that encountered a deadlock
   retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+
+  # Retry jobs when the database connection is not established
+  retry_on ActiveRecord::ConnectionNotEstablished, wait: 5.seconds, attempts: 3
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   discard_on ActiveJob::DeserializationError

--- a/app/jobs/bulk_deletion_job.rb
+++ b/app/jobs/bulk_deletion_job.rb
@@ -27,9 +27,6 @@ class BulkDeletionJob < BulkOperations::BaseJob
 
       percentage = (processed.to_f / total * 100).round
       track_progress(percentage, "Deleted #{processed} of #{total} expenses...")
-
-      # Short sleep to prevent overwhelming the system
-      sleep 0.1 if total > 100
     end
 
     last_result

--- a/app/jobs/bulk_operations/base_job.rb
+++ b/app/jobs/bulk_operations/base_job.rb
@@ -6,12 +6,13 @@ module BulkOperations
   class BaseJob < ApplicationJob
     queue_as :bulk_operations
 
-    # Retry failed jobs with exponential backoff
-    retry_on StandardError, wait: :exponentially_longer, attempts: 3
+    # Retry failed jobs on transient database errors
+    retry_on ActiveRecord::Deadlocked, wait: :exponentially_longer, attempts: 3
+    retry_on ActiveRecord::ConnectionNotEstablished, wait: :exponentially_longer, attempts: 3
 
     def perform(expense_ids:, user_id: nil, options: {})
       @expense_ids = expense_ids
-      @user = user_id ? User.find_by(id: user_id) : nil
+      @user = user_id ? AdminUser.find_by(id: user_id) : nil
       @options = options
       @job_id = job_id
 

--- a/app/jobs/bulk_status_update_job.rb
+++ b/app/jobs/bulk_status_update_job.rb
@@ -29,9 +29,6 @@ class BulkStatusUpdateJob < BulkOperations::BaseJob
 
       percentage = (processed.to_f / total * 100).round
       track_progress(percentage, "Updated status for #{processed} of #{total} expenses...")
-
-      # Short sleep to prevent overwhelming the system
-      sleep 0.1 if total > 100
     end
 
     last_result

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -62,15 +62,19 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       expect(ApplicationJob.rescue_handlers).not_to be_empty
 
       handler_classes = ApplicationJob.rescue_handlers.map(&:first)
-      expect(handler_classes).to include('StandardError')
       expect(handler_classes).to include('ActiveRecord::Deadlocked')
+      expect(handler_classes).to include('ActiveRecord::ConnectionNotEstablished')
       expect(handler_classes).to include('ActiveJob::DeserializationError')
     end
 
-    it 'configures retry for StandardError with correct parameters' do
-      handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'StandardError' }
+    it 'does not retry on generic StandardError' do
+      handler_classes = ApplicationJob.rescue_handlers.map(&:first)
+      expect(handler_classes).not_to include('StandardError')
+    end
+
+    it 'configures retry for ActiveRecord::ConnectionNotEstablished' do
+      handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'ActiveRecord::ConnectionNotEstablished' }
       expect(handler).not_to be_nil
-      # Handler exists and will be used for StandardError and its subclasses
     end
 
     it 'configures retry for ActiveRecord::Deadlocked with correct parameters' do
@@ -91,18 +95,9 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       expect(unique_handlers.size).to be >= 3
     end
 
-    it 'configures StandardError with 3 retry attempts' do
-      # The retry_on configuration for StandardError specifies 3 attempts
-      handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'StandardError' }
+    it 'configures ActiveRecord::ConnectionNotEstablished with 3 retry attempts' do
+      handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'ActiveRecord::ConnectionNotEstablished' }
       expect(handler).not_to be_nil
-      # Configuration includes attempts: 3 in the class definition
-    end
-
-    it 'configures StandardError with 10 second wait time' do
-      # The retry_on configuration for StandardError specifies wait: 10.seconds
-      handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'StandardError' }
-      expect(handler).not_to be_nil
-      # Configuration includes wait: 10.seconds in the class definition
     end
 
     it 'configures ActiveRecord::Deadlocked with 5 second wait time' do
@@ -123,62 +118,27 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       # More specific handlers should come before more general ones
       handler_classes = ApplicationJob.rescue_handlers.map(&:first)
 
-      # In Rails, handlers are processed in reverse order (last defined is checked first)
-      # So StandardError (defined first) will be at a higher index than Deadlocked (defined second)
+      # Verify all three specific handlers exist
+      expect(handler_classes).to include('ActiveRecord::Deadlocked')
+      expect(handler_classes).to include('ActiveRecord::ConnectionNotEstablished')
+      expect(handler_classes).to include('ActiveJob::DeserializationError')
+
+      # Deadlocked should appear before ConnectionNotEstablished (defined first)
       deadlock_index = handler_classes.index('ActiveRecord::Deadlocked')
-      standard_index = handler_classes.index('StandardError')
-
-      # Both handlers should exist
+      connection_index = handler_classes.index('ActiveRecord::ConnectionNotEstablished')
       expect(deadlock_index).not_to be_nil
-      expect(standard_index).not_to be_nil
-
-      # The order in the array represents the order they'll be checked
-      # ActiveJob checks handlers from last to first, so more specific should be defined after general
-      expect(handler_classes).to include('StandardError', 'ActiveRecord::Deadlocked', 'ActiveJob::DeserializationError')
+      expect(connection_index).not_to be_nil
     end
   end
 
   describe 'retry behavior verification' do
-    context 'when StandardError is raised' do
-      let(:job_with_standard_error) do
-        Class.new(ApplicationJob) do
-          def self.name
-            'TestStandardErrorJob'
-          end
-
-          attr_accessor :attempt_count
-
-          def initialize
-            super
-            @attempt_count = 0
-          end
-
-          def perform
-            @attempt_count += 1
-            raise StandardError, "Attempt #{@attempt_count}"
-          end
-        end
+    context 'when ActiveRecord::ConnectionNotEstablished is raised' do
+      it 'is configured to retry on ConnectionNotEstablished' do
+        expect(ApplicationJob.rescue_handlers.map(&:first)).to include('ActiveRecord::ConnectionNotEstablished')
       end
 
-      it 'is configured to retry on StandardError' do
-        job = job_with_standard_error.new
-
-        # The job should have retry_on configuration from ApplicationJob
-        expect(ApplicationJob.rescue_handlers.map(&:first)).to include('StandardError')
-      end
-
-      it 'handles StandardError subclasses' do
-        job_with_argument_error = Class.new(ApplicationJob) do
-          def perform
-            raise ArgumentError, "Invalid argument"
-          end
-        end
-
-        # ArgumentError is a StandardError subclass, so it should be handled
-        expect(ApplicationJob.rescue_handlers.map(&:first)).to include('StandardError')
-
-        # Verify ArgumentError is indeed a StandardError
-        expect(ArgumentError.ancestors).to include(StandardError)
+      it 'does not retry on generic StandardError' do
+        expect(ApplicationJob.rescue_handlers.map(&:first)).not_to include('StandardError')
       end
     end
 
@@ -250,12 +210,17 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       handlers = ApplicationJob.rescue_handlers
       handler_classes = handlers.map(&:first)
 
-      expect(handler_classes).to include('StandardError')
       expect(handler_classes).to include('ActiveRecord::Deadlocked')
+      expect(handler_classes).to include('ActiveRecord::ConnectionNotEstablished')
       expect(handler_classes).to include('ActiveJob::DeserializationError')
 
       # Verify we have exactly these three handlers
       expect(handlers.size).to be >= 3
+    end
+
+    it 'does not have a blanket StandardError handler' do
+      handler_classes = ApplicationJob.rescue_handlers.map(&:first)
+      expect(handler_classes).not_to include('StandardError')
     end
 
     it 'maintains handler configuration across job inheritance' do
@@ -286,8 +251,8 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       handlers = child_with_custom_handler.rescue_handlers.map(&:first)
 
       # Should have parent handlers plus the custom one
-      expect(handlers).to include('StandardError')
       expect(handlers).to include('ActiveRecord::Deadlocked')
+      expect(handlers).to include('ActiveRecord::ConnectionNotEstablished')
       expect(handlers).to include('ActiveJob::DeserializationError')
       expect(handlers.join).to include('CustomError')
     end
@@ -511,8 +476,8 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       # All should have the same base handlers
       [ parent, child, grandchild ].each do |klass|
         handlers = klass.rescue_handlers.map(&:first)
-        expect(handlers).to include('StandardError')
         expect(handlers).to include('ActiveRecord::Deadlocked')
+        expect(handlers).to include('ActiveRecord::ConnectionNotEstablished')
         expect(handlers).to include('ActiveJob::DeserializationError')
       end
     end
@@ -535,13 +500,13 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
 
   describe 'comprehensive coverage validation' do
     it 'covers all retry_on configurations' do
-      # Verify StandardError retry configuration
-      standard_handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'StandardError' }
-      expect(standard_handler).not_to be_nil
-
       # Verify Deadlocked retry configuration
       deadlock_handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'ActiveRecord::Deadlocked' }
       expect(deadlock_handler).not_to be_nil
+
+      # Verify ConnectionNotEstablished retry configuration
+      connection_handler = ApplicationJob.rescue_handlers.find { |h| h.first == 'ActiveRecord::ConnectionNotEstablished' }
+      expect(connection_handler).not_to be_nil
     end
 
     it 'covers discard_on configuration' do
@@ -600,11 +565,10 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
       expect(job).to respond_to(:deserialize)
     end
 
-    it 'ensures retry_on StandardError configuration line is covered' do
-      # Line 3: retry_on StandardError, wait: 10.seconds, attempts: 3
+    it 'ensures retry_on ActiveRecord::ConnectionNotEstablished configuration line is covered' do
       handlers = ApplicationJob.rescue_handlers
-      standard_handler = handlers.find { |h| h.first == 'StandardError' }
-      expect(standard_handler).not_to be_nil
+      connection_handler = handlers.find { |h| h.first == 'ActiveRecord::ConnectionNotEstablished' }
+      expect(connection_handler).not_to be_nil
     end
 
     it 'ensures retry_on ActiveRecord::Deadlocked configuration line is covered' do
@@ -660,8 +624,8 @@ RSpec.describe ApplicationJob, type: :job, unit: true do
     it 'follows ActiveJob retry patterns' do
       # Verify the retry configuration aligns with ActiveJob patterns
       handlers = ApplicationJob.rescue_handlers.map(&:first)
-      expect(handlers).to include('StandardError')
       expect(handlers).to include('ActiveRecord::Deadlocked')
+      expect(handlers).to include('ActiveRecord::ConnectionNotEstablished')
     end
   end
 

--- a/spec/jobs/bulk_categorization_job_spec.rb
+++ b/spec/jobs/bulk_categorization_job_spec.rb
@@ -2,19 +2,6 @@
 
 require 'rails_helper'
 
-# Stub User class for testing since BaseJob references it
-class User
-  attr_accessor :id
-
-  def initialize(id)
-    @id = id
-  end
-
-  def self.find_by(id:)
-    new(id) if id
-  end
-end unless defined?(User)
-
 RSpec.describe BulkCategorizationJob, type: :job, unit: true do
   subject(:job) { described_class.new }
 
@@ -42,6 +29,8 @@ RSpec.describe BulkCategorizationJob, type: :job, unit: true do
     allow(Rails.logger).to receive(:info)
     allow(Rails.logger).to receive(:error)
     allow(Category).to receive(:find_by).with(id: category_id).and_return(category)
+    allow(AdminUser).to receive(:find_by).with(id: user_id).and_return(double('AdminUser', id: user_id))
+    allow(AdminUser).to receive(:find_by).with(id: nil).and_return(nil)
     allow(Rails.cache).to receive(:write)
     allow(ActionCable.server).to receive(:broadcast)
     allow(Time).to receive(:current).and_return(Time.zone.parse('2025-08-30 12:00:00'))

--- a/spec/jobs/bulk_deletion_job_spec.rb
+++ b/spec/jobs/bulk_deletion_job_spec.rb
@@ -15,20 +15,19 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
 
   before do
     # Stub constants for unit test environment
-    user_class = double('UserClass')
-    stub_const('User', user_class)
+    admin_user_class = double('AdminUserClass')
+    stub_const('AdminUser', admin_user_class)
 
     deletion_service_class = double('DeletionServiceClass')
     stub_const('Services::BulkOperations::DeletionService', deletion_service_class)
 
     # Mock inherited behavior from BaseJob
-    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    allow(AdminUser).to receive(:find_by).with(id: user.id).and_return(user)
     allow(job).to receive(:track_progress)
     allow(job).to receive(:broadcast_completion)
     allow(job).to receive(:broadcast_failure)
     allow(job).to receive(:handle_job_error)
     allow(job).to receive(:job_id).and_return('test-job-id')
-    allow(job).to receive(:sleep) # Stub sleep to keep tests fast
 
     # Default service mocking - allow any parameters
     allow(Services::BulkOperations::DeletionService).to receive(:new).and_return(batch_service)
@@ -69,18 +68,12 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
         expect(job).to have_received(:track_progress).with(83, "Deleted 100 of 120 expenses...").once
         expect(job).to have_received(:track_progress).with(100, "Deleted 120 of 120 expenses...").once
       end
-
-      it 'calls sleep to throttle large jobs' do
-        job.perform(expense_ids: expense_ids, user_id: user.id, options: options)
-
-        expect(job).to have_received(:sleep).with(0.1).exactly(3).times
-      end
     end
 
     context 'with fewer expenses than batch size' do
       let(:expense_ids) { (1..30).to_a }
 
-      it 'processes all expenses in a single batch without sleep' do
+      it 'processes all expenses in a single batch' do
         single_batch_service = double('SingleBatchService', call: { success: true })
 
         allow(Services::BulkOperations::DeletionService).to receive(:new)
@@ -88,7 +81,6 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
           .and_return(single_batch_service)
 
         expect(single_batch_service).to receive(:call).once
-        expect(job).not_to receive(:sleep)
 
         job.perform(expense_ids: expense_ids, user_id: user.id, options: options)
       end
@@ -99,7 +91,6 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
 
       it 'completes successfully without processing batches' do
         expect(Services::BulkOperations::DeletionService).not_to receive(:new)
-        expect(job).not_to receive(:sleep)
 
         job.perform(expense_ids: expense_ids, user_id: user.id, options: options)
       end
@@ -123,7 +114,7 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
 
     context 'when user is not found' do
       before do
-        allow(User).to receive(:find_by).with(id: user.id).and_return(nil)
+        allow(AdminUser).to receive(:find_by).with(id: user.id).and_return(nil)
       end
 
       it 'proceeds with nil user' do
@@ -171,15 +162,15 @@ RSpec.describe BulkDeletionJob, type: :job, unit: true do
       expect(expense_id_frequency.values.uniq).to eq([ 1 ])
     end
 
-    context 'with large batch requiring throttling' do
+    context 'with large batch' do
       let(:expense_ids) { (1..150).to_a }
 
-      it 'calls sleep after each batch for large jobs' do
+      it 'processes all batches without throttling' do
         allow(Services::BulkOperations::DeletionService).to receive(:new).and_return(batch_service)
 
         job.send(:execute_operation)
 
-        expect(job).to have_received(:sleep).with(0.1).exactly(3).times
+        expect(Services::BulkOperations::DeletionService).to have_received(:new).exactly(3).times
       end
     end
   end

--- a/spec/jobs/bulk_operations/base_job_spec.rb
+++ b/spec/jobs/bulk_operations/base_job_spec.rb
@@ -2,19 +2,6 @@
 
 require 'rails_helper'
 
-# Stub User class for testing since BaseJob references it
-class User
-  attr_accessor :id
-
-  def initialize(id)
-    @id = id
-  end
-
-  def self.find_by(id:)
-    new(id) if id
-  end
-end unless defined?(User)
-
 # Test-specific subclasses for testing the abstract base class
 class SuccessfulBulkJob < BulkOperations::BaseJob
   def execute_operation
@@ -61,7 +48,7 @@ end
 RSpec.describe BulkOperations::BaseJob, type: :job, unit: true do
   let(:expense_ids) { [ 1, 2, 3, 4, 5 ] }
   let(:user_id) { 42 }
-  let(:user) { User.new(user_id) }
+  let(:user) { instance_double(AdminUser, id: user_id) }
   let(:options) { { batch_size: 10, force: true } }
   let(:job_id) { 'test-job-123' }
 
@@ -76,6 +63,10 @@ RSpec.describe BulkOperations::BaseJob, type: :job, unit: true do
     allow(ActionCable).to receive(:server).and_return(action_cable)
     allow(Rails).to receive(:logger).and_return(rails_logger)
     allow(Time).to receive(:current).and_return(Time.zone.parse('2025-08-31 10:00:00'))
+
+    # Stub AdminUser lookup so job receives a user with an id
+    allow(AdminUser).to receive(:find_by).with(id: user_id).and_return(user)
+    allow(AdminUser).to receive(:find_by).with(id: nil).and_return(nil)
   end
 
   describe 'abstract method contract' do
@@ -500,7 +491,7 @@ RSpec.describe BulkOperations::BaseJob, type: :job, unit: true do
 
     context 'with invalid user_id' do
       it 'continues without user context' do
-        # User.find_by returns nil for nil id in our stub implementation
+        # AdminUser.find_by returns nil for nil id in our stub implementation
         result = successful_job.perform(expense_ids: expense_ids, user_id: nil)
 
         expect(result[:success]).to be true

--- a/spec/jobs/bulk_status_update_job_spec.rb
+++ b/spec/jobs/bulk_status_update_job_spec.rb
@@ -16,20 +16,19 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
 
   before do
     # Stub constants for unit test environment
-    user_class = double('UserClass')
-    stub_const('User', user_class)
+    admin_user_class = double('AdminUserClass')
+    stub_const('AdminUser', admin_user_class)
 
     status_update_service_class = double('StatusUpdateServiceClass')
     stub_const('Services::BulkOperations::StatusUpdateService', status_update_service_class)
 
     # Mock inherited behavior from BaseJob
-    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    allow(AdminUser).to receive(:find_by).with(id: user.id).and_return(user)
     allow(job).to receive(:track_progress)
     allow(job).to receive(:broadcast_completion)
     allow(job).to receive(:broadcast_failure)
     allow(job).to receive(:handle_job_error)
     allow(job).to receive(:job_id).and_return('test-job-id')
-    allow(job).to receive(:sleep) # Stub sleep to keep tests fast
 
     # Default service mocking - allow any parameters
     allow(Services::BulkOperations::StatusUpdateService).to receive(:new).and_return(batch_service)
@@ -78,13 +77,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
         expect(job).to have_received(:track_progress).with(83, "Updated status for 100 of 120 expenses...").once
         expect(job).to have_received(:track_progress).with(100, "Updated status for 120 of 120 expenses...").once
       end
-
-      it 'calls sleep to throttle large jobs' do
-        job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
-
-        # Should sleep after each batch since total > 100
-        expect(job).to have_received(:sleep).with(0.1).exactly(3).times
-      end
     end
 
     context 'processes each expense exactly once' do
@@ -130,7 +122,7 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
     context 'with fewer expenses than batch size' do
       let(:expense_ids) { (1..30).to_a }
 
-      it 'processes all expenses in a single batch without sleep' do
+      it 'processes all expenses in a single batch' do
         single_batch_service = double('SingleBatchService', call: { success: true })
 
         allow(Services::BulkOperations::StatusUpdateService).to receive(:new)
@@ -138,7 +130,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
           .and_return(single_batch_service)
 
         expect(single_batch_service).to receive(:call).once
-        expect(job).not_to receive(:sleep) # No sleep for jobs with <= 100 items
 
         job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
       end
@@ -155,7 +146,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
           .and_return(boundary_service)
 
         expect(boundary_service).to receive(:call).once
-        expect(job).not_to receive(:sleep)
 
         job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
       end
@@ -177,20 +167,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
 
         sizes = batch_services.map { |b| b[:size] }
         expect(sizes).to eq([ 50, 50 ])
-
-        # No sleep since total == 100 (not > 100)
-        expect(job).not_to have_received(:sleep)
-      end
-    end
-
-    context 'with exactly 101 expenses (triggers sleep)' do
-      let(:expense_ids) { (1..101).to_a }
-
-      it 'triggers sleep behavior at > 100 threshold' do
-        job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
-
-        # Should sleep after each batch since total > 100
-        expect(job).to have_received(:sleep).with(0.1).exactly(3).times # 2 full batches + 1 partial
       end
     end
 
@@ -199,7 +175,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
 
       it 'completes successfully without processing batches' do
         expect(Services::BulkOperations::StatusUpdateService).not_to receive(:new)
-        expect(job).not_to receive(:sleep)
 
         job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
       end
@@ -216,7 +191,6 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
           .and_return(single_service)
 
         expect(single_service).to receive(:call).once
-        expect(job).not_to receive(:sleep)
 
         job.perform(expense_ids: expense_ids, status: status, user_id: user.id, options: options)
       end
@@ -240,7 +214,7 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
 
     context 'when user is not found' do
       before do
-        allow(User).to receive(:find_by).with(id: user.id).and_return(nil)
+        allow(AdminUser).to receive(:find_by).with(id: user.id).and_return(nil)
       end
 
       it 'proceeds with nil user' do
@@ -302,16 +276,16 @@ RSpec.describe BulkStatusUpdateJob, type: :job, unit: true do
       expect(expense_id_frequency.values.uniq).to eq([ 1 ])
     end
 
-    context 'with large batch requiring throttling' do
+    context 'with large batch' do
       let(:expense_ids) { (1..150).to_a }
 
-      it 'calls sleep after each batch for large jobs' do
+      it 'processes all batches without throttling' do
         allow(Services::BulkOperations::StatusUpdateService).to receive(:new).and_return(batch_service)
 
         job.send(:execute_operation)
 
         # 3 batches: 50, 50, 50
-        expect(job).to have_received(:sleep).with(0.1).exactly(3).times
+        expect(Services::BulkOperations::StatusUpdateService).to have_received(:new).exactly(3).times
       end
     end
 

--- a/spec/jobs/unit/process_email_job_spec.rb
+++ b/spec/jobs/unit/process_email_job_spec.rb
@@ -522,7 +522,12 @@ RSpec.describe ProcessEmailJob, type: :job, unit: true do
     end
 
     it 'discards the job when DeserializationError is raised' do
-      allow(EmailAccount).to receive(:find_by).and_raise(ActiveJob::DeserializationError)
+      deserialization_error = begin
+        raise StandardError, "Record not found"
+      rescue StandardError
+        ActiveJob::DeserializationError.new
+      end
+      allow(EmailAccount).to receive(:find_by).and_raise(deserialization_error)
 
       expect {
         described_class.perform_now(email_account_id, email_data)


### PR DESCRIPTION
## Summary
- **PER-440**: Change `User.find_by` to `AdminUser.find_by` in BulkOperations::BaseJob (bulk ops for 100+ items were broken)
- **PER-439**: Remove blanket `retry_on StandardError` from ApplicationJob; add specific retries for Deadlocked/ConnectionNotEstablished
- **PER-452**: Remove `sleep 0.1` from bulk deletion/status update jobs
- Fix pre-existing DeserializationError spec

## Test plan
- [ ] Verify bulk deletion of 100+ expenses triggers background job successfully
- [ ] Verify bulk status update of 100+ expenses works
- [ ] Confirm job failures for programming bugs are not retried
- [ ] Confirm transient DB errors (deadlock, connection lost) are retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)