### PR TITLE
feat: admin categorization metrics dashboard (PER-468)

### DIFF
--- a/app/controllers/admin/categorization_metrics_controller.rb
+++ b/app/controllers/admin/categorization_metrics_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Admin
+  # Displays categorization system performance metrics.
+  class CategorizationMetricsController < BaseController
+    def index
+      service = Services::Categorization::Monitoring::MetricsDashboardService.new
+      @overview = service.overview
+      @layer_performance = service.layer_performance
+    end
+  end
+end

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  module Monitoring
+    # Aggregates categorization metrics for the admin dashboard.
+    # Provides overview stats and per-layer performance breakdowns.
+    class MetricsDashboardService
+      def overview(period: 30.days)
+        metrics = CategorizationMetric.recent(period)
+        total = metrics.count
+
+        return empty_overview if total.zero?
+
+        {
+          accuracy: percentage(metrics.uncorrected.count, total),
+          fallback_rate: percentage(metrics.for_layer("haiku").count, total),
+          correction_rate: percentage(metrics.corrected.count, total),
+          api_spend: metrics.sum(:api_cost).to_f
+        }
+      end
+
+      def layer_performance(period: 30.days)
+        metrics = CategorizationMetric.recent(period)
+
+        metrics.group(:layer_used).pluck(:layer_used).map do |layer|
+          layer_metrics = metrics.for_layer(layer)
+          total = layer_metrics.count
+
+          next if total.zero?
+
+          corrected_count = layer_metrics.corrected.count
+          correct_count = total - corrected_count
+
+          {
+            layer: layer,
+            total: total,
+            correct: correct_count,
+            corrected: corrected_count,
+            accuracy: percentage(correct_count, total),
+            avg_confidence: layer_metrics.average(:confidence).to_f.round(2),
+            avg_time: layer_metrics.average(:processing_time_ms).to_f.round(2)
+          }
+        end.compact
+      end
+
+      private
+
+      def empty_overview
+        { accuracy: 0.0, fallback_rate: 0.0, correction_rate: 0.0, api_spend: 0.0 }
+      end
+
+      def percentage(numerator, denominator)
+        return 0.0 if denominator.zero?
+
+        (numerator.to_f / denominator * 100).round(2)
+      end
+    end
+  end
+end

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -3,50 +3,56 @@
 module Services::Categorization
   module Monitoring
     # Aggregates categorization metrics for the admin dashboard.
-    # Provides overview stats and per-layer performance breakdowns.
+    # Uses single-query conditional aggregation for efficiency.
     class MetricsDashboardService
       def overview(period: 30.days)
-        metrics = CategorizationMetric.recent(period)
-        total = metrics.count
+        result = CategorizationMetric.recent(period).pick(
+          Arel.sql("COUNT(*)"),
+          Arel.sql("COUNT(CASE WHEN was_corrected = false THEN 1 END)"),
+          Arel.sql("COUNT(CASE WHEN layer_used = 'haiku' THEN 1 END)"),
+          Arel.sql("COUNT(CASE WHEN was_corrected = true THEN 1 END)"),
+          Arel.sql("COALESCE(SUM(api_cost), 0)")
+        )
 
+        total, uncorrected, haiku, corrected, spend = result
         return empty_overview if total.zero?
 
         {
-          accuracy: percentage(metrics.uncorrected.count, total),
-          fallback_rate: percentage(metrics.for_layer("haiku").count, total),
-          correction_rate: percentage(metrics.corrected.count, total),
-          api_spend: metrics.sum(:api_cost).to_f
+          empty: false,
+          accuracy: percentage(uncorrected, total),
+          fallback_rate: percentage(haiku, total),
+          correction_rate: percentage(corrected, total),
+          api_spend: spend.to_f
         }
       end
 
       def layer_performance(period: 30.days)
