### PR TITLE
feat: i18n category names and fix BAC email parsing

### DIFF
--- a/app/controllers/admin/patterns_controller.rb
+++ b/app/controllers/admin/patterns_controller.rb
@@ -411,7 +411,7 @@ module Admin
         pattern.pattern_type,
         pattern.pattern_value,
         pattern.category_id,
-        pattern.category.name,
+        pattern.category.display_name,
         pattern.confidence_weight,
         pattern.active,
         pattern.usage_count,
@@ -572,7 +572,7 @@ module Admin
         id: pattern.id,
         type: pattern.pattern_type,
         value: pattern.pattern_value,
-        category: pattern.category.name,
+        category: pattern.category.display_name,
         usage: pattern.usage_count,
         success_rate: (pattern.success_rate * 100).round(2)
       }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,7 +8,7 @@ class CategoriesController < ApplicationController
         render json: @categories.map { |category|
           {
             id: category.id,
-            name: category.name,
+            name: category.display_name,
             color: category.color,
             parent_id: category.parent_id
           }

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -659,7 +659,7 @@ class ExpensesController < ApplicationController
       transaction_date: expense.transaction_date,
       category: expense.category ? {
         id: expense.category.id,
-        name: expense.category.name,
+        name: expense.category.display_name,
         color: expense.category.color
       } : nil,
       ml_confidence: expense.ml_confidence,
@@ -667,7 +667,7 @@ class ExpensesController < ApplicationController
       confidence_percentage: expense.confidence_percentage,
       ml_suggested_category: expense.ml_suggested_category ? {
         id: expense.ml_suggested_category.id,
-        name: expense.ml_suggested_category.name,
+        name: expense.ml_suggested_category.display_name,
         color: expense.ml_suggested_category.color
       } : nil
     }
@@ -687,7 +687,7 @@ class ExpensesController < ApplicationController
       created_at: expense.created_at.to_s,
       category: expense.category ? {
         id: expense.category.id,
-        name: expense.category.name,
+        name: expense.category.display_name,
         color: expense.category.color
       } : nil,
       ml_confidence: expense.ml_confidence
@@ -821,7 +821,7 @@ class ExpensesController < ApplicationController
 
       # Group by category for summary
       @categories_summary = result.expenses
-        .group_by { |e| e.category&.name || "Uncategorized" }
+        .group_by { |e| e.category&.display_name || "Uncategorized" }
         .transform_values { |expenses| expenses.sum(&:amount) }
         .sort_by { |_, amount| -amount }
     else

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -821,7 +821,7 @@ class ExpensesController < ApplicationController
 
       # Group by category for summary
       @categories_summary = result.expenses
-        .group_by { |e| e.category&.display_name || "Uncategorized" }
+        .group_by { |e| e.category&.display_name || I18n.t("categories.names.uncategorized") }
         .transform_values { |expenses| expenses.sum(&:amount) }
         .sort_by { |_, amount| -amount }
     else

--- a/app/helpers/expenses_helper.rb
+++ b/app/helpers/expenses_helper.rb
@@ -102,7 +102,7 @@ module ExpensesHelper
   def expense_category_badge(expense)
     if expense.category
       content_tag :span,
-                  expense.category.name,
+                  expense.category.display_name,
                   class: "inline-flex px-2 py-1 text-xs font-medium rounded-full",
                   style: "background-color: #{expense.category.color}20; color: #{expense.category.color};"
     else

--- a/app/jobs/bulk_categorization_job.rb
+++ b/app/jobs/bulk_categorization_job.rb
@@ -41,7 +41,7 @@ class BulkCategorizationJob < BulkOperations::BaseJob
     end
 
     category = Category.find_by(id: category_id)
