### PR TITLE
fix: model safety — dedupe soft_delete, merchant_name rename, constantize allowlists (PER-454, PER-455, PER-462)

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -140,7 +140,7 @@ class Api::WebhooksController < ApplicationController
       amount: expense.amount.to_f,
       formatted_amount: expense.formatted_amount,
       description: expense.display_description,
-      merchant_name: expense.merchant_name,
+      merchant_name: expense.display_merchant_name,
       transaction_date: expense.transaction_date.iso8601,
       category: expense.category_name,
       bank_name: expense.bank_name,

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -223,7 +223,7 @@ class ExpensesController < ApplicationController
     if @sorted_categories.present? && @sorted_categories.size > 5
       @pie_chart_categories = @sorted_categories.first(5)
       other_total = @sorted_categories.drop(5).sum { |_, v| v }
-      @pie_chart_categories << [I18n.t("expenses.dashboard.other_category"), other_total] if other_total > 0
+      @pie_chart_categories << [ I18n.t("expenses.dashboard.other_category"), other_total ] if other_total > 0
     else
       @pie_chart_categories = @sorted_categories
     end
@@ -654,7 +654,7 @@ class ExpensesController < ApplicationController
       id: expense.id,
       amount: expense.amount.to_f.to_s,
       description: expense.description,
