### PR TITLE
feat: MetricsRecorder logs every categorization (PER-467)

### DIFF
--- a/app/services/categorization/engine.rb
+++ b/app/services/categorization/engine.rb
@@ -300,10 +300,11 @@ module Services::Categorization
             options.merge(correlation_id: correlation_id)
           )
 
-          # Invalidate affected cache entries only on success
+          # Invalidate affected cache entries and record correction metrics on success
           if result.success?
             invalidate_relevant_cache(correct_category)
             @pattern_cache_service.invalidate_all if @pattern_cache_service.respond_to?(:invalidate_all)
+            metrics_recorder.record_correction(expense: expense, corrected_to_category: correct_category)
           end
 
           result
@@ -510,8 +511,8 @@ module Services::Categorization
       # Increment counter atomically
       @total_categorizations.increment
 
-      # Delegate to strategy chain
-      result = run_strategy_chain(expense, opts)
+      # Delegate to strategy chain — returns [result, layer_name] tuple
+      result, layer = run_strategy_chain(expense, opts)
 
       # Post-strategy processing (stays in Engine)
       if result.successful?
@@ -535,7 +536,6 @@ module Services::Categorization
       end
 
       # Record categorization metrics for monitoring
-      layer = result.metadata[:layer_name] || "pattern"
       metrics_recorder.record(expense: expense, result: result, layer_name: layer)
 
       result
@@ -544,16 +544,15 @@ module Services::Categorization
     # Iterate through strategies until one returns a confident result.
     # Database and connection errors are re-raised so Engine#categorize
     # can translate them into the appropriate error results.
+    # Returns [result, layer_name] tuple. Layer name is returned separately
+    # to avoid mutating the result's metadata hash.
     def run_strategy_chain(expense, opts)
       last_result = nil
-      last_layer = "unknown"
+      last_layer = "pattern"
 
       strategies.each do |strategy|
         result = strategy.call(expense, opts)
-        if result.successful?
-          result.metadata[:layer_name] = strategy.layer_name
-          return result
-        end
+        return [ result, strategy.layer_name ] if result.successful?
         last_result = result
         last_layer = strategy.layer_name
       rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid, PG::Error
@@ -566,8 +565,7 @@ module Services::Categorization
 
       # Return last strategy's result (preserves processing_time_ms) or fallback
       fallback = last_result || CategorizationResult.no_match(processing_time_ms: 0.0)
-      fallback.metadata[:layer_name] = last_layer
-      fallback
+      [ fallback, last_layer ]
     end
 
     # Ordered list of categorization strategies.

--- a/app/services/categorization/engine.rb
+++ b/app/services/categorization/engine.rb
@@ -6,6 +6,7 @@ require_relative "ml_confidence_integration"
 require_relative "service_registry"
 require_relative "strategies/base_strategy"
 require_relative "strategies/pattern_strategy"
+require_relative "learning/metrics_recorder"
 
 module Services::Categorization
   # Simple circuit breaker implementation for fault tolerance
@@ -533,6 +534,10 @@ module Services::Categorization
         @successful_categorizations.increment
       end
 
+      # Record categorization metrics for monitoring
+      layer = result.metadata[:layer_name] || "pattern"
+      metrics_recorder.record(expense: expense, result: result, layer_name: layer)
+
       result
     end
 
@@ -541,11 +546,16 @@ module Services::Categorization
     # can translate them into the appropriate error results.
     def run_strategy_chain(expense, opts)
       last_result = nil
+      last_layer = "unknown"
 
       strategies.each do |strategy|
         result = strategy.call(expense, opts)
-        return result if result.successful?
+        if result.successful?
+          result.metadata[:layer_name] = strategy.layer_name
+          return result
+        end
         last_result = result
+        last_layer = strategy.layer_name
       rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid, PG::Error
         raise
       rescue => e
@@ -555,7 +565,9 @@ module Services::Categorization
       end
 
       # Return last strategy's result (preserves processing_time_ms) or fallback
-      last_result || CategorizationResult.no_match(processing_time_ms: 0.0)
+      fallback = last_result || CategorizationResult.no_match(processing_time_ms: 0.0)
+      fallback.metadata[:layer_name] = last_layer
+      fallback
     end
 
     # Ordered list of categorization strategies.
@@ -569,6 +581,10 @@ module Services::Categorization
           logger: @logger
         )
       ]
+    end
+
+    def metrics_recorder
+      @metrics_recorder ||= Learning::MetricsRecorder.new(logger: @logger)
     end
 
     def update_expense_sync(expense, result, correlation_id)