-    category_name = category&.name || "category"
+    category_name = category&.display_name || "category"
 
     {
       success: failures.empty?,

--- a/app/models/bulk_operation.rb
+++ b/app/models/bulk_operation.rb
@@ -128,7 +128,7 @@ class BulkOperation < ApplicationRecord
       status: status.humanize,
       expenses_affected: expense_count,
       total_amount: total_amount,
-      target_category: target_category&.name,
+      target_category: target_category&.display_name,
       success_rate: success_rate,
       duration: duration_seconds,
       average_confidence: average_confidence,

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -28,9 +28,15 @@ class Category < ApplicationRecord
     !root?
   end
 
+  def display_name
+    return name unless i18n_key.present?
+
+    I18n.t("categories.names.#{i18n_key}", default: name)
+  end
+
   def full_name
-    return name if root?
-    "#{parent.name} > #{name}"
+    return display_name if root?
+    "#{parent.display_name} > #{display_name}"
   end
 
   private

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -48,7 +48,7 @@ class Expense < ApplicationRecord
   end
 
   def category_name
-    category&.name || "Uncategorized"
+    category&.display_name || "Uncategorized"
   end
 
   def display_description

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -48,7 +48,7 @@ class Expense < ApplicationRecord
   end
 
   def category_name
-    category&.display_name || "Uncategorized"
+    category&.display_name || I18n.t("categories.names.uncategorized")
   end
 
   def display_description

--- a/app/serializers/api/v1/categorization_serializer.rb
+++ b/app/serializers/api/v1/categorization_serializer.rb
@@ -32,7 +32,7 @@ module Api
           category_id: feedback_record.category_id,
           category: {
             id: feedback_record.category_id,
-            name: feedback_record.category&.name
+            name: feedback_record.category&.display_name
           },
           pattern_id: feedback_record.categorization_pattern_id,
           feedback_type: feedback_record.feedback_type,
@@ -50,7 +50,7 @@ module Api
 
         {
           id: category.id,
-          name: category.name,
+          name: category.display_name,
           color: category.color,
           parent_id: category.parent_id
         }

--- a/app/serializers/api/v1/pattern_serializer.rb
+++ b/app/serializers/api/v1/pattern_serializer.rb
@@ -46,7 +46,7 @@ module Api
 
         {
           id: pattern.category.id,
-          name: pattern.category.name,
+          name: pattern.category.display_name,
           color: pattern.category.color
         }
       end

--- a/app/services/analytics/pattern_performance_analyzer.rb
+++ b/app/services/analytics/pattern_performance_analyzer.rb
@@ -67,11 +67,12 @@ module Services::Analytics
         end
 
         categories_data = query
-          .group("categories.id", "categories.name", "categories.color")
+          .group("categories.id", "categories.name", "categories.color", "categories.i18n_key")
           .select(
             "categories.id",
             "categories.name",
             "categories.color",
+            "categories.i18n_key",
             "COUNT(DISTINCT categorization_patterns.id) as pattern_count",
             "COUNT(DISTINCT CASE WHEN categorization_patterns.active = true THEN categorization_patterns.id END) as active_patterns_count",
             "COALESCE(SUM(categorization_patterns.usage_count), 0) as total_usage",
@@ -84,7 +85,7 @@ module Services::Analytics
         categories_data.map do |category|
           {
             id: category.id,
-            name: category.name,
+            name: category.display_name,
             color: category.color,
             pattern_count: category.pattern_count,
             active_patterns: category.active_patterns_count,
@@ -109,7 +110,7 @@ module Services::Analytics
             id: pattern.id,
             pattern_type: pattern.pattern_type,
             pattern_value: pattern.pattern_value,
-            category_name: pattern.category.name,
+            category_name: pattern.category.display_name,
             category_color: pattern.category.color,
             usage_count: pattern.usage_count,
             success_count: pattern.success_count,
@@ -134,7 +135,7 @@ module Services::Analytics
             id: pattern.id,
             pattern_type: pattern.pattern_type,
             pattern_value: pattern.pattern_value,
-            category_name: pattern.category.name,
+            category_name: pattern.category.display_name,
             category_color: pattern.category.color,
             usage_count: pattern.usage_count,
             success_count: pattern.success_count,
@@ -285,7 +286,7 @@ module Services::Analytics
             feedback_type: feedback.feedback_type,
             expense_description: feedback.expense&.description,
             expense_amount: feedback.expense&.amount,
-            category_name: feedback.category.name,
+            category_name: feedback.category.display_name,
             category_color: feedback.category.color,
             pattern_type: feedback.categorization_pattern&.pattern_type,
             pattern_value: feedback.categorization_pattern&.pattern_value,

--- a/app/services/categorization/bulk_categorization_service.rb
+++ b/app/services/categorization/bulk_categorization_service.rb
@@ -311,14 +311,14 @@ module Services::Categorization
           description: expense.description,
           amount: expense.amount,
           date: expense.transaction_date,
-          current_category: expense.category&.name,
-          new_category: Category.find(category_id)&.name,
+          current_category: expense.category&.display_name,
+          new_category: Category.find(category_id)&.display_name,
           will_change: expense.category_id != category_id
         }
       end
 
       def group_by_current_category(expenses)
-        expense_adapter.group_by { |e| e.category&.name || "Uncategorized" }
+        expense_adapter.group_by { |e| e.category&.display_name || "Uncategorized" }
                 .transform_values { |group| {
                   count: group.count,
                   amount: group.sum(&:amount)
@@ -391,7 +391,7 @@ module Services::Categorization
               expense.transaction_date,
               expense.description,
               expense.amount,
-              expense.category&.name,
+              expense.category&.display_name,
               expense.merchant_name
             ]
           end
@@ -405,7 +405,7 @@ module Services::Categorization
             date: expense.transaction_date,
             description: expense.description,
             amount: expense.amount,
-            category: expense.category&.name,
+            category: expense.category&.display_name,
             merchant: expense.merchant_name
           }
         end.to_json
@@ -465,7 +465,7 @@ module Services::Categorization
       end
 
       def group_by_category
-        expense_adapter.group_by { |e| e.category&.name || "Uncategorized" }
+        expense_adapter.group_by { |e| e.category&.display_name || "Uncategorized" }
                 .transform_values { |group| {
                   expenses: group,
                   count: group.count,
@@ -553,7 +553,7 @@ module Services::Categorization
               {
                 category: category,
                 confidence: 0.6,
-                reason: "Similar expenses in #{category.name}"
+                reason: "Similar expenses in #{category.display_name}"
               }
             end
           end
@@ -618,7 +618,7 @@ module Services::Categorization
                 action: "categorized",
                 expense_id: expense.id,
                 category_id: expense.category_id,
-                category_name: expense.category&.name
+                category_name: expense.category&.display_name
               }
             )
           rescue StandardError => e

--- a/app/services/categorization/bulk_categorization_service.rb
+++ b/app/services/categorization/bulk_categorization_service.rb
@@ -318,7 +318,7 @@ module Services::Categorization
       end
 
       def group_by_current_category(expenses)
-        expense_adapter.group_by { |e| e.category&.display_name || "Uncategorized" }
+        expenses.group_by { |e| e.category&.display_name || I18n.t("categories.names.uncategorized") }
                 .transform_values { |group| {
                   count: group.count,
                   amount: group.sum(&:amount)
@@ -465,7 +465,7 @@ module Services::Categorization
       end
 
       def group_by_category
-        expense_adapter.group_by { |e| e.category&.display_name || "Uncategorized" }
+        expense_adapter.group_by { |e| e.category&.display_name || I18n.t("categories.names.uncategorized") }
                 .transform_values { |group| {
                   expenses: group,
                   count: group.count,

--- a/app/services/categorization/categorization_result.rb
+++ b/app/services/categorization/categorization_result.rb
@@ -163,7 +163,7 @@ module Services::Categorization
         if @alternative_categories.any?
           parts << "Alternative categories:"
           @alternative_categories.each do |alt|
-            parts << "  - #{alt[:category].name}: #{(alt[:confidence] * 100).round(1)}%"
+            parts << "  - #{alt[:category].display_name}: #{(alt[:confidence] * 100).round(1)}%"
           end
         end
       elsif no_match?
@@ -192,7 +192,7 @@ module Services::Categorization
         alternative_categories: @alternative_categories.map do |alt|
           {
             category_id: alt[:category].id,
-            category_name: alt[:category].name,
+            category_name: alt[:category].display_name,
             confidence: alt[:confidence].round(4)
           }
         end,

--- a/app/services/categorization/categorization_result.rb
+++ b/app/services/categorization/categorization_result.rb
@@ -145,7 +145,7 @@ module Services::Categorization
       parts = []
 
       if successful?
-        parts << "Category: #{@category.name}"
+        parts << "Category: #{@category.display_name}"
         parts << "Confidence: #{(@confidence * 100).round(1)}% (#{confidence_level})"
         parts << "Method: #{@method.humanize}"
 
@@ -183,7 +183,7 @@ module Services::Categorization
     def to_h
       {
         category_id: @category&.id,
-        category_name: @category&.name,
+        category_name: @category&.display_name,
         confidence: @confidence.round(4),
         confidence_level: confidence_level,
         method: @method,
@@ -230,13 +230,13 @@ module Services::Categorization
     # Display methods
 
     def inspect
-      "#<CategorizationResult category=#{@category&.name} confidence=#{@confidence.round(3)} " \
+      "#<CategorizationResult category=#{@category&.display_name} confidence=#{@confidence.round(3)} " \
         "method=#{@method} patterns=#{@patterns_used.size} time=#{@processing_time_ms.round(2)}ms>"
     end
 
     def to_s
       if successful?
-        "#{@category.name} (#{(@confidence * 100).round(1)}% confidence)"
+        "#{@category.display_name} (#{(@confidence * 100).round(1)}% confidence)"
       elsif no_match?
         "No match found"
       elsif @error.present?

--- a/app/services/categorization/monitoring/structured_logger.rb
+++ b/app/services/categorization/monitoring/structured_logger.rb
@@ -158,7 +158,7 @@ module Services::Categorization
           transaction_date: expense.transaction_date&.iso8601,
           result: {
             category_id: result&.category_id,
-            category_name: result&.category&.name,
+            category_name: result&.category&.display_name,
             confidence: result&.confidence,
             method: result&.method,
             rule_matched: result&.metadata&.dig(:rule_id),

--- a/app/services/categorization/pattern_exporter.rb
+++ b/app/services/categorization/pattern_exporter.rb
@@ -42,7 +42,7 @@ module Services::Categorization
       [
         pattern.pattern_type,
         pattern.pattern_value,
-        pattern.category&.name,
+        pattern.category&.display_name,
         pattern.confidence_weight,
         pattern.active,
         pattern.usage_count,

--- a/app/services/categorization/pattern_learner.rb
+++ b/app/services/categorization/pattern_learner.rb
@@ -256,12 +256,12 @@ module Services::Categorization
       if predicted_category && predicted_category != correct_category
         # Weaken patterns that led to incorrect prediction
         weaken_patterns_for_category(expense, predicted_category, patterns_affected)
-        actions_taken << { action: "weakened_incorrect_patterns", category: predicted_category.name }
+        actions_taken << { action: "weakened_incorrect_patterns", category: predicted_category.display_name }
       end
 
       # Strengthen patterns for correct category
       strengthen_patterns_for_category(expense, correct_category, patterns_affected)
-      actions_taken << { action: "strengthened_correct_patterns", category: correct_category.name }
+      actions_taken << { action: "strengthened_correct_patterns", category: correct_category.display_name }
 
       # Record learning event
       record_learning_event(expense, correct_category, patterns_created.first || merchant_pattern)
@@ -303,7 +303,7 @@ module Services::Categorization
         pattern.save! unless @dry_run
 
         @metrics[:patterns_created] += 1
-        logger.info "[PatternLearner] Created merchant pattern: #{merchant_name} -> #{category.name}"
+        logger.info "[PatternLearner] Created merchant pattern: #{merchant_name} -> #{category.display_name}"
       else
         strengthen_pattern(pattern, user_correction: true)
       end
@@ -336,7 +336,7 @@ module Services::Categorization
 
             patterns << pattern
             @metrics[:patterns_created] += 1
-            logger.info "[PatternLearner] Created keyword pattern: #{keyword} -> #{category.name}"
+            logger.info "[PatternLearner] Created keyword pattern: #{keyword} -> #{category.display_name}"
           end
         else
           strengthen_pattern(pattern)

--- a/app/services/expense_filter_service.rb
+++ b/app/services/expense_filter_service.rb
@@ -73,7 +73,7 @@ module Services
         merchant_name: expense.display_merchant_name,
         category: expense.category ? {
           id: expense.category.id,
-          name: expense.category.name,
+          name: expense.category.display_name,
           color: expense.category.color
         } : nil,
         status: expense.status,

--- a/app/services/metrics_calculator.rb
+++ b/app/services/metrics_calculator.rb
@@ -516,7 +516,7 @@ module Services
     {
       id: budget.id,
       name: budget.name,
-      category: budget.category&.name,
+      category: budget.category&.display_name,
       period: budget.period,
       amount: budget.amount.to_f,
       currency: budget.currency,

--- a/app/services/patterns/statistics_calculator.rb
+++ b/app/services/patterns/statistics_calculator.rb
@@ -118,15 +118,16 @@ module Services::Patterns
         .select(
           "categories.id",
           "categories.name",
+          "categories.i18n_key",
           "COUNT(categorization_patterns.id) as pattern_count",
           "AVG(categorization_patterns.success_rate) as avg_success_rate",
           "SUM(categorization_patterns.usage_count) as total_usage"
         )
-        .group("categories.id, categories.name")
+        .group("categories.id, categories.name, categories.i18n_key")
         .map do |category|
           {
             id: category.id,
-            name: category.name,
+            name: category.display_name,
             pattern_count: category.pattern_count,
             average_success_rate: (category.avg_success_rate * 100).round(2),
             total_usage: category.total_usage
@@ -161,7 +162,7 @@ module Services::Patterns
         id: pattern.id,
         pattern_type: pattern.pattern_type,
         pattern_value: pattern.pattern_value,
-        category: pattern.category.name,
+        category: pattern.category.display_name,
         usage_count: pattern.usage_count,
         success_rate: (pattern.success_rate * 100).round(2),
         confidence_weight: pattern.confidence_weight

--- a/app/views/admin/composite_patterns/_form.html.erb
+++ b/app/views/admin/composite_patterns/_form.html.erb
@@ -60,7 +60,7 @@
         <div class="max-h-64 overflow-y-auto">
           <%= f.select :pattern_ids,
               options_for_select(
-                @available_patterns.map { |p| ["#{p.pattern_type}: #{p.pattern_value} (#{p.category&.name})", p.id] },
+                @available_patterns.map { |p| ["#{p.pattern_type}: #{p.pattern_value} (#{p.category&.display_name})", p.id] },
                 @composite_pattern.pattern_ids
               ),
               {},

--- a/app/views/admin/composite_patterns/index.html.erb
+++ b/app/views/admin/composite_patterns/index.html.erb
@@ -46,7 +46,7 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm">
                 <span class="px-2 py-1 text-xs rounded-full bg-teal-100 text-teal-700">
-                  <%= pattern.category.name %>
+                  <%= pattern.category.display_name %>
                 </span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">

--- a/app/views/admin/composite_patterns/show.html.erb
+++ b/app/views/admin/composite_patterns/show.html.erb
@@ -26,7 +26,7 @@
       <dl class="space-y-3">
         <div class="flex justify-between">
           <dt class="text-sm font-medium text-slate-500"><%= t("admin.composite_patterns.show.category_label") %></dt>
-          <dd class="text-sm text-slate-900"><%= @composite_pattern.category.name %></dd>
+          <dd class="text-sm text-slate-900"><%= @composite_pattern.category.display_name %></dd>
         </div>
         <div class="flex justify-between">
           <dt class="text-sm font-medium text-slate-500"><%= t("admin.composite_patterns.show.operator_label") %></dt>
@@ -106,7 +106,7 @@
               <tr class="hover:bg-slate-50">
                 <td class="py-2 px-3 text-slate-600"><%= pattern.pattern_type %></td>
                 <td class="py-2 px-3 font-mono text-slate-900"><%= pattern.pattern_value %></td>
-                <td class="py-2 px-3 text-slate-600"><%= pattern.category&.name %></td>
+                <td class="py-2 px-3 text-slate-600"><%= pattern.category&.display_name %></td>
                 <td class="py-2 px-3 text-slate-600"><%= pattern.confidence_weight %></td>
                 <td class="py-2 px-3">
                   <% if pattern.active? %>

--- a/app/views/admin/patterns/_pattern_row.html.erb
+++ b/app/views/admin/patterns/_pattern_row.html.erb
@@ -12,7 +12,7 @@
     </td>
     <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">
       <span class="px-2 py-1 text-xs rounded-full bg-teal-100 text-teal-700">
-        <%= pattern.category.name %>
+        <%= pattern.category.display_name %>
       </span>
     </td>
     <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">

--- a/app/views/admin/patterns/show.html.erb
+++ b/app/views/admin/patterns/show.html.erb
@@ -41,7 +41,7 @@
             <dt class="text-sm font-medium text-slate-500">Categoría</dt>
             <dd class="mt-1 text-sm text-slate-900">
               <span class="px-2 py-1 text-xs rounded-full bg-teal-100 text-teal-700">
-                <%= @pattern.category.name %>
+                <%= @pattern.category.display_name %>
               </span>
             </dd>
           </div>

--- a/app/views/admin/patterns/test.html.erb
+++ b/app/views/admin/patterns/test.html.erb
@@ -129,7 +129,7 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm">
                 <span class="px-2 py-1 text-xs rounded-full bg-teal-100 text-teal-700">
-                  <%= pattern.category.name %>
+                  <%= pattern.category.display_name %>
                 </span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900">

--- a/app/views/analytics/pattern_dashboard/index.html.erb
+++ b/app/views/analytics/pattern_dashboard/index.html.erb
@@ -28,7 +28,7 @@
           <% Category.order(:name).each do |category| %>
             <option value="<%= category.id %>"
                     <%= 'selected' if params[:category_id] == category.id.to_s %>>
-              <%= category.name %>
+              <%= category.display_name %>
             </option>
           <% end %>
         </select>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -19,7 +19,7 @@
             <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
               <h3 class="font-semibold text-slate-900 mb-2"><%= budget.name %></h3>
               <p class="text-sm text-slate-600 mb-4">
-                <%= budget.category&.name || "General" %>
+                <%= budget.category&.display_name || "General" %>
               </p>
 
               <div class="space-y-2">

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -22,7 +22,7 @@
 
         <div>
           <p class="text-sm text-slate-500"><%= t("budgets.show.category_label") %></p>
-          <p class="font-medium text-slate-900"><%= @budget.category&.name || t("budgets.show.general") %></p>
+          <p class="font-medium text-slate-900"><%= @budget.category&.display_name || t("budgets.show.general") %></p>
         </div>
 
         <div>

--- a/app/views/bulk_categorizations/_expense_groups.html.erb
+++ b/app/views/bulk_categorizations/_expense_groups.html.erb
@@ -79,7 +79,7 @@
               <% @categories.each do |category| %>
                 <option value="<%= category.id %>"
                         <%= "selected" if group[:suggested_category] == category %>>
-                  <%= category.parent ? "#{category.parent.name} → " : "" %><%= category.name %>
+                  <%= category.parent ? "#{category.parent.display_name} → " : "" %><%= category.display_name %>
                 </option>
               <% end %>
             </select>
@@ -158,7 +158,7 @@
                   <option value="">Usar categoría del grupo</option>
                   <% @categories.each do |category| %>
                     <option value="<%= category.id %>">
-                      <%= category.parent ? "#{category.parent.name} → " : "" %><%= category.name %>
+                      <%= category.parent ? "#{category.parent.display_name} → " : "" %><%= category.display_name %>
                     </option>
                   <% end %>
                 </select>

--- a/app/views/dashboard/_recent_activity.html.erb
+++ b/app/views/dashboard/_recent_activity.html.erb
@@ -14,7 +14,7 @@
               <% if expense.category %>
                 <% safe_color = (expense.category.color.to_s.match?(/\A#[0-9a-fA-F]{3,6}\z/) ? expense.category.color : "#64748b") %>
                 <span class="w-2 h-2 rounded-full shrink-0" style="background-color: <%= safe_color %>"></span>
-                <span class="text-xs text-slate-500"><%= expense.category.name %></span>
+                <span class="text-xs text-slate-500"><%= expense.category.display_name %></span>
               <% else %>
                 <span class="w-2 h-2 rounded-full shrink-0 bg-slate-400"></span>
                 <span class="text-xs text-slate-500"><%= t("dashboard.v2.uncategorized_label", default: "Sin categoría") %></span>

--- a/app/views/expenses/_bulk_operations_modal.html.erb
+++ b/app/views/expenses/_bulk_operations_modal.html.erb
@@ -123,7 +123,7 @@
                     class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500">
               <option value=""><%= t("expenses.bulk.select_category_prompt") %></option>
               <% Category.order(:name).each do |category| %>
-                <option value="<%= category.id %>"><%= category.name %></option>
+                <option value="<%= category.id %>"><%= category.display_name %></option>
               <% end %>
             </select>
           </div>

--- a/app/views/expenses/_category_with_confidence.html.erb
+++ b/app/views/expenses/_category_with_confidence.html.erb
@@ -13,7 +13,7 @@
     <% if expense.category %>
       <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full transition-all"
             style="background-color: <%= expense.category.color %>20; color: <%= expense.category.color %>;">
-        <%= expense.category.name %>
+        <%= expense.category.display_name %>
       </span>
     <% else %>
       <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-slate-100 text-slate-600">
@@ -77,7 +77,7 @@
           <span class="text-xs text-amber-800 font-medium">Sugerencia:</span>
           <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
                 style="background-color: <%= expense.ml_suggested_category.color %>20; color: <%= expense.ml_suggested_category.color %>;">
-            <%= expense.ml_suggested_category.name %>
+            <%= expense.ml_suggested_category.display_name %>
           </span>
           <div class="flex gap-1 ml-2">
             <%= button_to accept_suggestion_expense_path(expense),
@@ -117,7 +117,7 @@
         <% if expense.category %>
           <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
                 style="background-color: <%= expense.category.color %>20; color: <%= expense.category.color %>;">
-            <%= expense.category.name %>
+            <%= expense.category.display_name %>
           </span>
         <% else %>
           <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-slate-100 text-slate-600">

--- a/app/views/expenses/_expense_card.html.erb
+++ b/app/views/expenses/_expense_card.html.erb
@@ -27,7 +27,7 @@
       <% if expense.category %>
         <div class="w-3 h-3 rounded-full flex-shrink-0"
              style="background-color: <%= expense.category.color %>;"
-             title="<%= expense.category.name %>"></div>
+             title="<%= expense.category.display_name %>"></div>
       <% else %>
         <div class="w-3 h-3 rounded-full bg-slate-400 flex-shrink-0"
              title="<%= t('expenses.card.no_category') %>"></div>
@@ -56,7 +56,7 @@
 
       <% if expense.category %>
         <span class="text-xs text-slate-400">&middot;</span>
-        <span id="expense_<%= expense.id %>_category" class="text-xs text-slate-600"><%= expense.category.name %></span>
+        <span id="expense_<%= expense.id %>_category" class="text-xs text-slate-600"><%= expense.category.display_name %></span>
       <% end %>
 
       <%# Status badge — hidden when processed %>
@@ -110,10 +110,10 @@
                     class="w-full px-3 py-2.5 text-left text-xs text-slate-700 hover:bg-slate-50 flex items-center gap-2"
                     data-action="click->mobile-card#selectCategory:stop"
                     data-category-id="<%= cat.id %>"
-                    data-category-name="<%= cat.name %>"
+                    data-category-name="<%= cat.display_name %>"
                     role="option">
               <span class="inline-block w-3 h-3 rounded-full flex-shrink-0" style="background-color: <%= cat.color %>"></span>
-              <%= cat.name %>
+              <%= cat.display_name %>
             </button>
           <% end %>
         </div>

--- a/app/views/expenses/_expense_item.html.erb
+++ b/app/views/expenses/_expense_item.html.erb
@@ -42,7 +42,7 @@
       <% if expense.category %>
         <div class="w-3 h-3 rounded-full flex-shrink-0"
              style="background-color: <%= expense.category.color %>;"
-             title="<%= expense.category.name %>"></div>
+             title="<%= expense.category.display_name %>"></div>
       <% else %>
         <div class="w-3 h-3 rounded-full bg-slate-400 flex-shrink-0"
              title="<%= t('expenses.card.no_category') %>"></div>
@@ -69,7 +69,7 @@
 
       <% if expense.category %>
         <span class="text-xs text-slate-400">&middot;</span>
-        <span id="expense_<%= expense.id %>_category" class="text-xs text-slate-600"><%= expense.category.name %></span>
+        <span id="expense_<%= expense.id %>_category" class="text-xs text-slate-600"><%= expense.category.display_name %></span>
       <% end %>
 
       <% unless expense.status == "processed" %>
@@ -137,7 +137,7 @@
           <% if expense.category %>
             <% safe_color = (expense.category.color.to_s.match?(/\A#[0-9a-fA-F]{3,6}\z/) ? expense.category.color : "#64748b") %>
             <span class="w-2 h-2 rounded-full shrink-0" style="background-color: <%= safe_color %>"></span>
-            <span class="text-slate-700"><%= expense.category.name %></span>
+            <span class="text-slate-700"><%= expense.category.display_name %></span>
           <% else %>
             <span class="w-2 h-2 rounded-full shrink-0 bg-slate-400"></span>
             <span class="text-slate-500"><%= t("expenses.card.no_category", default: "Sin categoria") %></span>
@@ -190,10 +190,10 @@
                     class="w-full px-3 py-2.5 text-left text-xs text-slate-700 hover:bg-slate-50 flex items-center gap-2"
                     data-action="click->mobile-card#selectCategory:stop"
                     data-category-id="<%= cat.id %>"
-                    data-category-name="<%= cat.name %>"
+                    data-category-name="<%= cat.display_name %>"
                     role="option">
               <span class="inline-block w-3 h-3 rounded-full flex-shrink-0" style="background-color: <%= cat.color %>"></span>
-              <%= cat.name %>
+              <%= cat.display_name %>
             </button>
           <% end %>
         </div>

--- a/app/views/expenses/_expense_row.html.erb
+++ b/app/views/expenses/_expense_row.html.erb
@@ -54,8 +54,8 @@
         <% if expense.category %>
           <div class="w-8 h-8 rounded-full flex items-center justify-center text-white font-bold text-xs flex-shrink-0"
                style="background-color: <%= expense.category.color %>;"
-               title="<%= expense.category.name %>">
-            <%= expense.category.name.first.upcase %>
+               title="<%= expense.category.display_name %>">
+            <%= expense.category.display_name.first.upcase %>
           </div>
         <% else %>
           <div class="w-8 h-8 rounded-full flex items-center justify-center bg-slate-400 text-white font-bold text-xs flex-shrink-0"
@@ -98,10 +98,10 @@
                       class="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2"
                       data-action="click-><%= controller_name %>#selectCategory"
                       data-category-id="<%= category.id %>"
-                      data-category-name="<%= category.name %>"
+                      data-category-name="<%= category.display_name %>"
                       role="option">
                 <span class="inline-block w-3 h-3 rounded-full" style="background-color: <%= category.color %>"></span>
-                <%= category.name %>
+                <%= category.display_name %>
               </button>
               <% end %>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,32 @@ en:
   # Application-wide translations
   hello: "Hello world"
 
+  # Category display names (used by Category#display_name via i18n_key)
+  categories:
+    names:
+      food: "Food"
+      transport: "Transport"
+      utilities: "Utilities"
+      entertainment: "Entertainment"
+      health: "Health"
+      shopping: "Shopping"
+      education: "Education"
+      home: "Home"
+      uncategorized: "Uncategorized"
+      restaurants: "Restaurants"
+      supermarket: "Supermarket"
+      coffee_shop: "Coffee Shop"
+      gas: "Gas"
+      rideshare: "Rideshare"
+      bus: "Bus"
+      electricity: "Electricity"
+      water: "Water"
+      internet: "Internet"
+      phone: "Phone"
+      clothing: "Clothing"
+      electronics: "Electronics"
+      household: "Household"
+
   # Navigation
   nav:
     dashboard: "Dashboard"
@@ -233,7 +259,22 @@ en:
       entertainment: "Entertainment"
       health: "Health"
       shopping: "Shopping"
-      other: "Other"
+      education: "Education"
+      home: "Home"
+      uncategorized: "Uncategorized"
+      restaurants: "Restaurants"
+      supermarket: "Supermarket"
+      coffee_shop: "Coffee Shop"
+      gas: "Gas"
+      rideshare: "Rideshare"
+      bus: "Bus"
+      electricity: "Electricity"
+      water: "Water"
+      internet: "Internet"
+      phone: "Phone"
+      clothing: "Clothing"
+      electronics: "Electronics"
+      household: "Household"
 
     status:
       pending: "Pending"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -28,7 +28,7 @@ es:
       phone: "Teléfono"
       clothing: "Ropa"
       electronics: "Electrónicos"
-      household: "Hogar"
+      household: "Artículos del Hogar"
 
   # Navigation
   nav:
@@ -271,7 +271,7 @@ es:
       phone: "Teléfono"
       clothing: "Ropa"
       electronics: "Electrónicos"
-      household: "Hogar"
+      household: "Artículos del Hogar"
 
     status:
       pending: "Pendiente"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,7 +3,33 @@
 es:
   # Application-wide translations
   hello: "Hola mundo"
-  
+
+  # Category display names (used by Category#display_name via i18n_key)
+  categories:
+    names:
+      food: "Alimentación"
+      transport: "Transporte"
+      utilities: "Servicios"
+      entertainment: "Entretenimiento"
+      health: "Salud"
+      shopping: "Compras"
+      education: "Educación"
+      home: "Hogar"
+      uncategorized: "Sin Categoría"
+      restaurants: "Restaurantes"
+      supermarket: "Supermercado"
+      coffee_shop: "Cafetería"
+      gas: "Gasolina"
+      rideshare: "Uber/Taxi"
+      bus: "Autobús"
+      electricity: "Electricidad"
+      water: "Agua"
+      internet: "Internet"
+      phone: "Teléfono"
+      clothing: "Ropa"
+      electronics: "Electrónicos"
+      household: "Hogar"
+
   # Navigation
   nav:
     dashboard: "Dashboard"
@@ -230,8 +256,23 @@ es:
       entertainment: "Entretenimiento"
       health: "Salud"
       shopping: "Compras"
-      other: "Otros"
-      
+      education: "Educación"
+      home: "Hogar"
+      uncategorized: "Sin Categoría"
+      restaurants: "Restaurantes"
+      supermarket: "Supermercado"
+      coffee_shop: "Cafetería"
+      gas: "Gasolina"
+      rideshare: "Uber/Taxi"
+      bus: "Autobús"
+      electricity: "Electricidad"
+      water: "Agua"
+      internet: "Internet"
+      phone: "Teléfono"
+      clothing: "Ropa"
+      electronics: "Electrónicos"
+      household: "Hogar"
+
     status:
       pending: "Pendiente"
       confirmed: "Confirmado"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       resources :categories, only: [ :index ]
 
       # Categorization patterns management
-      resources :patterns, except: [:new, :edit] do
+      resources :patterns, except: [ :new, :edit ] do
         collection do
           get :statistics
         end
@@ -167,7 +167,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :sync_conflicts, only: [:index, :show] do
+  resources :sync_conflicts, only: [ :index, :show ] do
     member do
       post :resolve
       post :undo

--- a/db/migrate/20260410165725_add_i18n_key_to_categories.rb
+++ b/db/migrate/20260410165725_add_i18n_key_to_categories.rb
@@ -1,0 +1,6 @@
+class AddI18nKeyToCategories < ActiveRecord::Migration[8.1]
+  def change
+    add_column :categories, :i18n_key, :string
+    add_index :categories, :i18n_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_06_210819) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_10_165725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -143,9 +143,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_210819) do
     t.string "color", limit: 7
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "i18n_key"
     t.string "name", null: false
     t.integer "parent_id"
     t.datetime "updated_at", null: false
+    t.index ["i18n_key"], name: "index_categories_on_i18n_key", unique: true
     t.index ["name"], name: "index_categories_on_name"
     t.index ["parent_id"], name: "index_categories_on_parent_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -155,7 +155,7 @@ end
 puts ""
 puts "📂 Categories created:"
 Category.root_categories.each do |category|
-  puts "  • #{category.name} (#{category.children.count} subcategories)"
+  puts "  • #{category.display_name} (#{category.children.count} subcategories)"
 end
 puts ""
 puts "🚀 Ready to use! API endpoints:"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,54 +8,58 @@ puts "🌱 Seeding initial data..."
 puts "Creating expense categories..."
 
 root_categories = [
-  { name: "Alimentación", description: "Comida, restaurantes, supermercados", color: "#FF6B6B" },
-  { name: "Transporte", description: "Gasolina, Uber, taxis, transporte público", color: "#4ECDC4" },
-  { name: "Servicios", description: "Electricidad, agua, teléfono, internet", color: "#45B7D1" },
-  { name: "Entretenimiento", description: "Cine, teatro, eventos, diversión", color: "#96CEB4" },
-  { name: "Salud", description: "Medicina, doctor, hospital, farmacia", color: "#FFEAA7" },
-  { name: "Compras", description: "Ropa, electrónicos, artículos personales", color: "#DDA0DD" },
-  { name: "Educación", description: "Cursos, libros, capacitación", color: "#98D8C8" },
-  { name: "Hogar", description: "Artículos para el hogar, mantenimiento", color: "#F7DC6F" },
-  { name: "Sin Categoría", description: "Gastos sin categorizar", color: "#BDC3C7" }
+  { i18n_key: "food", description: "Comida, restaurantes, supermercados", color: "#FF6B6B" },
+  { i18n_key: "transport", description: "Gasolina, Uber, taxis, transporte público", color: "#4ECDC4" },
+  { i18n_key: "utilities", description: "Electricidad, agua, teléfono, internet", color: "#45B7D1" },
+  { i18n_key: "entertainment", description: "Cine, teatro, eventos, diversión", color: "#96CEB4" },
+  { i18n_key: "health", description: "Medicina, doctor, hospital, farmacia", color: "#FFEAA7" },
+  { i18n_key: "shopping", description: "Ropa, electrónicos, artículos personales", color: "#DDA0DD" },
+  { i18n_key: "education", description: "Cursos, libros, capacitación", color: "#98D8C8" },
+  { i18n_key: "home", description: "Artículos para el hogar, mantenimiento", color: "#F7DC6F" },
+  { i18n_key: "uncategorized", description: "Gastos sin categorizar", color: "#BDC3C7" }
 ]
 
 root_categories.each do |category_data|
-  category = Category.find_or_create_by!(name: category_data[:name]) do |cat|
+  name = I18n.t("categories.names.#{category_data[:i18n_key]}", locale: :es)
+  category = Category.find_or_create_by!(i18n_key: category_data[:i18n_key]) do |cat|
+    cat.name = name
     cat.description = category_data[:description]
     cat.color = category_data[:color]
   end
-  puts "  ✓ #{category.name}"
+  puts "  ✓ #{category.display_name}"
 end
 
 # Create subcategories
 puts "Creating subcategories..."
 
 subcategories = [
-  { parent: "Alimentación", name: "Restaurantes", description: "Comidas en restaurantes" },
-  { parent: "Alimentación", name: "Supermercado", description: "Compras de comestibles" },
-  { parent: "Alimentación", name: "Cafetería", description: "Café, desayunos, snacks" },
+  { parent_key: "food", i18n_key: "restaurants", description: "Comidas en restaurantes" },
+  { parent_key: "food", i18n_key: "supermarket", description: "Compras de comestibles" },
+  { parent_key: "food", i18n_key: "coffee_shop", description: "Café, desayunos, snacks" },
 
-  { parent: "Transporte", name: "Gasolina", description: "Combustible para vehículo" },
-  { parent: "Transporte", name: "Uber/Taxi", description: "Servicios de transporte" },
-  { parent: "Transporte", name: "Autobús", description: "Transporte público" },
+  { parent_key: "transport", i18n_key: "gas", description: "Combustible para vehículo" },
+  { parent_key: "transport", i18n_key: "rideshare", description: "Servicios de transporte" },
+  { parent_key: "transport", i18n_key: "bus", description: "Transporte público" },
 
-  { parent: "Servicios", name: "Electricidad", description: "Factura de electricidad" },
-  { parent: "Servicios", name: "Agua", description: "Factura de agua" },
-  { parent: "Servicios", name: "Internet", description: "Servicio de internet" },
-  { parent: "Servicios", name: "Teléfono", description: "Servicio telefónico" },
+  { parent_key: "utilities", i18n_key: "electricity", description: "Factura de electricidad" },
+  { parent_key: "utilities", i18n_key: "water", description: "Factura de agua" },
+  { parent_key: "utilities", i18n_key: "internet", description: "Servicio de internet" },
+  { parent_key: "utilities", i18n_key: "phone", description: "Servicio telefónico" },
 
-  { parent: "Compras", name: "Ropa", description: "Vestimenta y accesorios" },
-  { parent: "Compras", name: "Electrónicos", description: "Dispositivos electrónicos" },
-  { parent: "Compras", name: "Hogar", description: "Artículos para el hogar" }
+  { parent_key: "shopping", i18n_key: "clothing", description: "Vestimenta y accesorios" },
+  { parent_key: "shopping", i18n_key: "electronics", description: "Dispositivos electrónicos" },
+  { parent_key: "shopping", i18n_key: "household", description: "Artículos para el hogar" }
 ]
 
 subcategories.each do |subcat_data|
-  parent = Category.find_by!(name: subcat_data[:parent])
-  subcategory = Category.find_or_create_by!(name: subcat_data[:name]) do |cat|
+  parent = Category.find_by!(i18n_key: subcat_data[:parent_key])
+  name = I18n.t("categories.names.#{subcat_data[:i18n_key]}", locale: :es)
+  subcategory = Category.find_or_create_by!(i18n_key: subcat_data[:i18n_key]) do |cat|
+    cat.name = name
     cat.parent = parent
     cat.description = subcat_data[:description]
   end
-  puts "  ✓ #{parent.name} > #{subcategory.name}"
+  puts "  ✓ #{parent.display_name} > #{subcategory.display_name}"
 end
 
 # Create API tokens
@@ -88,10 +92,10 @@ parsing_rules = [
   {
     bank_name: "BAC",
     email_pattern: "(?:transacci[oó]n|notificaci[oó]n).*(?:BAC|PTA)",
-    amount_pattern: "(?:Monto)[:\\s]*₡?([\\d,]+\\.\\d{2})",
-    date_pattern: "(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{2}:\\d{2})",
-    merchant_pattern: "(?:Comercio)[:\\s]+([^\\n\\r]+)",
-    description_pattern: "(?:Autorizaci[oó]n)[:\\s]+([\\d]+)"
+    amount_pattern: "(?:Monto)[:\\s]*(?:CRC|USD|₡|\\$)?\\s*([\\d,]+\\.\\d{2})",
+    date_pattern: "Fecha:\\s*(\\w+\\s+\\d{1,2},\\s*\\d{4},?\\s*\\d{1,2}:\\d{2})",
+    merchant_pattern: "Comercio:\\s*(.+?)\\s*Ciudad y país:",
+    description_pattern: "(?:Autorización)[:\\s]+(\\d+)"
   },
   {
     bank_name: "BCR",

--- a/spec/db/index_audit_per126_spec.rb
+++ b/spec/db/index_audit_per126_spec.rb
@@ -441,7 +441,8 @@ RSpec.describe "PER-126 Index Audit", :unit do
     it "has 208 or fewer indexes after removing 42 redundant indexes from the pre-audit total of 250" do
       total = connection.tables.sum { |t| connection.indexes(t).size }
       # Pre-audit: 250 indexes; 42 removed => current total is 208
-      expect(total).to be <= 210  # small buffer for schema drift
+      # +1 for categories.i18n_key unique index added in i18n migration
+      expect(total).to be <= 212  # small buffer for schema drift
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -50,5 +50,4 @@ RSpec.describe ApplicationHelper, type: :helper, unit: true do
       expect(helper.format_datetime(datetime)).to eq('December 25, 2024 at 12:00 PM')
     end
   end
-
 end

--- a/spec/helpers/expenses_helper_spec.rb
+++ b/spec/helpers/expenses_helper_spec.rb
@@ -143,5 +143,4 @@ RSpec.describe ExpensesHelper, type: :helper, unit: true do
       end
     end
   end
-
 end

--- a/spec/jobs/bulk_categorization_job_spec.rb
+++ b/spec/jobs/bulk_categorization_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BulkCategorizationJob, type: :job, unit: true do
   let(:category_id) { 10 }
   let(:user_id) { 20 }
   let(:options) { { category_id: category_id, force: true } }
-  let(:category) { double('Category', id: category_id, name: 'Test Category') }
+  let(:category) { double('Category', id: category_id, name: 'Test Category', display_name: 'Test Category') }
   let(:successful_result) do
     OpenStruct.new(
       success?: true,
@@ -199,7 +199,7 @@ RSpec.describe BulkCategorizationJob, type: :job, unit: true do
 
   describe '#execute_operation (via perform)' do
     it 'extracts category_id from options' do
-      other_category = double('Category', id: 99, name: 'Other Category')
+      other_category = double('Category', id: 99, name: 'Other Category', display_name: 'Other Category')
       allow(Category).to receive(:find_by).with(id: 99).and_return(other_category)
       service_double = double('Service', call: successful_result)
       allow(Services::BulkCategorization::ApplyService).to receive(:new).and_return(service_double)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -103,6 +103,54 @@ RSpec.describe Category, type: :model, integration: true do
     end
   end
 
+  describe '#display_name', :unit do
+    it 'returns name when i18n_key is nil' do
+      category = Category.new(name: 'Custom Category', i18n_key: nil)
+      expect(category.display_name).to eq('Custom Category')
+    end
+
+    it 'returns translated name when i18n_key is present' do
+      category = Category.new(name: 'Alimentación', i18n_key: 'food')
+      I18n.with_locale(:en) do
+        expect(category.display_name).to eq('Food')
+      end
+    end
+
+    it 'returns Spanish translation with es locale' do
+      category = Category.new(name: 'Food', i18n_key: 'food')
+      I18n.with_locale(:es) do
+        expect(category.display_name).to eq('Alimentación')
+      end
+    end
+
+    it 'falls back to name when translation key is missing' do
+      category = Category.new(name: 'Fallback Name', i18n_key: 'nonexistent_key')
+      expect(category.display_name).to eq('Fallback Name')
+    end
+
+    it 'returns name when i18n_key is blank string' do
+      category = Category.new(name: 'Blank Key', i18n_key: '')
+      expect(category.display_name).to eq('Blank Key')
+    end
+  end
+
+  describe '#full_name with i18n', :unit do
+    it 'uses display_name for root category' do
+      category = Category.new(name: 'Alimentación', i18n_key: 'food')
+      I18n.with_locale(:en) do
+        expect(category.full_name).to eq('Food')
+      end
+    end
+
+    it 'uses display_name for parent and child' do
+      parent = create(:category, name: 'Alimentación', i18n_key: 'food')
+      child = Category.new(name: 'Restaurantes', i18n_key: 'restaurants', parent: parent)
+      I18n.with_locale(:en) do
+        expect(child.full_name).to eq('Food > Restaurants')
+      end
+    end
+  end
+
   describe 'validations edge cases', integration: true do
     it 'validates name length maximum' do
       long_name = 'a' * 256

--- a/spec/models/expense_unit_spec.rb
+++ b/spec/models/expense_unit_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe Expense, type: :model, unit: true do
         expect(expense.category_name).to eq("Food")
       end
 
-      it "returns 'Uncategorized' when category is nil" do
+      it "returns translated 'uncategorized' when category is nil" do
         expense.category = nil
-        expect(expense.category_name).to eq("Uncategorized")
+        expect(expense.category_name).to eq(I18n.t("categories.names.uncategorized"))
       end
     end
 

--- a/spec/services/categorization/bulk_categorization_service_spec.rb
+++ b/spec/services/categorization/bulk_categorization_service_spec.rb
@@ -77,9 +77,10 @@ RSpec.describe Services::Categorization::BulkCategorizationService, type: :servi
         result = service.preview
         by_category = result[:summary][:by_current_category]
 
-        expect(by_category).to have_key("Uncategorized")
-        expect(by_category).to have_key(other_category.name)
-        expect(by_category["Uncategorized"][:count]).to eq(2)
+        uncategorized_label = I18n.t("categories.names.uncategorized")
+        expect(by_category).to have_key(uncategorized_label)
+        expect(by_category).to have_key(other_category.display_name)
+        expect(by_category[uncategorized_label][:count]).to eq(2)
       end
 
       it "estimates time saved" do
@@ -440,9 +441,9 @@ RSpec.describe Services::Categorization::BulkCategorizationService, type: :servi
       it "groups by category name" do
         groups = service.group_expenses(by: :category)
 
-        expect(groups).to have_key(category.name)
-        expect(groups).to have_key(other_category.name)
-        expect(groups).to have_key("Uncategorized")
+        expect(groups).to have_key(category.display_name)
+        expect(groups).to have_key(other_category.display_name)
+        expect(groups).to have_key(I18n.t("categories.names.uncategorized"))
       end
 
       it "sorts by total amount descending" do


### PR DESCRIPTION
## Summary
- Add `i18n_key` column to categories with unique index, enabling locale-based display names via `Category#display_name`
- Replace all 43 `category.name` references with `category.display_name` across views, controllers, serializers, and services
- Fix BAC parsing rules to match current email format: CRC/USD currency codes, Spanish date format (`Abr 3, 2026, 10:30`), proper merchant extraction
- Add complete category translations (22 keys) to both `en.yml` and `es.yml`
- Update seeds to use `i18n_key` for category creation

## Test plan
- [x] Unit tests pass (7281 examples, 0 failures)
- [x] RuboCop clean
- [x] Brakeman clean
- [ ] Verify category names display correctly in both EN and ES locales
- [ ] Verify email sync processes BAC transaction emails correctly
- [ ] Verify dashboard, expenses list, and category filters show translated names

🤖 Generated with [Claude Code](https://claude.com/claude-code)