### PR TITLE
fix: security hardening — CSP, CSRF, DNS rebinding, admin audit (PER-458, PER-459, PER-460, PER-451, PER-464)

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -35,7 +35,7 @@ module Admin
     end
 
     def filtered_params
-      params.except(:password, :password_confirmation, :authenticity_token).to_unsafe_h
+      request.filtered_parameters
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,6 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern unless Rails.env.test?
 
-  # Handle CSRF for JSON requests
-  protect_from_forgery with: :null_session, if: -> { request.format.json? }
-
   private
 
   def set_locale

--- a/app/controllers/concerns/admin_authentication.rb
+++ b/app/controllers/concerns/admin_authentication.rb
@@ -171,21 +171,8 @@ module AdminAuthentication
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Content-Security-Policy"] = content_security_policy
-  end
-
-  def content_security_policy
-    [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-      "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-      "img-src 'self' data: https:",
-      "font-src 'self' data:",
-      "connect-src 'self'",
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-      "form-action 'self'"
-    ].join("; ")
+    # CSP is managed globally via config/initializers/content_security_policy.rb
+    # with nonce-based script-src. Do not override here with unsafe-inline.
   end
 
   # Authorization helpers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,13 +80,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [ ENV.fetch("RENDER_EXTERNAL_HOSTNAME", "localhost") ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Enable ExpenseFilterService caching
   config.expense_filter_cache_enabled = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,5 +27,5 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report CSP violations to an endpoint for monitoring before enforcement.
-  config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = false
 end

--- a/spec/controllers/admin/base_controller_unit_spec.rb
+++ b/spec/controllers/admin/base_controller_unit_spec.rb
@@ -73,14 +73,13 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
         allow(controller.request).to receive(:path).and_return("/admin/test")
       end
 
-      it "calls log_admin_action with correct parameters" do
+      it "calls log_admin_action with filtered parameters" do
         expect(controller).to receive(:log_admin_action).with(
           "test#show",
-          {
-            params: { "id" => "123" }, # password should be filtered out
+          hash_including(
             method: "GET",
             path: "/admin/test"
-          }
+          )
         )
 
         controller.send(:log_admin_activity)
@@ -88,41 +87,22 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
     end
 
     describe "#filtered_params" do
-      it "removes sensitive parameters" do
-        controller.params = ActionController::Parameters.new({
-          id: "123",
-          name: "test",
-          password: "secret",
-          password_confirmation: "secret",
-          authenticity_token: "token123",
-          regular_param: "value"
-        })
-
+      it "masks sensitive parameter values via Rails filter_parameters" do
+        # request.filtered_parameters uses Rails' filter_parameters config
+        # (passw, token, secret, etc.) — sensitive values become [FILTERED]
         result = controller.send(:filtered_params)
 
-        expect(result).to include("id" => "123", "name" => "test", "regular_param" => "value")
-        expect(result).not_to have_key("password")
-        expect(result).not_to have_key("password_confirmation")
-        expect(result).not_to have_key("authenticity_token")
+        # Should return a hash (request.filtered_parameters returns a Hash)
+        expect(result).to be_a(Hash)
       end
 
-      it "handles empty parameters" do
-        controller.params = ActionController::Parameters.new({})
+      it "delegates to request.filtered_parameters" do
+        filtered = { "id" => "123", "password" => "[FILTERED]" }
+        allow(controller.request).to receive(:filtered_parameters).and_return(filtered)
 
         result = controller.send(:filtered_params)
 
-        expect(result).to eq({})
-      end
-
-      it "filters only sensitive parameters when present" do
-        controller.params = ActionController::Parameters.new({
-          id: "123",
-          password: "secret"
-        })
-
-        result = controller.send(:filtered_params)
-
-        expect(result).to eq({ "id" => "123" })
+        expect(result).to eq(filtered)
       end
     end
   end
@@ -148,18 +128,16 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
       expect(controller.respond_to?(:filtered_params, true)).to be_truthy
     end
 
-    it "filters sensitive parameters consistently" do
-      controller.params = ActionController::Parameters.new({
-        password: "test123",
-        password_confirmation: "test123",
-        authenticity_token: "csrf_token",
-        safe_param: "safe_value"
-      })
+    it "uses request.filtered_parameters for safe audit logging" do
+      # filtered_params delegates to request.filtered_parameters which applies
+      # Rails filter_parameters config — sensitive values are masked, not removed.
+      expected = { "safe_param" => "safe_value", "password" => "[FILTERED]" }
+      allow(controller.request).to receive(:filtered_parameters).and_return(expected)
 
       filtered = controller.send(:filtered_params)
 
-      expect(filtered.keys).to contain_exactly("safe_param")
       expect(filtered["safe_param"]).to eq("safe_value")
+      expect(filtered["password"]).to eq("[FILTERED]")
     end
   end
 

--- a/spec/controllers/concerns/admin_authentication_spec.rb
+++ b/spec/controllers/concerns/admin_authentication_spec.rb
@@ -142,17 +142,21 @@ RSpec.describe AdminAuthentication, type: :controller, unit: true do
       expect(response.headers["X-Content-Type-Options"]).to eq("nosniff")
       expect(response.headers["X-XSS-Protection"]).to eq("1; mode=block")
       expect(response.headers["Referrer-Policy"]).to eq("strict-origin-when-cross-origin")
-      expect(response.headers["Content-Security-Policy"]).to include("default-src 'self'")
     end
 
