### PR TITLE
fix: add IMAP timeouts and email sync concurrency control (PER-438, PER-445)

### DIFF
--- a/app/jobs/process_emails_job.rb
+++ b/app/jobs/process_emails_job.rb
@@ -1,6 +1,8 @@
 class ProcessEmailsJob < ApplicationJob
   queue_as :email_processing
 
+  limits_concurrency to: 1, key: ->(email_account_id = nil, **) { "process_emails_#{email_account_id || 'all'}" }
+
   # Add retry logic
   retry_on Services::ImapConnectionService::ConnectionError, wait: 10.seconds, attempts: 3
   retry_on Net::ReadTimeout, wait: 5.seconds, attempts: 2

--- a/app/services/imap_connection_service.rb
+++ b/app/services/imap_connection_service.rb
@@ -154,7 +154,9 @@ module Services
     Net::IMAP.new(
       settings[:address],
       port: settings[:port],
-      ssl: settings[:enable_ssl]
+      ssl: settings[:enable_ssl],
+      open_timeout: 10,
+      idle_response_timeout: 30
     )
   end
 

--- a/spec/services/imap_connection_service_spec.rb
+++ b/spec/services/imap_connection_service_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Services::ImapConnectionService, integration: true do
 
     context 'with valid account' do
       it 'creates connection, authenticates, selects inbox, and cleans up' do
-        expect(Net::IMAP).to receive(:new).with('imap.test.com', port: 993, ssl: true)
+        expect(Net::IMAP).to receive(:new).with('imap.test.com', port: 993, ssl: true, open_timeout: 10, idle_response_timeout: 30)
         expect(mock_imap).to receive(:login).with('test@test.com', 'password123')
         expect(mock_imap).to receive(:select).with("INBOX")
         expect(mock_imap).to receive(:logout)


### PR DESCRIPTION
## Summary
- **PER-438**: Add `open_timeout: 10` and `idle_response_timeout: 30` to `Net::IMAP.new` to prevent stuck connections
- **PER-445**: Add `limits_concurrency` to `ProcessEmailsJob` to prevent duplicate syncs for the same email account

## Test plan
- [ ] Verify email sync completes normally with timeouts in place
- [ ] Confirm unreachable IMAP server times out after 10s instead of hanging
- [ ] Verify concurrent sync triggers for same account are serialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)