--- a/app/services/categorization/learning/metrics_recorder.rb
+++ b/app/services/categorization/learning/metrics_recorder.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  module Learning
+    # Records categorization metrics for every expense categorization.
+    # Used by Engine to track per-layer performance, accuracy, and API costs.
+    class MetricsRecorder
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
+      # Record a categorization result.
+      #
+      # @param expense [Expense]
+      # @param result [CategorizationResult]
+      # @param layer_name [String] "pattern", "pg_trgm", "haiku", or "manual"
+      # @param api_cost [Float] cost of the API call (0 for local layers)
+      def record(expense:, result:, layer_name:, api_cost: 0)
+        CategorizationMetric.create!(
+          expense: expense,
+          layer_used: layer_name,
+          confidence: result.successful? ? result.confidence : nil,
+          category: result.successful? ? result.category : nil,
+          was_corrected: false,
+          processing_time_ms: result.processing_time_ms,
+          api_cost: api_cost
+        )
+      rescue => e
+        @logger.error "[MetricsRecorder] Failed to record metric: #{e.message}"
+      end
+
+      # Record a user correction on a previously categorized expense.
+      # Updates the most recent metric for the given expense.
+      #
+      # @param expense [Expense]
+      # @param corrected_to_category [Category]
+      def record_correction(expense:, corrected_to_category:)
+        metric = CategorizationMetric
+          .where(expense: expense)
+          .order(created_at: :desc)
+          .first
+
+        return unless metric
+
+        hours = ((Time.current - metric.created_at) / 1.hour).round
+
+        metric.update!(
+          was_corrected: true,
+          corrected_to_category: corrected_to_category,
+          time_to_correction_hours: hours
+        )
+      rescue => e
+        @logger.error "[MetricsRecorder] Failed to record correction: #{e.message}"
+      end
+    end
+  end
+end

--- a/app/services/categorization/learning/metrics_recorder.rb
+++ b/app/services/categorization/learning/metrics_recorder.rb
@@ -26,7 +26,7 @@ module Services::Categorization
           api_cost: api_cost
         )
       rescue => e
-        @logger.error "[MetricsRecorder] Failed to record metric: #{e.message}"
+        @logger.error "[MetricsRecorder] Failed to record metric: #{e.class}: #{e.message}"
       end
 
       # Record a user correction on a previously categorized expense.
@@ -50,7 +50,7 @@ module Services::Categorization
           time_to_correction_hours: hours
         )
       rescue => e
-        @logger.error "[MetricsRecorder] Failed to record correction: #{e.message}"
+        @logger.error "[MetricsRecorder] Failed to record correction: #{e.class}: #{e.message}"
       end
     end
   end

--- a/spec/services/categorization/learning/metrics_recorder_spec.rb
+++ b/spec/services/categorization/learning/metrics_recorder_spec.rb
@@ -56,12 +56,18 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
       expect(metric.confidence).to be_nil
     end
 
-    it "does not raise on database errors" do
+    it "does not raise on database errors and logs the failure" do
+      logger = instance_double(ActiveSupport::Logger)
+      allow(logger).to receive(:error)
+      recorder_with_logger = described_class.new(logger: logger)
+
       allow(CategorizationMetric).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
 
       expect {
-        recorder.record(expense: expense, result: result, layer_name: "pattern")
+        recorder_with_logger.record(expense: expense, result: result, layer_name: "pattern")
       }.not_to raise_error
+
+      expect(logger).to have_received(:error).with(/Failed to record metric/)
     end
   end
 
@@ -96,12 +102,26 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
       expect(metric.time_to_correction_hours).to be_between(47, 49)
     end
 
-    it "handles missing metric row gracefully" do
+    it "handles missing metric row gracefully without modifying anything" do
       other_expense = create(:expense)
 
+      recorder.record_correction(expense: other_expense, corrected_to_category: new_category)
+
+      expect(CategorizationMetric.where(was_corrected: true).count).to eq(0)
+    end
+
+    it "does not raise on correction errors and logs the failure" do
+      logger = instance_double(ActiveSupport::Logger)
+      allow(logger).to receive(:error)
+      recorder_with_logger = described_class.new(logger: logger)
+
+      allow_any_instance_of(CategorizationMetric).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
       expect {
-        recorder.record_correction(expense: other_expense, corrected_to_category: new_category)
+        recorder_with_logger.record_correction(expense: expense, corrected_to_category: new_category)
       }.not_to raise_error
+
+      expect(logger).to have_received(:error).with(/Failed to record correction/)
     end
 
     it "updates the most recent metric for the expense" do