-      merchant_name: expense.merchant_name,
+      merchant_name: expense.display_merchant_name,
       status: expense.status,
       transaction_date: expense.transaction_date,
       category: expense.category ? {
@@ -677,7 +677,7 @@ class ExpensesController < ApplicationController
     # Optimized JSON for virtual scrolling with minimal data
     {
       id: expense.id,
-      merchant_name: expense.merchant_name,
+      merchant_name: expense.display_merchant_name,
       amount: expense.amount.to_f,
       currency: expense.currency,
       transaction_date: expense.transaction_date.to_s,

--- a/app/models/concerns/expense_query_optimizer.rb
+++ b/app/models/concerns/expense_query_optimizer.rb
@@ -199,26 +199,4 @@ module ExpenseQueryOptimizer
   def cache_key_with_version
     "#{model_name.cache_key}/#{id}-#{updated_at.to_i}-#{lock_version}"
   end
-
-  def soft_delete!(user_id = nil)
-    transaction do
-      self.deleted_at = Time.current
-      self.deleted_by_id = user_id if respond_to?(:deleted_by_id=)
-      self.lock_version = (lock_version || 0) + 1
-      save!(validate: false)
-    end
-  end
-
-  def restore!
-    transaction do
-      self.deleted_at = nil
-      self.deleted_by_id = nil if respond_to?(:deleted_by_id=)
-      self.lock_version = (lock_version || 0) + 1
-      save!(validate: false)
-    end
-  end
-
-  def deleted?
-    deleted_at.present?
-  end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -52,7 +52,7 @@ class Expense < ApplicationRecord
   end
 
   def display_description
-    description.presence || merchant_name.presence || "Unknown Transaction"
+    description.presence || display_merchant_name.presence || "Unknown Transaction"
   end
 
   def display_merchant_name

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -55,9 +55,8 @@ class Expense < ApplicationRecord
     description.presence || merchant_name.presence || "Unknown Transaction"
   end
 
-  def merchant_name
-    # Simple attribute access without computed logic to avoid circular dependencies
-    # Returns merchant_name if present, otherwise merchant_normalized
+  def display_merchant_name
+    # Returns merchant_name if present, otherwise falls back to merchant_normalized
     self[:merchant_name] || self[:merchant_normalized]
   end
 

--- a/app/models/failed_broadcast_store.rb
+++ b/app/models/failed_broadcast_store.rb
@@ -16,6 +16,9 @@
 # - recovered_at: When the broadcast was successfully recovered
 # - recovery_notes: Manual notes about recovery process
 class FailedBroadcastStore < ApplicationRecord
+  # Allowed target types — must match BroadcastRequestValidator::ALLOWED_TARGET_TYPES
+  ALLOWED_TARGET_TYPES = %w[SyncSession User EmailAccount Expense].freeze
+
   # Error type constants
   ERROR_TYPES = %w[
     record_not_found
@@ -37,7 +40,7 @@ class FailedBroadcastStore < ApplicationRecord
 
   # Validations
   validates :channel_name, presence: true
-  validates :target_type, presence: true
+  validates :target_type, presence: true, inclusion: { in: ALLOWED_TARGET_TYPES }
   validates :target_id, presence: true, numericality: { greater_than: 0 }
   validates :priority, presence: true, inclusion: { in: PRIORITIES }
   validates :error_type, presence: true, inclusion: { in: ERROR_TYPES }
@@ -158,6 +161,7 @@ class FailedBroadcastStore < ApplicationRecord
   # @return [Boolean] Success status
   def retry_broadcast!(manual: false)
     return false unless can_retry?
+    return false unless ALLOWED_TARGET_TYPES.include?(target_type)
 
     begin
       # Find the target object
@@ -207,6 +211,8 @@ class FailedBroadcastStore < ApplicationRecord
   # Get target object if it exists
   # @return [ActiveRecord::Base, nil] Target object or nil
   def target_object
+    return nil unless ALLOWED_TARGET_TYPES.include?(target_type)
+
     target_type.constantize.find(target_id)
   rescue ActiveRecord::RecordNotFound, NameError
     nil

--- a/app/models/undo_history.rb
+++ b/app/models/undo_history.rb
@@ -6,6 +6,7 @@ class UndoHistory < ApplicationRecord
   # Constants
   UNDO_WINDOW = 5.minutes
   MAX_UNDO_RECORDS = 100
+  ALLOWED_UNDOABLE_TYPES = %w[Expense].freeze
 
   # Associations
   belongs_to :undoable, polymorphic: true, optional: true
@@ -15,7 +16,7 @@ class UndoHistory < ApplicationRecord
   # Validations
   validates :action_type, presence: true
   validates :record_data, presence: true
-  validates :undoable_type, presence: true
+  validates :undoable_type, presence: true, inclusion: { in: ALLOWED_UNDOABLE_TYPES }
 
   # Scopes
   scope :recent, -> { where(created_at: UNDO_WINDOW.ago..Time.current) }
@@ -146,6 +147,7 @@ class UndoHistory < ApplicationRecord
 
   def undo_single_deletion
     return false unless undoable_type.present? && record_data.present?
+    return false unless ALLOWED_UNDOABLE_TYPES.include?(undoable_type)
 
     klass = undoable_type.constantize
     record = klass.with_deleted.find_by(id: record_data["id"])
@@ -160,6 +162,7 @@ class UndoHistory < ApplicationRecord
 
   def undo_bulk_deletion
     return false unless record_data["ids"].present?
+    return false unless ALLOWED_UNDOABLE_TYPES.include?(undoable_type)
 
     klass = undoable_type.constantize
     records = klass.with_deleted.where(id: record_data["ids"])
@@ -178,6 +181,7 @@ class UndoHistory < ApplicationRecord
 
   def undo_bulk_update
     return false unless record_data["ids"].present? && record_data["original_values"].present?
+    return false unless ALLOWED_UNDOABLE_TYPES.include?(undoable_type)
 
     klass = undoable_type.constantize
     records = klass.where(id: record_data["ids"])

--- a/app/models/undo_history.rb
+++ b/app/models/undo_history.rb
@@ -47,7 +47,7 @@ class UndoHistory < ApplicationRecord
       action_type: :soft_delete,
       record_data: record.attributes,
       user_id: user&.try(:id),
-      description: "Deleted #{record.class.name.humanize.downcase}: #{record.try(:name) || record.try(:merchant_name) || record.id}"
+      description: "Deleted #{record.class.name.humanize.downcase}: #{record.try(:name) || record.try(:display_merchant_name) || record.id}"
     )
   end
 

--- a/app/services/email_processing/fetcher.rb
+++ b/app/services/email_processing/fetcher.rb
@@ -142,7 +142,7 @@ module Services::EmailProcessing
         format: "%u%n"
       )
 
-      merchant = expense.merchant_name.presence || "Comercio desconocido"
+      merchant = expense.display_merchant_name.presence || "Comercio desconocido"
       "#{amount} en #{merchant}"
     end
   end

--- a/app/services/expense_filter_service.rb
+++ b/app/services/expense_filter_service.rb
@@ -70,7 +70,7 @@ module Services
         amount: expense.amount,
         description: expense.description,
         transaction_date: expense.transaction_date,
-        merchant_name: expense.merchant_name,
+        merchant_name: expense.display_merchant_name,
         category: expense.category ? {
           id: expense.category.id,
           name: expense.category.name,

--- a/app/views/admin/patterns/show.html.erb
+++ b/app/views/admin/patterns/show.html.erb
@@ -115,7 +115,7 @@
               <div class="flex items-center justify-between p-3 bg-slate-50 rounded-lg">
                 <div class="flex-1">
                   <p class="text-sm text-slate-900 font-medium">
-                    <%= feedback.expense.description || feedback.expense.merchant_name %>
+                    <%= feedback.expense.description || feedback.expense.display_merchant_name %>
                   </p>
                   <p class="text-xs text-slate-500 mt-1">
                     <%= l(feedback.created_at, format: :long) %>

--- a/app/views/admin/patterns/test_pattern.turbo_stream.erb
+++ b/app/views/admin/patterns/test_pattern.turbo_stream.erb
@@ -52,7 +52,7 @@
       <div class="bg-slate-50 border border-slate-200 rounded-lg p-4">
         <h4 class="font-medium text-slate-900 mb-2">Datos de Prueba:</h4>
         <div class="text-sm text-slate-600 space-y-1">
-          <div><strong>Comercio:</strong> <%= @test_expense.merchant_name %></div>
+          <div><strong>Comercio:</strong> <%= @test_expense.display_merchant_name %></div>
           <div><strong>Descripción:</strong> <%= @test_expense.description %></div>
           <div><strong>Monto:</strong> <%= number_to_currency(@test_expense.amount) if @test_expense.amount %></div>
           <div><strong>Fecha:</strong> <%= @test_expense.transaction_date ? l(@test_expense.transaction_date, format: :long) : "" %></div>

--- a/app/views/dashboard/_recent_activity.html.erb
+++ b/app/views/dashboard/_recent_activity.html.erb
@@ -8,7 +8,7 @@
           </span>
           <div class="min-w-0">
             <p class="text-sm font-medium text-slate-900 truncate">
-              <%= truncate(expense.merchant_name, length: 25) %>
+              <%= truncate(expense.display_merchant_name, length: 25) %>
             </p>
             <div class="flex items-center gap-1.5 mt-0.5">
               <% if expense.category %>

--- a/app/views/expenses/_expense_card.html.erb
+++ b/app/views/expenses/_expense_card.html.erb
@@ -4,7 +4,7 @@
 <article class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden"
          id="expense_card_<%= expense.id %>"
          tabindex="0"
-         aria-label="<%= expense.merchant_name || t('expenses.card.no_merchant') %> <%= number_with_delimiter(expense.amount.to_i) %>"
+         aria-label="<%= expense.display_merchant_name || t('expenses.card.no_merchant') %> <%= number_with_delimiter(expense.amount.to_i) %>"
          data-controller="mobile-card"
          data-mobile-card-expense-id-value="<%= expense.id %>"
          data-mobile-card-expanded-value="false"
@@ -15,7 +15,7 @@
   <div class="hidden px-4 pt-3" data-mobile-card-target="checkbox">
     <input type="checkbox"
            class="h-4 w-4 text-teal-600 focus:ring-teal-500 border-slate-300 rounded"
-           aria-label="Seleccionar gasto <%= expense.merchant_name || t('expenses.card.no_merchant') %>"
+           aria-label="Seleccionar gasto <%= expense.display_merchant_name || t('expenses.card.no_merchant') %>"
            data-action="click->mobile-card#toggleCheckbox:stop">
   </div>
 
@@ -36,7 +36,7 @@
       <%# Merchant name (truncated) %>
       <span class="flex-1 text-sm font-semibold text-slate-900 truncate min-w-0">
         <% if expense.merchant_name? %>
-          <%= expense.merchant_name %>
+          <%= expense.display_merchant_name %>
         <% else %>
           <span class="text-rose-600 italic"><%= t('expenses.card.no_merchant') %></span>
         <% end %>

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -20,7 +20,7 @@
      data-action="click->batch-selection#handleRowClick click->mobile-card#toggleActions touchstart->mobile-card#touchStart touchend->mobile-card#touchEnd touchmove->mobile-card#touchMove keydown.enter->mobile-card#toggleActions keydown.space->mobile-card#toggleActions keydown.escape->mobile-card#collapseActions"
      tabindex="0"
      aria-selected="false"
-     aria-label="<%= expense.merchant_name || t('expenses.card.no_merchant') %> <%= number_with_delimiter(expense.amount.to_i) %>">
+     aria-label="<%= expense.display_merchant_name || t('expenses.card.no_merchant') %> <%= number_with_delimiter(expense.amount.to_i) %>">
 
   <%# ——————————————————————————————————————————————————————————
       BATCH SELECTION CHECKBOX (shared, hidden until selection mode)
@@ -28,7 +28,7 @@
   <div class="hidden px-4 pt-3 md:hidden" data-mobile-card-target="checkbox">
     <input type="checkbox"
            class="h-4 w-4 text-teal-600 focus:ring-teal-500 border-slate-300 rounded"
-           aria-label="Seleccionar gasto <%= expense.merchant_name || t('expenses.card.no_merchant') %>"
+           aria-label="Seleccionar gasto <%= expense.display_merchant_name || t('expenses.card.no_merchant') %>"
            data-action="click->mobile-card#toggleCheckbox:stop">
   </div>
 
@@ -50,7 +50,7 @@
 
       <span class="flex-1 text-sm font-semibold text-slate-900 truncate min-w-0">
         <% if expense.merchant_name? %>
-          <%= expense.merchant_name %>
+          <%= expense.display_merchant_name %>
         <% else %>
           <span class="text-rose-600 italic"><%= t('expenses.card.no_merchant') %></span>
         <% end %>
@@ -110,7 +110,7 @@
              data-action="change->batch-selection#toggleSelection click->batch-selection#toggleSelection:stop"
              data-expense-id="<%= expense.id %>"
              class="h-4 w-4 text-teal-600 focus:ring-teal-500 border-slate-300 rounded"
-             aria-label="Seleccionar gasto <%= expense.merchant_name || 'sin comercio' %> de <%= expense.amount %>">
+             aria-label="Seleccionar gasto <%= expense.display_merchant_name || 'sin comercio' %> de <%= expense.amount %>">
     </div>
 
     <%# Date %>
@@ -122,7 +122,7 @@
     <div class="px-3 py-2.5">
       <div class="text-[13px] font-medium text-slate-900 truncate">
         <% if expense.merchant_name? %>
-          <%= expense.merchant_name %>
+          <%= expense.display_merchant_name %>
         <% else %>
           <span class="text-rose-600 italic"><%= t("expenses.card.no_merchant", default: "Sin comercio") %></span>
         <% end %>

--- a/app/views/expenses/_expense_row.html.erb
+++ b/app/views/expenses/_expense_row.html.erb
@@ -28,7 +28,7 @@
            <% end %>
            data-expense-id="<%= expense.id %>"
            class="h-4 w-4 text-teal-600 focus:ring-teal-500 border-slate-300 rounded"
-           aria-label="Seleccionar gasto <%= expense.merchant_name || 'sin comercio' %> de <%= expense.amount %>">
+           aria-label="Seleccionar gasto <%= expense.display_merchant_name || 'sin comercio' %> de <%= expense.amount %>">
   </td>
   <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">
     <%= expense.transaction_date.strftime("%d/%m/%Y") %>
@@ -37,7 +37,7 @@
   <td class="px-6 py-4 text-sm text-slate-900">
     <div class="font-medium">
       <% if expense.merchant_name? %>
-      <%= expense.merchant_name %>
+      <%= expense.display_merchant_name %>
       <% else %>
       <span class="text-rose-600 italic">⚠️ Sin comercio (verificar)</span>
       <% end %>

--- a/app/views/expenses/_kebab_menu.html.erb
+++ b/app/views/expenses/_kebab_menu.html.erb
@@ -8,7 +8,7 @@
           class="p-1.5 rounded-md hover:bg-slate-100 text-slate-400 hover:text-slate-600 cursor-pointer transition-colors"
           aria-haspopup="true"
           aria-expanded="false"
-          aria-label="<%= t('expenses.actions.menu_label') %> — <%= expense.merchant_name %>">
+          aria-label="<%= t('expenses.actions.menu_label') %> — <%= expense.display_merchant_name %>">
     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
       <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
     </svg>
@@ -57,7 +57,7 @@
             role="menuitem"
             data-action="click->kebab-menu#requestDelete"
             data-expense-path="<%= expense_path(expense) %>"
-            data-merchant-name="<%= expense.merchant_name || t('expenses.card.no_merchant') %>"
+            data-merchant-name="<%= expense.display_merchant_name || t('expenses.card.no_merchant') %>"
             data-amount="<%= currency_symbol(expense) %><%= number_with_delimiter(expense.amount.to_i) %>">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>

--- a/app/views/expenses/edit.html.erb
+++ b/app/views/expenses/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("expenses.titles.edit", name: @expense.merchant_name) %>
+<% content_for :title, t("expenses.titles.edit", name: @expense.display_merchant_name) %>
 
 <div class="max-w-2xl mx-auto">
   <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @expense.merchant_name? ? t("expenses.titles.show", name: @expense.merchant_name) : t("expenses.titles.show_no_merchant") %>
+<% content_for :title, @expense.merchant_name? ? t("expenses.titles.show", name: @expense.display_merchant_name) : t("expenses.titles.show_no_merchant") %>
 
 <div class="max-w-3xl mx-auto space-y-6">
   <!-- Header -->
@@ -22,7 +22,7 @@
       <div class="text-4xl font-bold text-slate-900 mb-2"><%= currency_symbol(@expense) %><%= number_with_delimiter(@expense.amount.to_i) %></div>
       <div class="text-lg text-slate-600">
         <% if @expense.merchant_name? %>
-        <%= @expense.merchant_name %>
+        <%= @expense.display_merchant_name %>
         <% else %>
         <span class="text-rose-600 italic"><%= t("expenses.show.error_no_merchant") %></span>
         <% end %>
@@ -72,7 +72,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
             </svg>
             <% if @expense.merchant_name? %>
-              <%= @expense.merchant_name %>
+              <%= @expense.display_merchant_name %>
             <% else %>
               <span class="text-rose-600 italic"><%= t("expenses.show.error_no_merchant") %></span>
             <% end %>

--- a/app/views/sync_conflicts/_modal.html.erb
+++ b/app/views/sync_conflicts/_modal.html.erb
@@ -61,7 +61,7 @@
                 </div>
                 <div class="flex justify-between">
                   <dt class="text-sm text-slate-600">Comercio:</dt>
-                  <dd class="text-sm font-medium text-slate-900"><%= existing_expense.merchant_name || 'N/A' %></dd>
+                  <dd class="text-sm font-medium text-slate-900"><%= existing_expense.display_merchant_name || 'N/A' %></dd>
                 </div>
                 <div class="flex justify-between">
                   <dt class="text-sm text-slate-600">Categoría:</dt>
@@ -103,7 +103,7 @@
                 <div class="flex justify-between">
                   <dt class="text-sm text-slate-600">Comercio:</dt>
                   <dd class="text-sm font-medium text-slate-900 <%= 'text-rose-600' if differences['merchant_name'] && !differences['merchant_name'][:match] %>">
-                    <%= new_expense.merchant_name || 'N/A' %>
+                    <%= new_expense.display_merchant_name || 'N/A' %>
                   </dd>
                 </div>
                 <div class="flex justify-between">

--- a/app/views/sync_conflicts/show.html.erb
+++ b/app/views/sync_conflicts/show.html.erb
@@ -51,7 +51,7 @@
               </div>
               <div class="flex justify-between">
                 <dt class="text-sm text-slate-600">Comercio:</dt>
-                <dd class="text-sm font-medium text-slate-900"><%= @existing_expense.merchant_name || 'N/A' %></dd>
+                <dd class="text-sm font-medium text-slate-900"><%= @existing_expense.display_merchant_name || 'N/A' %></dd>
               </div>
               <div class="flex justify-between">
                 <dt class="text-sm text-slate-600">Categoría:</dt>
@@ -90,7 +90,7 @@
                 <div class="flex justify-between">
                   <dt class="text-sm text-slate-600">Comercio:</dt>
                   <dd class="text-sm font-medium text-slate-900 <%= 'text-rose-600' if @differences['merchant_name'] && !@differences['merchant_name'][:match] %>">
-                    <%= @new_expense.merchant_name || 'N/A' %>
+                    <%= @new_expense.display_merchant_name || 'N/A' %>
                   </dd>
                 </div>
                 <div class="flex justify-between">

--- a/spec/models/categorization_pattern_unit_spec.rb
+++ b/spec/models/categorization_pattern_unit_spec.rb
@@ -535,9 +535,9 @@ RSpec.describe CategorizationPattern, type: :model, unit: true do
         expect(time_pattern.matches?(expense)).to be true
       end
 
-      it "falls back to read_attribute when attributes fail" do
+      it "falls back to merchant_name when attributes fail" do
         allow(expense).to receive(:attributes).and_raise(StandardError)
-        allow(expense).to receive(:read_attribute).with(:merchant_name).and_return("Amazon.com")
+        allow(expense).to receive(:merchant_name).and_return("Amazon.com")
         expect(pattern.matches?(expense)).to be true
       end
 

--- a/spec/models/expense_unit_spec.rb
+++ b/spec/models/expense_unit_spec.rb
@@ -251,23 +251,23 @@ RSpec.describe Expense, type: :model, unit: true do
       end
     end
 
-    describe "#merchant_name" do
+    describe "#display_merchant_name" do
       it "returns merchant_name when present" do
         expense[:merchant_name] = "Store ABC"
         expense[:merchant_normalized] = "store abc"
-        expect(expense.merchant_name).to eq("Store ABC")
+        expect(expense.display_merchant_name).to eq("Store ABC")
       end
 
       it "returns merchant_normalized when merchant_name is nil" do
         expense[:merchant_name] = nil
         expense[:merchant_normalized] = "store abc"
-        expect(expense.merchant_name).to eq("store abc")
+        expect(expense.display_merchant_name).to eq("store abc")
       end
 
       it "returns nil when both are nil" do
         expense[:merchant_name] = nil
         expense[:merchant_normalized] = nil
-        expect(expense.merchant_name).to be_nil
+        expect(expense.display_merchant_name).to be_nil
       end
     end
 

--- a/spec/services/email_processing/fetcher_broadcasting_spec.rb
+++ b/spec/services/email_processing/fetcher_broadcasting_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
       let(:expense1) do
         instance_double(Expense,
                         amount: 15500.50,
-                        merchant_name: 'Automercado',
+                        display_merchant_name: 'Automercado',
                         description: 'Compra en supermercado')
       end
 
       let(:expense2) do
         instance_double(Expense,
                         amount: 3200.00,
-                        merchant_name: 'Starbucks',
+                        display_merchant_name: 'Starbucks',
                         description: 'Café')
       end
 
@@ -133,7 +133,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
 
     context 'when broadcasting fails' do
       let(:expense) do
-        instance_double(Expense, amount: 1000.00, merchant_name: 'Test Store')
+        instance_double(Expense, amount: 1000.00, display_merchant_name: 'Test Store')
       end
 
       before do
@@ -162,8 +162,8 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
     end
 
     context 'with multiple expenses in single callback' do
-      let(:expense1) { instance_double(Expense, amount: 1000, merchant_name: 'Store A') }
-      let(:expense2) { instance_double(Expense, amount: 2000, merchant_name: 'Store B') }
+      let(:expense1) { instance_double(Expense, amount: 1000, display_merchant_name: 'Store A') }
+      let(:expense2) { instance_double(Expense, amount: 2000, display_merchant_name: 'Store B') }
 
       before do
         allow(mock_email_processor).to receive(:process_emails) do |ids, service, &block|
@@ -215,37 +215,37 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
   describe '#format_expense_message', unit: true do
     context 'with valid expense' do
       it 'formats Costa Rican currency correctly' do
-        expense = instance_double(Expense, amount: 15500.50, merchant_name: 'Automercado')
+        expense = instance_double(Expense, amount: 15500.50, display_merchant_name: 'Automercado')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡15,500.50 en Automercado')
       end
 
       it 'formats thousands separator correctly' do
-        expense = instance_double(Expense, amount: 1234567.89, merchant_name: 'Test')
+        expense = instance_double(Expense, amount: 1234567.89, display_merchant_name: 'Test')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡1,234,567.89 en Test')
       end
 
       it 'formats whole numbers without unnecessary decimals' do
-        expense = instance_double(Expense, amount: 5000.00, merchant_name: 'Store')
+        expense = instance_double(Expense, amount: 5000.00, display_merchant_name: 'Store')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡5,000.00 en Store')
       end
 
       it 'handles nil merchant' do
-        expense = instance_double(Expense, amount: 2500, merchant_name: nil)
+        expense = instance_double(Expense, amount: 2500, display_merchant_name: nil)
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡2,500.00 en Comercio desconocido')
       end
 
       it 'handles empty string merchant' do
-        expense = instance_double(Expense, amount: 3000, merchant_name: '')
+        expense = instance_double(Expense, amount: 3000, display_merchant_name: '')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡3,000.00 en Comercio desconocido')
       end
 
       it 'preserves merchant with special characters' do
-        expense = instance_double(Expense, amount: 1500, merchant_name: 'Café & Bar')
+        expense = instance_double(Expense, amount: 1500, display_merchant_name: 'Café & Bar')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡1,500.00 en Café & Bar')
       end
@@ -260,19 +260,19 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
 
     context 'with edge cases' do
       it 'handles zero amount' do
-        expense = instance_double(Expense, amount: 0, merchant_name: 'Test')
+        expense = instance_double(Expense, amount: 0, display_merchant_name: 'Test')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡0.00 en Test')
       end
 
       it 'handles very large amounts' do
-        expense = instance_double(Expense, amount: 999999999.99, merchant_name: 'Bank')
+        expense = instance_double(Expense, amount: 999999999.99, display_merchant_name: 'Bank')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡999,999,999.99 en Bank')
       end
 
       it 'handles negative amounts' do
-        expense = instance_double(Expense, amount: -500.50, merchant_name: 'Refund')
+        expense = instance_double(Expense, amount: -500.50, display_merchant_name: 'Refund')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('-₡500.50 en Refund')
       end
@@ -334,7 +334,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'broadcasting integration', t
     end
 
     context 'when both update_progress and broadcast fail' do
-      let(:expense) { instance_double(Expense, amount: 100, merchant_name: 'Test') }
+      let(:expense) { instance_double(Expense, amount: 100, display_merchant_name: 'Test') }
 
       before do
         allow(mock_imap_service).to receive(:search_emails).and_return([ 1 ])

--- a/spec/services/email_processing/fetcher_progress_spec.rb
+++ b/spec/services/email_processing/fetcher_progress_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
       let(:message_ids) { (1..10).to_a }
       let(:expenses) do
         (1..5).map do |i|
-          instance_double(Expense, amount: i * 1000, merchant_name: "Store #{i}")
+          instance_double(Expense, amount: i * 1000, display_merchant_name: "Store #{i}")
         end
       end
 
@@ -94,8 +94,8 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
 
     context 'with batch expense detection' do
       let(:message_ids) { [ 1, 2, 3 ] }
-      let(:expense1) { instance_double(Expense, amount: 1000, merchant_name: 'Store A') }
-      let(:expense2) { instance_double(Expense, amount: 2000, merchant_name: 'Store B') }
+      let(:expense1) { instance_double(Expense, amount: 1000, display_merchant_name: 'Store A') }
+      let(:expense2) { instance_double(Expense, amount: 2000, display_merchant_name: 'Store B') }
 
       before do
         allow(mock_imap_service).to receive(:search_emails).and_return(message_ids)
@@ -161,7 +161,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
 
   describe 'last_detected tracking', unit: true do
     let(:message_ids) { [ 1, 2, 3 ] }
-    let(:expense) { instance_double(Expense, amount: 1500, merchant_name: 'Test') }
+    let(:expense) { instance_double(Expense, amount: 1500, display_merchant_name: 'Test') }
 
     before do
       allow(mock_imap_service).to receive(:search_emails).and_return(message_ids)
@@ -242,7 +242,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
 
     context 'when detected count decreases (data inconsistency)' do
       let(:message_ids) { [ 1, 2 ] }
-      let(:expense) { instance_double(Expense, amount: 1000, merchant_name: 'Store') }
+      let(:expense) { instance_double(Expense, amount: 1000, display_merchant_name: 'Store') }
 
       before do
         allow(mock_imap_service).to receive(:search_emails).and_return(message_ids)
@@ -295,7 +295,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
             # Every 4th email has an expense
             if (index + 1) % 4 == 0
               current_expenses += 1
-              expense = instance_double(Expense, amount: 100 * (index + 1), merchant_name: "Store #{index}")
+              expense = instance_double(Expense, amount: 100 * (index + 1), display_merchant_name: "Store #{index}")
               block&.call(index + 1, current_expenses, expense)
             else
               block&.call(index + 1, current_expenses, nil)
@@ -360,7 +360,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'progress tracking', type: :s
 
   describe 'progress calculation precision', unit: true do
     let(:message_ids) { [ 1 ] }
-    let(:expense) { instance_double(Expense, amount: 1234.56, merchant_name: 'Test') }
+    let(:expense) { instance_double(Expense, amount: 1234.56, display_merchant_name: 'Test') }
 
     before do
       allow(mock_imap_service).to receive(:search_emails).and_return(message_ids)

--- a/spec/services/email_processing/fetcher_spec.rb
+++ b/spec/services/email_processing/fetcher_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, type: :service, integration: 
   describe 'private methods', integration: true do
     describe '#format_expense_message', integration: true do
       it 'formats expense with Costa Rican currency' do
-        expense = instance_double(Expense, amount: 25750.99, merchant_name: 'Walmart')
+        expense = instance_double(Expense, amount: 25750.99, display_merchant_name: 'Walmart')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡25,750.99 en Walmart')
       end
@@ -152,13 +152,13 @@ RSpec.describe Services::EmailProcessing::Fetcher, type: :service, integration: 
       end
 
       it 'handles expense with nil merchant' do
-        expense = instance_double(Expense, amount: 1000, merchant_name: nil)
+        expense = instance_double(Expense, amount: 1000, display_merchant_name: nil)
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡1,000.00 en Comercio desconocido')
       end
 
       it 'handles expense with blank merchant' do
-        expense = instance_double(Expense, amount: 500.50, merchant_name: '   ')
+        expense = instance_double(Expense, amount: 500.50, display_merchant_name: '   ')
         message = fetcher.send(:format_expense_message, expense)
         expect(message).to eq('₡500.50 en Comercio desconocido')
       end
@@ -237,7 +237,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, type: :service, integration: 
           )
         end
 
-        let(:expense) { instance_double(Expense, amount: 1500, merchant_name: 'Test Store') }
+        let(:expense) { instance_double(Expense, amount: 1500, display_merchant_name: 'Test Store') }
 
         before do
           stub_const('SyncStatusChannel', double('SyncStatusChannel'))


### PR DESCRIPTION
## Summary
- **PER-454**: Remove duplicate `soft_delete!`/`restore!`/`deleted?` from ExpenseQueryOptimizer — SoftDelete is single source of truth
- **PER-455**: Rename `merchant_name` override to `display_merchant_name` to restore AR dirty tracking; updated 20+ view/helper/service callers
- **PER-462**: Add `constantize` allowlist validations to UndoHistory and FailedBroadcastStore

## Test plan
- [ ] Verify expense soft delete and restore still work correctly
- [ ] Confirm merchant name displays correctly in all views (expense list, show, edit, dashboard, admin)
- [ ] Verify undo history works for expense deletions
- [ ] Confirm failed broadcast retry works
- [ ] Check that invalid undoable_type/target_type values are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)