### PR TITLE
fix: controller and config — summary stats, SolidQueue query, health auth, Rack::Attack (PER-444, PER-443, PER-461, PER-463, PER-456)

### DIFF
--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -5,6 +5,7 @@ module Api
   class HealthController < ApplicationController
     skip_before_action :authenticate_user!
     skip_before_action :verify_authenticity_token
+    before_action :authenticate_metrics_token!, only: :metrics
 
     # Comprehensive health check endpoint
     # GET /api/health
@@ -71,6 +72,14 @@ module Api
     end
 
     private
+
+    def authenticate_metrics_token!
+      token = request.headers["Authorization"]&.remove("Bearer ")
+      api_token = token.present? && ApiToken.authenticate(token)
+      return if api_token
+
+      render json: { error: "Unauthorized", status: 401 }, status: :unauthorized
+    end
 
     def format_response(result)
       {

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -32,8 +32,8 @@ class ExpensesController < ApplicationController
       # Build Pagy::Offset instance from the already-paginated result for navigation controls
       @pagy = Pagy::Offset.new(count: @total_count, page: @current_page, limit: @per_page) if @total_count
 
-      # Calculate summary statistics from the result
-      calculate_summary_from_result(@result)
+      # Calculate summary statistics from the full (pre-pagination) filtered scope
+      calculate_summary_statistics
     else
       # Fallback to empty result on error
       @expenses = []
@@ -223,7 +223,7 @@ class ExpensesController < ApplicationController
     if @sorted_categories.present? && @sorted_categories.size > 5
       @pie_chart_categories = @sorted_categories.first(5)
       other_total = @sorted_categories.drop(5).sum { |_, v| v }
-      @pie_chart_categories << [I18n.t("expenses.dashboard.other_category"), other_total] if other_total > 0
+      @pie_chart_categories << [ I18n.t("expenses.dashboard.other_category"), other_total ] if other_total > 0
     else
       @pie_chart_categories = @sorted_categories
     end

--- a/app/services/dashboard_service.rb
+++ b/app/services/dashboard_service.rb
@@ -139,14 +139,11 @@ module Services
         }
       end
 
-    # Check for running jobs
-    running_jobs = SolidQueue::Job.where(
-      class_name: "ProcessEmailsJob",
-      finished_at: nil
-    ).where("created_at > ?", 5.minutes.ago)
+    # Check for running syncs via SyncSession
+    running_syncs = SyncSession.where(status: %w[pending running]).where("created_at > ?", 5.minutes.ago)
 
-    sync_data[:has_running_jobs] = running_jobs.exists?
-    sync_data[:running_job_count] = running_jobs.count
+    sync_data[:has_running_jobs] = running_syncs.exists?
+    sync_data[:running_job_count] = running_syncs.count
 
     sync_data
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -71,7 +71,7 @@ production:
     username: <%= ENV.fetch("POSTGRES_USER") { "expense_tracker" } %>
     password: <%= ENV["POSTGRES_PASSWORD"] %>
     # Production performance settings
-    pool: <%= ENV.fetch("DB_POOL", 25) %>
+    pool: <%= ENV.fetch("DB_POOL", 35) %>
     statement_timeout: 30000  # 30 seconds
     lock_timeout: 10000       # 10 seconds
     variables:

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,9 +30,7 @@ class Rack::Attack
       /crawler/i,
       /spider/i,
       /scraper/i,
-      /curl/i,
       /wget/i,
-      /python/i,
       /nikto/i,
       /sqlmap/i,
       /nmap/i

--- a/spec/controllers/api/health_controller_spec.rb
+++ b/spec/controllers/api/health_controller_spec.rb
@@ -151,6 +151,8 @@ RSpec.describe Api::HealthController, type: :controller, unit: true do
     let!(:pattern2) { create(:categorization_pattern, active: false) }
 
     before do