-        metrics = CategorizationMetric.recent(period)
-
-        metrics.group(:layer_used).pluck(:layer_used).map do |layer|
-          layer_metrics = metrics.for_layer(layer)
-          total = layer_metrics.count
-
-          next if total.zero?
-
-          corrected_count = layer_metrics.corrected.count
-          correct_count = total - corrected_count
-
-          {
-            layer: layer,
-            total: total,
-            correct: correct_count,
-            corrected: corrected_count,
-            accuracy: percentage(correct_count, total),
-            avg_confidence: layer_metrics.average(:confidence).to_f.round(2),
-            avg_time: layer_metrics.average(:processing_time_ms).to_f.round(2)
-          }
-        end.compact
+        CategorizationMetric.recent(period)
+          .group(:layer_used)
+          .pluck(
+            :layer_used,
+            Arel.sql("COUNT(*)"),
+            Arel.sql("COUNT(CASE WHEN was_corrected = true THEN 1 END)"),
+            Arel.sql("ROUND(AVG(confidence)::numeric, 2)"),
+            Arel.sql("ROUND(AVG(processing_time_ms)::numeric, 2)")
+          ).map do |layer, total, corrected, avg_conf, avg_time|
+            correct = total - corrected
+            {
+              layer: layer,
+              total: total,
+              correct: correct,
+              corrected: corrected,
+              accuracy: percentage(correct, total),
+              avg_confidence: avg_conf.to_f,
+              avg_time: avg_time.to_f
+            }
+          end
       end
 
       private
 
       def empty_overview
-        { accuracy: 0.0, fallback_rate: 0.0, correction_rate: 0.0, api_spend: 0.0 }
+        { empty: true, accuracy: 0.0, fallback_rate: 0.0, correction_rate: 0.0, api_spend: 0.0 }
       end
 
       def percentage(numerator, denominator)

--- a/app/views/admin/categorization_metrics/index.html.erb
+++ b/app/views/admin/categorization_metrics/index.html.erb
@@ -1,0 +1,135 @@
+<div class="container mx-auto px-4">
+  <!-- Header -->
+  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
+    <div>
+      <h1 class="text-3xl font-bold text-slate-900">Categorization Metrics</h1>
+      <p class="text-slate-600 mt-1">Categorization system performance overview</p>
+    </div>
+  </div>
+
+  <% if @overview[:accuracy].zero? && @overview[:api_spend].zero? %>
+    <!-- Empty State -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-12 text-center">
+      <div class="bg-slate-100 text-slate-400 p-4 rounded-full inline-block mb-4">
+        <svg aria-hidden="true" class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+        </svg>
+      </div>
+      <h2 class="text-xl font-semibold text-slate-900 mb-2">No metrics yet</h2>
+      <p class="text-slate-500">Categorization metrics will appear here once expenses are processed.</p>
+    </div>
+  <% else %>
+    <!-- Overview Cards -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <!-- Accuracy Card -->
+      <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+        <div class="flex items-center">
+          <div class="bg-emerald-100 text-emerald-700 p-3 rounded-lg">
+            <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+          </div>
+          <div class="ml-4">
+            <p class="text-sm text-slate-600">Overall Accuracy</p>
+            <p class="text-2xl font-bold text-slate-900"><%= number_with_precision(@overview[:accuracy], precision: 1) %>%</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Fallback Rate Card -->
+      <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+        <div class="flex items-center">
+          <div class="bg-amber-100 text-amber-700 p-3 rounded-lg">
+            <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+            </svg>
+          </div>
+          <div class="ml-4">
+            <p class="text-sm text-slate-600">LLM Fallback Rate</p>
+            <p class="text-2xl font-bold text-slate-900"><%= number_with_precision(@overview[:fallback_rate], precision: 1) %>%</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Correction Rate Card -->
+      <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+        <div class="flex items-center">
+          <div class="bg-rose-100 text-rose-700 p-3 rounded-lg">
+            <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+            </svg>
+          </div>
+          <div class="ml-4">
+            <p class="text-sm text-slate-600">User Correction Rate</p>
+            <p class="text-2xl font-bold text-slate-900"><%= number_with_precision(@overview[:correction_rate], precision: 1) %>%</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- API Spend Card -->
+      <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+        <div class="flex items-center">
+          <div class="bg-teal-100 text-teal-700 p-3 rounded-lg">
+            <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+          </div>
+          <div class="ml-4">
+            <p class="text-sm text-slate-600">API Spend</p>
+            <p class="text-2xl font-bold text-slate-900">$<%= number_with_precision(@overview[:api_spend], precision: 4) %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Layer Performance Table -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+      <div class="px-6 py-4 border-b border-slate-200">
+        <h2 class="text-lg font-semibold text-slate-900">Layer Performance</h2>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-slate-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Layer</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Total</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Correct</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Corrected</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Accuracy</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Avg Confidence</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Avg Time</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-slate-200">
+            <% @layer_performance.each do |row| %>
+              <tr>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                    <%= case row[:layer]
+                        when 'pattern' then 'bg-teal-100 text-teal-800'
+                        when 'pg_trgm' then 'bg-slate-100 text-slate-800'
+                        when 'haiku' then 'bg-amber-100 text-amber-800'
+                        when 'manual' then 'bg-rose-100 text-rose-800'
+                        end %>">
+                    <%= row[:layer].titleize %>
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900"><%= number_with_delimiter(row[:total]) %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-emerald-700"><%= number_with_delimiter(row[:correct]) %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-rose-700"><%= number_with_delimiter(row[:corrected]) %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-slate-900"><%= number_with_precision(row[:accuracy], precision: 1) %>%</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900"><%= number_with_precision(row[:avg_confidence], precision: 2) %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900"><%= number_with_precision(row[:avg_time], precision: 1) %> ms</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/categorization_metrics/index.html.erb
+++ b/app/views/admin/categorization_metrics/index.html.erb
@@ -7,7 +7,7 @@
     </div>
   </div>
 