--- a/spec/services/categorization/learning/metrics_recorder_spec.rb
+++ b/spec/services/categorization/learning/metrics_recorder_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :service, unit: true do
+  let(:category) { create(:category) }
+  let(:expense) { create(:expense, category: category) }
+  let(:recorder) { described_class.new }
+
+  describe "#record" do
+    let(:result) do
+      Services::Categorization::CategorizationResult.new(
+        category: category,
+        confidence: 0.85,
+        patterns_used: [ "merchant:walmart" ],
+        processing_time_ms: 5.2,
+        method: "fuzzy_match"
+      )
+    end
+
+    it "creates a categorization_metric row" do
+      expect {
+        recorder.record(expense: expense, result: result, layer_name: "pattern")
+      }.to change(CategorizationMetric, :count).by(1)
+    end
+
+    it "stores the correct attributes" do
+      recorder.record(expense: expense, result: result, layer_name: "pattern")
+
+      metric = CategorizationMetric.last
+      expect(metric.expense).to eq(expense)
+      expect(metric.layer_used).to eq("pattern")
+      expect(metric.confidence).to eq(0.85)
+      expect(metric.category).to eq(category)
+      expect(metric.processing_time_ms).to eq(5.2)
+      expect(metric.was_corrected).to be false
+      expect(metric.api_cost).to eq(0)
+    end
+
+    it "stores api_cost when provided" do
+      recorder.record(expense: expense, result: result, layer_name: "haiku", api_cost: 0.001)
+
+      metric = CategorizationMetric.last
+      expect(metric.api_cost).to eq(0.001)
+    end
+
+    it "handles no_match results gracefully" do
+      no_match = Services::Categorization::CategorizationResult.no_match(processing_time_ms: 1.0)
+
+      expect {
+        recorder.record(expense: expense, result: no_match, layer_name: "pattern")
+      }.to change(CategorizationMetric, :count).by(1)
+
+      metric = CategorizationMetric.last
+      expect(metric.category).to be_nil
+      expect(metric.confidence).to be_nil
+    end
+
+    it "does not raise on database errors" do
+      allow(CategorizationMetric).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect {
+        recorder.record(expense: expense, result: result, layer_name: "pattern")
+      }.not_to raise_error
+    end
+  end
+
+  describe "#record_correction" do
+    let!(:metric) do
+      CategorizationMetric.create!(
+        expense: expense,
+        layer_used: "pattern",
+        confidence: 0.85,
+        category: category,
+        was_corrected: false,
+        processing_time_ms: 5.0
+      )
+    end
+    let(:new_category) { create(:category, name: "Corrected", i18n_key: "corrected_test") }
+
+    it "updates the metric row" do
+      recorder.record_correction(expense: expense, corrected_to_category: new_category)
+
+      metric.reload
+      expect(metric.was_corrected).to be true
+      expect(metric.corrected_to_category).to eq(new_category)
+      expect(metric.time_to_correction_hours).to be_present
+    end
+
+    it "calculates time_to_correction_hours correctly" do
+      metric.update_columns(created_at: 48.hours.ago)
+
+      recorder.record_correction(expense: expense, corrected_to_category: new_category)
+
+      metric.reload
+      expect(metric.time_to_correction_hours).to be_between(47, 49)
+    end
+
+    it "handles missing metric row gracefully" do
+      other_expense = create(:expense)
+
+      expect {
+        recorder.record_correction(expense: other_expense, corrected_to_category: new_category)
+      }.not_to raise_error
+    end
+
+    it "updates the most recent metric for the expense" do
+      older_metric = CategorizationMetric.create!(
+        expense: expense,
+        layer_used: "pg_trgm",
+        confidence: 0.7,
+        category: category,
+        was_corrected: false,
+        processing_time_ms: 40.0,
+        created_at: 2.days.ago
+      )
+
+      recorder.record_correction(expense: expense, corrected_to_category: new_category)
+
+      # Should update the newer metric, not the older one
+      metric.reload
+      older_metric.reload
+      expect(metric.was_corrected).to be true
+      expect(older_metric.was_corrected).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `Services::Categorization::Learning::MetricsRecorder` service
- Records every categorization result to `categorization_metrics` table (layer, confidence, timing, cost)
- Records user corrections with `time_to_correction_hours`
- Wire into Engine's `perform_categorization` — every categorization now logged
- Strategy chain now embeds `layer_name` in result metadata for accurate recording

## Test plan
- [x] 9 new MetricsRecorder unit specs
- [x] All 78 Engine + Strategy specs pass (no behavior regression)
- [x] Full unit suite: 7350 examples, 0 failures
- [x] RuboCop: 0 offenses
- [x] Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)