### PR TITLE
feat: SimilarityStrategy for pg_trgm Layer 2 matching (PER-472)

### DIFF
--- a/app/services/categorization/merchant_normalizer.rb
+++ b/app/services/categorization/merchant_normalizer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  # Shared merchant name normalization for pg_trgm similarity matching.
+  #
+  # Used by SimilarityStrategy (Layer 2) and VectorUpdater (B2) to ensure
+  # consistent normalization when querying and updating categorization_vectors.
+  module MerchantNormalizer
+    module_function
+
+    # Normalize a merchant name for pg_trgm comparison.
+    #
+    # Strips whitespace, downcases, removes non-alphanumeric characters
+    # (except spaces), and collapses multiple spaces.
+    #
+    # @param name [String, nil] the merchant name to normalize
+    # @return [String] normalized name, or empty string if nil/blank
+    def normalize(name)
+      return "" if name.nil?
+
+      name.downcase
+          .strip
+          .gsub(/[^a-z0-9\s]/, "")
+          .gsub(/\s+/, " ")
+          .strip
+    end
+  end
+end

--- a/app/services/categorization/strategies/similarity_strategy.rb
+++ b/app/services/categorization/strategies/similarity_strategy.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  module Strategies
+    # Layer 2 categorization strategy that uses PostgreSQL's pg_trgm
+    # extension to find similar merchants in the categorization_vectors table.
+    #
+    # This strategy queries the GiST trigram index for fuzzy merchant name
+    # matching, then applies confidence scoring based on similarity score,
+    # occurrence count, and description keyword overlap.
+    class SimilarityStrategy < BaseStrategy
+      # Minimum similarity from pg_trgm for high confidence path
+      HIGH_SIMILARITY_THRESHOLD = 0.6
+      # Minimum similarity for medium confidence path
+      MEDIUM_SIMILARITY_THRESHOLD = 0.4
+      # Minimum occurrence_count to qualify for high confidence
+      HIGH_OCCURRENCE_THRESHOLD = 2
+      # Tolerance for considering two similarity scores "close"
+      TIEBREAK_TOLERANCE = 0.1
+
+      # @return [String]
+      def layer_name
+        "pg_trgm"
+      end
+
+      # Attempt to categorize an expense via pg_trgm similarity matching
+      # against the categorization_vectors table.
+      #
+      # @param expense [Expense]
+      # @param options [Hash]
+      # @return [CategorizationResult]
+      def call(expense, options = {})
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        normalized = normalize_merchant(expense)
+        if normalized.blank?
+          return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+        end
+
+        vectors = fetch_similar_vectors(normalized)
+        if vectors.empty?
+          return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+        end
+
+        best = select_best_vector(vectors, normalized, expense)
+        similarity = similarity_score(best, normalized)
+        confidence = calculate_confidence(similarity, best)
+
+        build_result(best, confidence, similarity, duration_ms(start_time))
+      end
+
+      private
+
+      def normalize_merchant(expense)
+        return "" unless expense.merchant_name?
+
+        MerchantNormalizer.normalize(expense.merchant_name)
+      end
+
+      def fetch_similar_vectors(normalized)
+        CategorizationVector
+          .for_merchant(normalized)
+          .includes(:category)
+          .to_a
+      end
+
+      def select_best_vector(vectors, normalized, expense)
+        scored = vectors.map do |vector|
+          sim = similarity_score(vector, normalized)
+          { vector: vector, similarity: sim }
+        end
+
+        scored.sort_by! { |s| -s[:similarity] }
+
+        top = scored.first
+        close_contenders = scored.select { |s| (top[:similarity] - s[:similarity]).abs < TIEBREAK_TOLERANCE }
+
+        if close_contenders.size > 1 && expense.description?
+          tiebreak_by_keywords(close_contenders, expense.description)
+        else
+          top[:vector]
+        end
+      end
+
+      def tiebreak_by_keywords(contenders, description)
+        desc_words = description.downcase.split(/\s+/).to_set
+
+        best = contenders.max_by do |entry|
+          keywords = entry[:vector].description_keywords || []
+          overlap = keywords.count { |kw| desc_words.include?(kw.downcase) }
+          [ overlap, entry[:similarity] ]
+        end
+
+        best[:vector]
+      end
+
+      def similarity_score(vector, normalized)
+        CategorizationVector
+          .where(id: vector.id)
+          .pick(Arel.sql("similarity(merchant_normalized, #{CategorizationVector.connection.quote(normalized)})"))
+          .to_f
+      end
+
+      def calculate_confidence(similarity, vector)
+        if similarity > HIGH_SIMILARITY_THRESHOLD && vector.occurrence_count > HIGH_OCCURRENCE_THRESHOLD
+          # High confidence: 0.7 + similarity * 0.3
+          0.7 + (similarity * 0.3)
+        elsif similarity > MEDIUM_SIMILARITY_THRESHOLD
+          # Medium confidence: 0.4 + similarity * 0.3
+          0.4 + (similarity * 0.3)
+        else
+          # Low confidence: similarity * 0.5
+          similarity * 0.5
+        end
+      end
+
+      def build_result(vector, confidence, similarity, processing_time_ms)
+        CategorizationResult.new(
+          category: vector.category,
+          confidence: confidence,
+          method: "pg_trgm_similarity",
+          patterns_used: [ "vector:#{vector.merchant_normalized}" ],
+          processing_time_ms: processing_time_ms,
+          metadata: {
+            similarity_score: similarity.round(4),
+            vector_id: vector.id,
+            occurrence_count: vector.occurrence_count,
+            merchant_normalized: vector.merchant_normalized
+          }
+        )
+      end
+
+      def duration_ms(start_time)
+        (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
+      end
+    end
+  end
+end

--- a/app/services/categorization/strategies/similarity_strategy.rb
+++ b/app/services/categorization/strategies/similarity_strategy.rb
@@ -18,6 +18,11 @@ module Services::Categorization
       # Tolerance for considering two similarity scores "close"
       TIEBREAK_TOLERANCE = 0.1
 
+      # @param logger [Logger]
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
       # @return [String]
       def layer_name
         "pg_trgm"
@@ -27,9 +32,9 @@ module Services::Categorization
       # against the categorization_vectors table.
       #
       # @param expense [Expense]
-      # @param options [Hash]
+      # @param _options [Hash] unused — confidence thresholds are internal to this strategy
       # @return [CategorizationResult]
-      def call(expense, options = {})
+      def call(expense, _options = {})
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         normalized = normalize_merchant(expense)
@@ -37,16 +42,15 @@ module Services::Categorization
           return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
         end
 
-        vectors = fetch_similar_vectors(normalized)
-        if vectors.empty?
+        scored_vectors = fetch_and_score_vectors(normalized)
+        if scored_vectors.empty?
           return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
         end
 
-        best = select_best_vector(vectors, normalized, expense)
-        similarity = similarity_score(best, normalized)
-        confidence = calculate_confidence(similarity, best)
+        best = select_best_vector(scored_vectors, expense)
+        confidence = calculate_confidence(best[:similarity], best[:vector])
 
-        build_result(best, confidence, similarity, duration_ms(start_time))
+        build_result(best[:vector], confidence, best[:similarity], duration_ms(start_time))
       end
 
       private
@@ -57,59 +61,47 @@ module Services::Categorization
         MerchantNormalizer.normalize(expense.merchant_name)
       end
 
-      def fetch_similar_vectors(normalized)
+      # Single query: fetches vectors AND their similarity scores together.
+      # Eliminates N+1 by selecting similarity() as a virtual attribute.
+      def fetch_and_score_vectors(normalized)
+        quoted = CategorizationVector.connection.quote(normalized)
+
         CategorizationVector
           .for_merchant(normalized)
+          .select("categorization_vectors.*, similarity(merchant_normalized, #{quoted}) AS trgm_score")
           .includes(:category)
-          .to_a
+          .map { |v| { vector: v, similarity: v.trgm_score.to_f } }
       end
 
-      def select_best_vector(vectors, normalized, expense)
-        scored = vectors.map do |vector|
-          sim = similarity_score(vector, normalized)
-          { vector: vector, similarity: sim }
-        end
+      def select_best_vector(scored_vectors, expense)
+        scored_vectors.sort_by! { |s| -s[:similarity] }
 
-        scored.sort_by! { |s| -s[:similarity] }
-
-        top = scored.first
-        close_contenders = scored.select { |s| (top[:similarity] - s[:similarity]).abs < TIEBREAK_TOLERANCE }
+        top = scored_vectors.first
+        close_contenders = scored_vectors.select { |s| (top[:similarity] - s[:similarity]).abs < TIEBREAK_TOLERANCE }
 
         if close_contenders.size > 1 && expense.description?
           tiebreak_by_keywords(close_contenders, expense.description)
         else
-          top[:vector]
+          top
         end
       end
 
       def tiebreak_by_keywords(contenders, description)
         desc_words = description.downcase.split(/\s+/).to_set
 
-        best = contenders.max_by do |entry|
+        contenders.max_by do |entry|
           keywords = entry[:vector].description_keywords || []
           overlap = keywords.count { |kw| desc_words.include?(kw.downcase) }
           [ overlap, entry[:similarity] ]
         end
-
-        best[:vector]
-      end
-
-      def similarity_score(vector, normalized)
-        CategorizationVector
-          .where(id: vector.id)
-          .pick(Arel.sql("similarity(merchant_normalized, #{CategorizationVector.connection.quote(normalized)})"))
-          .to_f
       end
 
       def calculate_confidence(similarity, vector)
         if similarity > HIGH_SIMILARITY_THRESHOLD && vector.occurrence_count > HIGH_OCCURRENCE_THRESHOLD
-          # High confidence: 0.7 + similarity * 0.3
           0.7 + (similarity * 0.3)
         elsif similarity > MEDIUM_SIMILARITY_THRESHOLD
-          # Medium confidence: 0.4 + similarity * 0.3
           0.4 + (similarity * 0.3)
         else
-          # Low confidence: similarity * 0.5
           similarity * 0.5
         end
       end

--- a/spec/factories/categorization_vectors.rb
+++ b/spec/factories/categorization_vectors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :categorization_vector do
+    sequence(:merchant_normalized) { |n| "merchant #{n}" }
+    association :category
+    occurrence_count { 5 }
+    correction_count { 0 }
+    confidence { 0.8 }
+    description_keywords { [] }
+    last_seen_at { Time.current }
+  end
+end

--- a/spec/services/categorization/merchant_normalizer_spec.rb
+++ b/spec/services/categorization/merchant_normalizer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::MerchantNormalizer, type: :service, unit: true do
+  describe ".normalize" do
+    it "downcases the name" do
+      expect(described_class.normalize("WALMART")).to eq("walmart")
+    end
+
+    it "strips leading and trailing whitespace" do
+      expect(described_class.normalize("  walmart  ")).to eq("walmart")
+    end
+
+    it "removes special characters" do
+      expect(described_class.normalize("Walmart® Super-Center!")).to eq("walmart supercenter")
+    end
+
+    it "preserves spaces between words" do
+      expect(described_class.normalize("Walmart Super Center")).to eq("walmart super center")
+    end
+
+    it "collapses multiple spaces" do
+      expect(described_class.normalize("walmart   super   center")).to eq("walmart super center")
+    end
+
+    it "handles nil by returning empty string" do
+      expect(described_class.normalize(nil)).to eq("")
+    end
+
+    it "handles empty string" do
+      expect(described_class.normalize("")).to eq("")
+    end
+
+    it "removes numbers' special chars but keeps digits" do
+      expect(described_class.normalize("Store #123")).to eq("store 123")
+    end
+  end
+end

--- a/spec/services/categorization/strategies/similarity_strategy_spec.rb
+++ b/spec/services/categorization/strategies/similarity_strategy_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::Strategies::SimilarityStrategy, type: :service, unit: true do
+  subject(:strategy) { described_class.new }
+
+  describe "#layer_name" do
+    it "returns 'pg_trgm'" do
+      expect(strategy.layer_name).to eq("pg_trgm")
+    end
+  end
+
+  describe "#call" do
+    let(:category) { create(:category, name: "Groceries") }
+    let(:other_category) { create(:category, name: "Restaurants") }
+
+    context "when expense has no merchant_name" do
+      let(:expense) { build(:expense, merchant_name: nil) }
+
+      it "returns no_match result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_no_match
+        expect(result.method).to eq("no_match")
+      end
+    end
+
+    context "when expense has blank merchant_name" do
+      let(:expense) { build(:expense, merchant_name: "  ") }
+
+      it "returns no_match result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_no_match
+      end
+    end
+
+    context "when no similar vectors exist" do
+      let(:expense) { build(:expense, merchant_name: "Completely Unknown Store") }
+
+      it "returns no_match result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_no_match
+      end
+    end
+
+    context "when an exact merchant match exists with high occurrence" do
+      let(:expense) { build(:expense, merchant_name: "walmart") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart",
+               category: category,
+               occurrence_count: 10,
+               confidence: 0.9)
+      end
+
+      it "returns a successful result with high confidence" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+        expect(result.confidence).to be > 0.9
+        expect(result.method).to eq("pg_trgm_similarity")
+      end
+    end
+
+    context "when a similar merchant exists (e.g., 'walmart' matches 'walmart supercenter')" do
+      let(:expense) { build(:expense, merchant_name: "walmart") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart supercenter",
+               category: category,
+               occurrence_count: 5,
+               confidence: 0.8)
+      end
+
+      it "returns a successful result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+        expect(result.method).to eq("pg_trgm_similarity")
+      end
+    end
+
+    context "when multiple categories match with different scores" do
+      let(:expense) { build(:expense, merchant_name: "walmart") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart",
+               category: category,
+               occurrence_count: 10,
+               confidence: 0.9)
+        create(:categorization_vector,
+               merchant_normalized: "walmart pharmacy",
+               category: other_category,
+               occurrence_count: 3,
+               confidence: 0.6)
+      end
+
+      it "returns the highest scoring category" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+      end
+    end
+
+    context "when occurrence_count is low (<=2) with moderate similarity" do
+      let(:expense) { build(:expense, merchant_name: "walmart") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart",
+               category: category,
+               occurrence_count: 1,
+               confidence: 0.5)
+      end
+
+      it "returns medium confidence instead of high" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        # similarity=1.0, but occurrence_count <= 2 so medium formula: 0.4 + 1.0 * 0.3 = 0.7
+        expect(result.confidence).to be <= 0.75
+      end
+    end
+
+    context "when similarity is low (between 0.3 and 0.4)" do
+      let(:expense) { build(:expense, merchant_name: "wal") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart supercenter groceries",
+               category: category,
+               occurrence_count: 10,
+               confidence: 0.9)
+      end
+
+      it "returns low confidence" do
+        result = strategy.call(expense)
+
+        # If similarity is below 0.4, low confidence: similarity * 0.5
+        # If no vectors match at all (below 0.3 threshold), no_match
+        if result.no_match?
+          expect(result).to be_no_match
+        else
+          expect(result.confidence).to be < 0.4
+        end
+      end
+    end
+
+    context "when multiple categories have close similarity scores" do
+      let(:expense) { build(:expense, merchant_name: "walmart supercenter", description: "groceries shopping") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart supercenter",
+               category: category,
+               occurrence_count: 5,
+               description_keywords: %w[groceries food shopping],
+               confidence: 0.8)
+        create(:categorization_vector,
+               merchant_normalized: "walmart supercenter",
+               category: other_category,
+               occurrence_count: 5,
+               description_keywords: %w[pharmacy medicine],
+               confidence: 0.8)
+      end
+
+      it "uses description_keywords as tiebreaker when scores are within 0.1" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        # Both vectors have identical merchant_normalized so identical similarity.
+        # The category with matching description_keywords should win the tiebreak
+        # (groceries + shopping overlap with the grocery category's keywords)
+        expect(result.category).to eq(category)
+      end
+    end
+
+    context "when merchant_name has special characters" do
+      let(:expense) { build(:expense, merchant_name: "Walmart® Super-Center!") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart supercenter",
+               category: category,
+               occurrence_count: 10,
+               confidence: 0.9)
+      end
+
+      it "normalizes the merchant name and still matches" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+      end
+    end
+
+    context "result metadata" do
+      let(:expense) { build(:expense, merchant_name: "walmart") }
+
+      before do
+        create(:categorization_vector,
+               merchant_normalized: "walmart",
+               category: category,
+               occurrence_count: 10,
+               confidence: 0.9)
+      end
+
+      it "includes similarity score and vector info in metadata" do
+        result = strategy.call(expense)
+
+        expect(result.metadata).to include(:similarity_score, :vector_id)
+      end
+
+      it "tracks processing time" do
+        result = strategy.call(expense)
+
+        expect(result.processing_time_ms).to be >= 0
+      end
+    end
+  end
+end

--- a/spec/services/categorization/strategies/similarity_strategy_spec.rb
+++ b/spec/services/categorization/strategies/similarity_strategy_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Services::Categorization::Strategies::SimilarityStrategy, type: :service, unit: true do
-  subject(:strategy) { described_class.new }
+  subject(:strategy) { described_class.new(logger: Rails.logger) }
 
   describe "#layer_name" do
     it "returns 'pg_trgm'" do
@@ -131,27 +131,21 @@ RSpec.describe Services::Categorization::Strategies::SimilarityStrategy, type: :
       end
     end
 
-    context "when similarity is low (between 0.3 and 0.4)" do
-      let(:expense) { build(:expense, merchant_name: "wal") }
+    context "when similarity is below pg_trgm threshold" do
+      let(:expense) { build(:expense, merchant_name: "xyz unknown") }
 
       before do
         create(:categorization_vector,
-               merchant_normalized: "walmart supercenter groceries",
+               merchant_normalized: "walmart supercenter",
                category: category,
                occurrence_count: 10,
                confidence: 0.9)
       end
 
-      it "returns low confidence" do
+      it "returns no_match when similarity is below 0.3 threshold" do
         result = strategy.call(expense)
 
-        # If similarity is below 0.4, low confidence: similarity * 0.5
-        # If no vectors match at all (below 0.3 threshold), no_match
-        if result.no_match?
-          expect(result).to be_no_match
-        else
-          expect(result.confidence).to be < 0.4
-        end
+        expect(result).to be_no_match
       end
     end
 
@@ -214,16 +208,19 @@ RSpec.describe Services::Categorization::Strategies::SimilarityStrategy, type: :
                confidence: 0.9)
       end
 