+      # Bypass token auth for unit tests
+      allow(controller).to receive(:authenticate_metrics_token!)
       # Mock the entire metrics collection to avoid complex database mocking
       allow(controller).to receive(:collect_metrics).and_return({
         timestamp: Time.current.iso8601,
@@ -264,6 +266,42 @@ RSpec.describe Api::HealthController, type: :controller, unit: true do
       json_response = JSON.parse(response.body)
       expect(json_response["error"]).to eq("Failed to collect metrics")
       expect(json_response["message"]).to eq("Metrics error")
+    end
+
+    context "authentication" do
+      before do
+        # Use the real authenticate_metrics_token! for these tests
+        allow(controller).to receive(:authenticate_metrics_token!).and_call_original
+      end
+
+      it "returns 401 when no token is provided" do
+        get :metrics
+
+        expect(response).to have_http_status(:unauthorized)
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq("Unauthorized")
+      end
+
+      it "returns 401 when an invalid token is provided" do
+        request.headers["Authorization"] = "Bearer invalid_token"
+
+        allow(ApiToken).to receive(:authenticate).with("invalid_token").and_return(nil)
+
+        get :metrics
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "allows access with a valid token" do
+        api_token = double("ApiToken")
+        request.headers["Authorization"] = "Bearer valid_token"
+        allow(ApiToken).to receive(:authenticate).with("valid_token").and_return(api_token)
+        allow(controller).to receive(:collect_metrics).and_return({ timestamp: Time.current.iso8601 })
+
+        get :metrics
+
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 

--- a/spec/controllers/expenses_bank_filter_spec.rb
+++ b/spec/controllers/expenses_bank_filter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ExpensesController, type: :controller, unit: true do
     allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
     allow(filter_service).to receive(:call).and_return(service_result)
     allow(controller).to receive(:setup_navigation_context)
-    allow(controller).to receive(:calculate_summary_from_result)
+    allow(controller).to receive(:calculate_summary_statistics)
     allow(controller).to receive(:build_filter_description).and_return("")
   end
 

--- a/spec/controllers/expenses_controller_unit_spec.rb
+++ b/spec/controllers/expenses_controller_unit_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ExpensesController, type: :controller, unit: true do
       allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
       allow(filter_service).to receive(:call).and_return(service_result)
       allow(controller).to receive(:setup_navigation_context)
-      allow(controller).to receive(:calculate_summary_from_result)
+      allow(controller).to receive(:calculate_summary_statistics)
       allow(controller).to receive(:build_filter_description).and_return("All expenses")
     end
 
@@ -68,8 +68,8 @@ RSpec.describe ExpensesController, type: :controller, unit: true do
         expect(assigns(:per_page)).to eq(25)
       end
 
-      it "calculates summary from result" do
-        expect(controller).to receive(:calculate_summary_from_result).with(service_result)
+      it "calculates summary statistics" do
+        expect(controller).to receive(:calculate_summary_statistics)
 
         get :index
       end

--- a/spec/controllers/expenses_pagination_spec.rb
+++ b/spec/controllers/expenses_pagination_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
         allow(filter_service).to receive(:call).and_return(service_result)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "assigns a Pagy::Offset instance to @pagy" do
@@ -116,7 +116,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
         allow(filter_service).to receive(:call).and_return(service_result)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "sets the correct page number in pagy" do
@@ -163,7 +163,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
         allow(filter_service).to receive(:call).and_return(service_result)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "does not provide next page navigation on the last page" do
@@ -209,7 +209,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
         allow(filter_service).to receive(:call).and_return(service_result)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "assigns a single-page pagy instance" do
@@ -280,7 +280,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
         allow(filter_service).to receive(:call).and_return(service_result)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "assigns a pagy instance with zero count" do
@@ -297,7 +297,7 @@ RSpec.describe ExpensesController, "pagination", type: :controller, unit: true d
 
       before do
         allow(Services::ExpenseFilterService).to receive(:new).and_return(filter_service)
-        allow(controller).to receive(:calculate_summary_from_result)
+        allow(controller).to receive(:calculate_summary_statistics)
       end
 
       it "passes the page parameter to the filter service" do

--- a/spec/services/dashboard_service_spec.rb
+++ b/spec/services/dashboard_service_spec.rb
@@ -92,12 +92,7 @@ RSpec.describe Services::DashboardService, integration: true do
     end
 
     it 'generates sync info with job status' do
-      # Mock SolidQueue::Job to avoid database dependency
-      jobs_relation = double("jobs_relation", exists?: false, count: 0)
-      allow(SolidQueue::Job).to receive(:where)
-        .with(class_name: "ProcessEmailsJob", finished_at: nil)
-        .and_return(double("intermediate", where: jobs_relation))
-
+      # No active SyncSessions in test DB, so has_running_jobs should be false
       result = service.analytics
       sync_info = result[:sync_info]
 


### PR DESCRIPTION
## Summary
- **PER-444**: Replace page-only `calculate_summary_from_result` with full-scope SQL `calculate_summary_statistics`
- **PER-443**: Replace direct `SolidQueue::Job` query with `SyncSession` state check in DashboardService
- **PER-461**: Add API token auth to `/api/health/metrics` endpoint
- **PER-463**: Remove `curl`/`python` from Rack::Attack user-agent blocklist
- **PER-456**: Increase production DB pool default from 25 to 35

## Test plan
- [ ] Verify expense index summary shows correct totals across all pages
- [ ] Confirm dashboard sync status displays correctly
- [ ] Verify /api/health/metrics requires auth token
- [ ] Verify /api/health and /api/health/ready remain unauthenticated
- [ ] Test API with curl user-agent is no longer blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)