-  <% if @overview[:accuracy].zero? && @overview[:api_spend].zero? %>
+  <% if @overview[:empty] %>
     <!-- Empty State -->
     <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-12 text-center">
       <div class="bg-slate-100 text-slate-400 p-4 rounded-full inline-block mb-4">
@@ -115,6 +115,7 @@
                         when 'pg_trgm' then 'bg-slate-100 text-slate-800'
                         when 'haiku' then 'bg-amber-100 text-amber-800'
                         when 'manual' then 'bg-rose-100 text-rose-800'
+                        else 'bg-slate-100 text-slate-800'
                         end %>">
                     <%= row[:layer].titleize %>
                   </span>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -50,7 +50,7 @@
             <%= link_to t("admin.nav.composite_patterns"), admin_composite_patterns_path,
                 class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/composite_patterns') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
                 'aria-current': (request.path.start_with?('/admin/composite_patterns') ? 'page' : nil) %>
-            <%= link_to "Metrics", admin_categorization_metrics_path,
+            <%= link_to t("admin.nav.categorization_metrics"), admin_categorization_metrics_path,
                 class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/categorization_metrics') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
                 'aria-current': (request.path.start_with?('/admin/categorization_metrics') ? 'page' : nil) %>
             <%= link_to t("admin.nav.analytics"), analytics_pattern_dashboard_index_path,

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -50,6 +50,9 @@
             <%= link_to t("admin.nav.composite_patterns"), admin_composite_patterns_path,
                 class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/composite_patterns') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
                 'aria-current': (request.path.start_with?('/admin/composite_patterns') ? 'page' : nil) %>
+            <%= link_to "Metrics", admin_categorization_metrics_path,
+                class: "text-sm font-medium transition-colors #{request.path.start_with?('/admin/categorization_metrics') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
+                'aria-current': (request.path.start_with?('/admin/categorization_metrics') ? 'page' : nil) %>
             <%= link_to t("admin.nav.analytics"), analytics_pattern_dashboard_index_path,
                 class: "text-sm font-medium transition-colors #{request.path.start_with?('/analytics') ? 'text-teal-700' : 'text-slate-600 hover:text-teal-700'}",
                 'aria-current': (request.path.start_with?('/analytics') ? 'page' : nil) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -775,6 +775,7 @@ en:
       title: "Admin - Expense Tracker"
       patterns: "Patterns"
       composite_patterns: "Composite Patterns"
+      categorization_metrics: "Metrics"
       analytics: "Analytics"
       sync_performance: "Sync Performance"
       back_to_app: "← Back to App"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -838,6 +838,7 @@ es:
       title: "Admin - Expense Tracker"
       patterns: "Patrones"
       composite_patterns: "Patrones Compuestos"
+      categorization_metrics: "Métricas"
       analytics: "Analíticas"
       sync_performance: "Rendimiento Sync"
       back_to_app: "← Volver a la App"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
     post "patterns/:id/toggle_active", to: "pattern_management#toggle_active", as: :toggle_active_pattern
 
     resources :patterns
+    resources :categorization_metrics, only: [ :index ]
     resources :composite_patterns do
       member do
         post :toggle_active

--- a/spec/controllers/admin/categorization_metrics_controller_spec.rb
+++ b/spec/controllers/admin/categorization_metrics_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Admin::CategorizationMetricsController, type: :controller, unit: 
 
   before do
     allow(controller).to receive(:current_admin_user).and_return(admin_user)
-    allow(controller).to receive(:log_admin_action)
   end
 
   describe "GET #index" do

