### PR TITLE
feat: configure Kamal deployment for Hetzner VPS

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,17 +1,18 @@
-# Secrets defined here are available for reference under registry/password, env/secret, builder/secrets,
-# and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
-# password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
+# Secrets for Kamal deploy — NEVER commit real values to git.
+# These are read by config/deploy.yml env.secret references.
 
-# Example of extracting secrets from 1password (or another compatible pw manager)
-# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
-
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
+# GitHub Container Registry PAT (write:packages scope)
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
-# Improve security by using a password manager. Never check config/master.key into git!
+# Rails master key for decrypting credentials
 RAILS_MASTER_KEY=$(cat config/master.key)
+
+# Rails secret key base
+SECRET_KEY_BASE=$SECRET_KEY_BASE
+
+# PostgreSQL password for the expense_tracker user
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+
+# Admin panel credentials
+ADMIN_EMAIL=$ADMIN_EMAIL
+ADMIN_PASSWORD=$ADMIN_PASSWORD

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,116 +1,62 @@
 # Name of your application. Used to uniquely configure containers.
-service: expense_tracker
+service: expense-tracker
 
 # Name of the container image.
-image: your-user/expense_tracker
+image: esoto/expense-tracker
 
 # Deploy to these servers.
 servers:
   web:
-    - 192.168.0.1
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+    - 178.104.88.183
 
-# Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
-# Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
-#
-# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
+# SSL via Let's Encrypt + kamal-proxy
 proxy:
   ssl: true
-  host: app.example.com
+  host: expense-tracker.estebansoto.dev
 
-# Credentials for your image host.
+# GitHub Container Registry
 registry:
-  # Specify the registry server, if you're not using Docker Hub
-  # server: registry.digitalocean.com / ghcr.io / ...
-  username: your-user
-
-  # Always use an access token rather than real password when possible.
+  server: ghcr.io
+  username: esoto
   password:
     - KAMAL_REGISTRY_PASSWORD
 
-# Inject ENV variables into containers (secrets come from .kamal/secrets).
+# Environment variables injected into containers
 env:
   secret:
     - RAILS_MASTER_KEY
+    - SECRET_KEY_BASE
+    - POSTGRES_PASSWORD
+    - ADMIN_EMAIL
+    - ADMIN_PASSWORD
   clear:
-    # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
-    # When you start using multiple servers, you should split out job processing to a dedicated machine.
+    RAILS_ENV: production
+    POSTGRES_USER: expense_tracker
+    POSTGRES_HOST: personal-blog-db
+    POSTGRES_PORT: "5432"
+    # Run Solid Queue inside Puma (single server setup)
     SOLID_QUEUE_IN_PUMA: true
+    # Host for DNS rebinding protection
+    RAILS_HOST: expense-tracker.estebansoto.dev
 
-    # Set number of processes dedicated to Solid Queue (default: 1)
-    # JOB_CONCURRENCY: 3
-
-    # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
-
-    # Match this to any external database server to configure Active Record correctly
-    # Use expense_tracker-db for a db accessory server on same machine via local kamal docker network.
-    # DB_HOST: 192.168.0.2
-
-    # Log everything from Rails
-    # RAILS_LOG_LEVEL: debug
-
-# Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
-# "bin/kamal logs -r job" will tail logs from the first server in the job section.
+# Useful aliases
 aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
-  dbc: app exec --interactive --reuse "bin/rails dbconsole"
+  dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
 
-
-# Use a persistent storage volume for sqlite database files and local Active Storage files.
-# Recommended to change this to a mounted volume path that is backed up off server.
+# Persistent storage for Active Storage and Solid Queue/Cache/Cable
 volumes:
-  - "expense_tracker_storage:/rails/storage"
+  - "expense-tracker-storage:/rails/storage"
 
-
-# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
-# hitting 404 on in-flight requests. Combines all files from new and old
-# version inside the asset_path.
+# Bridge assets between versions
 asset_path: /rails/public/assets
 
-# Configure the image builder.
+# Build for amd64 (Hetzner server architecture)
 builder:
   arch: amd64
 
-  # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
-  # remote: ssh://docker@docker-builder-server
-  #
-  # # Pass arguments and secrets to the Docker build process
-  # args:
-  #   RUBY_VERSION: 3.4.1
-  # secrets:
-  #   - GITHUB_TOKEN
-  #   - RAILS_MASTER_KEY
-
-# Use a different ssh user than root
-# ssh:
-#   user: app
-
-# Use accessory services (secrets come from .kamal/secrets).
-# accessories:
-#   db:
-#     image: mysql:8.0
-#     host: 192.168.0.2
-#     # Change to 3306 to expose port to the world instead of just local network.
-#     port: "127.0.0.1:3306:3306"
-#     env:
-#       clear:
-#         MYSQL_ROOT_HOST: '%'
-#       secret:
-#         - MYSQL_ROOT_PASSWORD
-#     files:
-#       - config/mysql/production.cnf:/etc/mysql/my.cnf
-#       - db/production.sql:/docker-entrypoint-initdb.d/setup.sql
-#     directories:
-#       - data:/var/lib/mysql
-#   redis:
-#     image: redis:7.0
-#     host: 192.168.0.2
-#     port: 6379
-#     directories:
-#       - data:/data
+# Use deploy user instead of root
+ssh:
+  user: deploy

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts = [ ENV.fetch("RENDER_EXTERNAL_HOSTNAME", "localhost") ]
+  config.hosts = [ ENV.fetch("RAILS_HOST", "expense-tracker.estebansoto.dev") ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
## Summary
- Configure `config/deploy.yml` for Hetzner VPS deployment via Kamal 2
- Set up ghcr.io/esoto/expense-tracker as container registry
- Domain: expense-tracker.estebansoto.dev
- Shared PostgreSQL 17 via Docker network (personal-blog-db)
- Update `.kamal/secrets` template with all required env vars
- Replace RENDER_EXTERNAL_HOSTNAME with RAILS_HOST in production.rb

## Pre-deploy steps
1. SSH to VPS and create `expense_tracker` PostgreSQL user + 4 databases + extensions (pg_trgm, unaccent)
2. Set env vars: KAMAL_REGISTRY_PASSWORD, SECRET_KEY_BASE, POSTGRES_PASSWORD, ADMIN_EMAIL, ADMIN_PASSWORD
3. Run `kamal setup`

## Test plan
- [ ] Verify `kamal setup` completes successfully
- [ ] Confirm health check at https://expense-tracker.estebansoto.dev/up
- [ ] Verify admin panel accessible at /admin
- [ ] Confirm API health at /api/health
- [ ] Test SSL auto-provisioning via Let's Encrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)