-      it "includes similarity score and vector info in metadata" do
+      it "includes all expected keys in metadata" do
         result = strategy.call(expense)
 
-        expect(result.metadata).to include(:similarity_score, :vector_id)
+        expect(result.metadata).to include(
+          :similarity_score, :vector_id, :occurrence_count, :merchant_normalized
+        )
       end
 
-      it "tracks processing time" do
+      it "tracks processing time as a positive number" do
         result = strategy.call(expense)
 
-        expect(result.processing_time_ms).to be >= 0
+        expect(result.processing_time_ms).to be_a(Numeric)
+        expect(result.processing_time_ms).to be > 0
       end
     end
   end


### PR DESCRIPTION
## Summary
- Create `SimilarityStrategy` using PostgreSQL pg_trgm similarity queries on `categorization_vectors`
- Three-tier confidence scoring: high (>0.6 similarity + >2 occurrences), medium (>0.4), low
- Description keywords tiebreaker for close matches
- Extract `MerchantNormalizer` shared module for consistent merchant name normalization
- Not wired into Engine yet — happens in C2 assembly ticket

## Test plan
- [x] 13 SimilarityStrategy unit specs
- [x] 8 MerchantNormalizer unit specs
- [x] Full unit suite: 7390 examples, 0 failures
- [x] RuboCop: 0 offenses
- [x] Brakeman: 0 warnings
- [x] Rails Best Practices: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)