--- a/spec/controllers/admin/categorization_metrics_controller_spec.rb
+++ b/spec/controllers/admin/categorization_metrics_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::CategorizationMetricsController, type: :controller, unit: true do
+  let(:admin_user) { create(:admin_user, email: "admin_#{SecureRandom.hex(4)}@example.com") }
+
+  before do
+    allow(controller).to receive(:current_admin_user).and_return(admin_user)
+    allow(controller).to receive(:log_admin_action)
+  end
+
+  describe "GET #index" do
+    let(:overview_data) do
+      { accuracy: 85.0, fallback_rate: 15.0, correction_rate: 10.0, api_spend: 0.05 }
+    end
+    let(:layer_data) do
+      [
+        { layer: "pattern", total: 80, correct: 70, corrected: 10,
+          accuracy: 87.5, avg_confidence: 0.9, avg_time: 12.0 },
+        { layer: "haiku", total: 20, correct: 15, corrected: 5,
+          accuracy: 75.0, avg_confidence: 0.7, avg_time: 200.0 }
+      ]
+    end
+
+    before do
+      service = instance_double(Services::Categorization::Monitoring::MetricsDashboardService)
+      allow(Services::Categorization::Monitoring::MetricsDashboardService).to receive(:new).and_return(service)
+      allow(service).to receive(:overview).and_return(overview_data)
+      allow(service).to receive(:layer_performance).and_return(layer_data)
+    end
+
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "assigns overview data" do
+      get :index
+      expect(assigns(:overview)).to eq(overview_data)
+    end
+
+    it "assigns layer performance data" do
+      get :index
+      expect(assigns(:layer_performance)).to eq(layer_data)
+    end
+
+    it "renders the index template" do
+      get :index
+      expect(response).to render_template(:index)
+    end
+  end
+
+  describe "authentication" do
+    before do
+      allow(controller).to receive(:current_admin_user).and_return(nil)
+    end
+
+    it "redirects unauthenticated users to login" do
+      get :index
+      expect(response).to redirect_to(admin_login_path)
+    end
+  end
+end

--- a/spec/factories/categorization_metrics.rb
+++ b/spec/factories/categorization_metrics.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :categorization_metric do
+    expense
+    category
+    layer_used { "pattern" }
+    confidence { 0.85 }
+    was_corrected { false }
+    processing_time_ms { 12.5 }
+    api_cost { 0.0 }
+
+    trait :corrected do
+      was_corrected { true }
+      association :corrected_to_category, factory: :category
+      time_to_correction_hours { 2 }
+    end
+
+    trait :haiku_layer do
+      layer_used { "haiku" }
+      api_cost { 0.001 }
+    end
+
+    trait :pg_trgm_layer do
+      layer_used { "pg_trgm" }
+    end
+
+    trait :manual_layer do
+      layer_used { "manual" }
+    end
+  end
+end