-    it "includes comprehensive CSP directives" do
+    it "does not override global CSP with unsafe-inline in script-src" do
       get :index
 
+      # The global nonce-based CSP policy applies; the admin concern must not
+      # inject a manual Content-Security-Policy header with unsafe-inline.
+      # In controller specs the global CSP initializer may not run, so nil is
+      # also acceptable — it means no manual unsafe-inline override was set.
       csp = response.headers["Content-Security-Policy"]
-      expect(csp).to include("script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net")
-      expect(csp).to include("style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net")
-      expect(csp).to include("frame-ancestors 'none'")
-      expect(csp).to include("base-uri 'self'")
+      if csp
+        expect(csp).not_to include("script-src 'self' 'unsafe-inline'")
+      else
+        expect(csp).to be_nil
+      end
     end
   end
 

--- a/spec/requests/csp_headers_spec.rb
+++ b/spec/requests/csp_headers_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe "Content Security Policy", type: :request do
-  describe "CSP report-only header", :unit do
-    it "includes Content-Security-Policy-Report-Only header" do
+  describe "CSP enforcing header", :unit do
+    it "includes Content-Security-Policy header" do
       get rails_health_check_path
 
       expect(response).to have_http_status(:success)
-      expect(response.headers["Content-Security-Policy-Report-Only"]).to be_present
+      expect(response.headers["Content-Security-Policy"]).to be_present
     end
 
     it "includes CSP header on redirect responses" do
@@ -16,20 +16,20 @@ RSpec.describe "Content Security Policy", type: :request do
 
       # Unauthenticated users are redirected to login
       expect(response).to have_http_status(:redirect)
-      expect(response.headers["Content-Security-Policy-Report-Only"]).to be_present
+      expect(response.headers["Content-Security-Policy"]).to be_present
     end
 
-    it "does not include enforcing Content-Security-Policy header" do
+    it "does not include report-only Content-Security-Policy header" do
       get rails_health_check_path
 
-      expect(response.headers["Content-Security-Policy"]).to be_nil
+      expect(response.headers["Content-Security-Policy-Report-Only"]).to be_nil
     end
   end
 
   describe "CSP directive values", :unit do
     before { get rails_health_check_path }
 
-    let(:csp_header) { response.headers["Content-Security-Policy-Report-Only"] }
+    let(:csp_header) { response.headers["Content-Security-Policy"] }
 
     it "sets default-src to self" do
       expect(csp_header).to include("default-src 'self'")
@@ -65,19 +65,19 @@ RSpec.describe "Content Security Policy", type: :request do
     it "includes a nonce in the script-src directive" do
       get rails_health_check_path
 
-      csp_header = response.headers["Content-Security-Policy-Report-Only"]
+      csp_header = response.headers["Content-Security-Policy"]
       expect(csp_header).to match(/script-src[^;]*'nonce-[A-Za-z0-9+\/=]+'/)
     end
 
     it "generates different nonces for different requests" do
       get rails_health_check_path
-      first_csp = response.headers["Content-Security-Policy-Report-Only"]
+      first_csp = response.headers["Content-Security-Policy"]
       first_nonce = first_csp[/nonce-([A-Za-z0-9+\/=]+)/, 1]
 
       # Reset session for a fresh request with a new session
       reset!
       get rails_health_check_path
-      second_csp = response.headers["Content-Security-Policy-Report-Only"]
+      second_csp = response.headers["Content-Security-Policy"]
       second_nonce = second_csp[/nonce-([A-Za-z0-9+\/=]+)/, 1]
 
       # Different requests should produce different nonces

--- a/spec/support/shared_examples/controller_concerns.rb
+++ b/spec/support/shared_examples/controller_concerns.rb
@@ -274,23 +274,14 @@ RSpec.shared_examples "security headers concern" do
         expect(headers["X-Content-Type-Options"]).to eq("nosniff")
         expect(headers["X-XSS-Protection"]).to eq("1; mode=block")
         expect(headers["Referrer-Policy"]).to eq("strict-origin-when-cross-origin")
-        expect(headers["Content-Security-Policy"]).to be_present
-      end
-    end
-
-    describe "#content_security_policy" do
-      let(:csp) { controller.send(:content_security_policy) }
-
-      it "includes default-src directive" do
-        expect(csp).to include("default-src 'self'")
       end
 
-      it "includes script-src directive" do
-        expect(csp).to include("script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net")
-      end
+      it "does not inject a manual CSP header that overrides the global policy" do
+        controller.send(:set_security_headers)
 
-      it "includes frame-ancestors directive" do
-        expect(csp).to include("frame-ancestors 'none'")
+        # The admin concern must not set Content-Security-Policy manually —
+        # the global nonce-based policy applies.
+        expect(headers["Content-Security-Policy"]).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary
- **PER-458**: Switch CSP from report-only to enforcement
- **PER-459**: Remove `unsafe-inline` from admin CSP — use global nonce-based policy
- **PER-460**: Configure `config.hosts` for DNS rebinding protection
- **PER-451**: Remove broad CSRF null_session for JSON — API controllers already skip forgery
- **PER-464**: Replace `to_unsafe_h` with `request.filtered_parameters` in admin audit log

## Test plan
- [ ] Verify admin panel loads correctly without inline scripts
- [ ] Confirm API endpoints still work without CSRF tokens
- [ ] Verify Turbo/Stimulus JSON requests include CSRF token
- [ ] Check production config.hosts accepts RENDER_EXTERNAL_HOSTNAME
- [ ] Confirm Brakeman reports 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)