--- a/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
+++ b/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, type: :service, unit: true do
+  subject(:service) { described_class.new }
+
+  describe "#overview" do
+    context "with no metrics" do
+      it "returns zeros without division errors" do
+        result = service.overview(period: 30.days)
+
+        expect(result).to eq(
+          accuracy: 0.0,
+          fallback_rate: 0.0,
+          correction_rate: 0.0,
+          api_spend: 0.0
+        )
+      end
+    end
+
+    context "with metrics in period" do
+      before do
+        # 3 uncorrected (accurate) + 1 corrected = 4 total
+        create_list(:categorization_metric, 3, created_at: 5.days.ago)
+        create(:categorization_metric, :corrected, created_at: 5.days.ago)
+
+        # 2 haiku layer metrics (one already counted above as corrected)
+        create(:categorization_metric, :haiku_layer, created_at: 5.days.ago)
+
+        # Outside period - should be excluded
+        create(:categorization_metric, created_at: 60.days.ago)
+      end
+
+      it "calculates accuracy as uncorrected / total * 100" do
+        result = service.overview(period: 30.days)
+
+        # 5 total in period, 4 uncorrected => 80%
+        expect(result[:accuracy]).to eq(80.0)
+      end
+
+      it "calculates fallback_rate as haiku layer / total * 100" do
+        result = service.overview(period: 30.days)
+
+        # 5 total in period, 1 haiku layer => 20%
+        expect(result[:fallback_rate]).to eq(20.0)
+      end
+
+      it "calculates correction_rate as corrected / total * 100" do
+        result = service.overview(period: 30.days)
+
+        # 5 total in period, 1 corrected => 20%
+        expect(result[:correction_rate]).to eq(20.0)
+      end
+
+      it "sums api_cost for the period" do
+        result = service.overview(period: 30.days)
+
+        # Only the haiku layer metric has api_cost of 0.001
+        expect(result[:api_spend]).to eq(0.001)
+      end
+    end
+
+    context "with custom period" do
+      before do
+        create(:categorization_metric, created_at: 5.days.ago)
+        create(:categorization_metric, created_at: 15.days.ago)
+      end
+
+      it "respects the period parameter" do
+        result = service.overview(period: 10.days)
+
+        expect(result[:accuracy]).to eq(100.0)
+      end
+    end
+  end
+
+  describe "#layer_performance" do
+    context "with no metrics" do
+      it "returns an empty array" do
+        result = service.layer_performance(period: 30.days)
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "with metrics across layers" do
+      before do
+        # Pattern layer: 2 correct, 1 corrected
+        create_list(:categorization_metric, 2, layer_used: "pattern",
+          confidence: 0.9, processing_time_ms: 10.0, created_at: 5.days.ago)
+        create(:categorization_metric, :corrected, layer_used: "pattern",
+          confidence: 0.6, processing_time_ms: 20.0, created_at: 5.days.ago)
+
+        # Haiku layer: 1 correct
+        create(:categorization_metric, :haiku_layer,
+          confidence: 0.75, processing_time_ms: 150.0, created_at: 5.days.ago)
+
+        # Outside period
+        create(:categorization_metric, layer_used: "pattern", created_at: 60.days.ago)
+      end
+
+      it "returns one entry per layer" do
+        result = service.layer_performance(period: 30.days)
+
+        layers = result.map { |r| r[:layer] }
+        expect(layers).to contain_exactly("pattern", "haiku")
+      end
+
+      it "calculates correct counts per layer" do
+        result = service.layer_performance(period: 30.days)
+        pattern_row = result.find { |r| r[:layer] == "pattern" }
+
+        expect(pattern_row[:total]).to eq(3)
+        expect(pattern_row[:correct]).to eq(2)
+        expect(pattern_row[:corrected]).to eq(1)
+      end
+
+      it "calculates accuracy per layer" do
+        result = service.layer_performance(period: 30.days)
+        pattern_row = result.find { |r| r[:layer] == "pattern" }
+
+        # 2 correct out of 3 total => 66.67%
+        expect(pattern_row[:accuracy]).to eq(66.67)
+      end
+
+      it "calculates average confidence per layer" do
+        result = service.layer_performance(period: 30.days)
+        pattern_row = result.find { |r| r[:layer] == "pattern" }
+
+        # (0.9 + 0.9 + 0.6) / 3 = 0.8
+        expect(pattern_row[:avg_confidence]).to eq(0.8)
+      end
+
+      it "calculates average processing time per layer" do
+        result = service.layer_performance(period: 30.days)
+        pattern_row = result.find { |r| r[:layer] == "pattern" }
+
+        # (10.0 + 10.0 + 20.0) / 3 ≈ 13.33
+        expect(pattern_row[:avg_time]).to eq(13.33)
+      end
+
+      it "handles haiku layer correctly" do
+        result = service.layer_performance(period: 30.days)
+        haiku_row = result.find { |r| r[:layer] == "haiku" }
+
+        expect(haiku_row[:total]).to eq(1)
+        expect(haiku_row[:correct]).to eq(1)
+        expect(haiku_row[:corrected]).to eq(0)
+        expect(haiku_row[:accuracy]).to eq(100.0)
+        expect(haiku_row[:avg_confidence]).to eq(0.75)
+        expect(haiku_row[:avg_time]).to eq(150.0)
+      end
+    end
+  end
+end

--- a/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
+++ b/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
         result = service.overview(period: 30.days)
 
         expect(result).to eq(
+          empty: true,
           accuracy: 0.0,
           fallback_rate: 0.0,
           correction_rate: 0.0,
@@ -25,7 +26,7 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
         create_list(:categorization_metric, 3, created_at: 5.days.ago)
         create(:categorization_metric, :corrected, created_at: 5.days.ago)
 
-        # 2 haiku layer metrics (one already counted above as corrected)
+        # 1 haiku layer metric
         create(:categorization_metric, :haiku_layer, created_at: 5.days.ago)
 
         # Outside period - should be excluded


### PR DESCRIPTION
## Summary
- Create `/admin/categorization_metrics` dashboard page with overview cards + layer performance table
- Build `MetricsDashboardService` with `overview()` and `layer_performance()` methods
- Add nav link in admin layout
- Financial Confidence palette (teal/emerald/amber/rose/slate)
- Handles empty state gracefully

## Test plan
- [x] 13 MetricsDashboardService unit specs
- [x] 5 controller specs (including auth redirect)
- [x] Full unit suite: 7369 examples, 0 failures
- [x] RuboCop: 0 offenses
- [x] Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)