### PR TITLE
feat: VectorUpdater + backfill rake task (PER-473)

### DIFF
--- a/app/services/categorization/learning/vector_updater.rb
+++ b/app/services/categorization/learning/vector_updater.rb
@@ -47,7 +47,7 @@ module Services::Categorization
         vector.save!
         vector
       rescue => e
-        @logger.error "[VectorUpdater] upsert failed: #{e.class}: #{e.message}"
+        @logger.error "[VectorUpdater] upsert failed for merchant=#{merchant.inspect} category=#{category&.id}: #{e.class}: #{e.message}"
         nil
       end
 
@@ -73,7 +73,7 @@ module Services::Categorization
 
         { old_vector: old_vector, new_vector: new_vector }
       rescue => e
-        @logger.error "[VectorUpdater] record_correction failed: #{e.class}: #{e.message}"
+        @logger.error "[VectorUpdater] record_correction failed for merchant=#{merchant.inspect}: #{e.class}: #{e.message}"
         nil
       end
 

--- a/app/services/categorization/learning/vector_updater.rb
+++ b/app/services/categorization/learning/vector_updater.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  module Learning
+    # Maintains categorization_vectors from expense categorization events.
+    #
+    # Called by the categorization pipeline after each expense is categorized,
+    # and when users correct a categorization. Keeps vector occurrence counts,
+    # correction counts, and description keywords up to date for the
+    # similarity-based categorization layer.
+    class VectorUpdater
+      MAX_KEYWORDS = 20
+
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
+      # Create or update a categorization vector for a merchant+category pair.
+      #
+      # @param merchant [String] raw merchant name (will be normalized)
+      # @param category [Category] the category associated with this merchant
+      # @param description_keywords [Array<String>] keywords from expense description
+      # @return [CategorizationVector, nil] the upserted vector, or nil if inputs invalid
+      def upsert(merchant:, category:, description_keywords: [])
+        normalized = normalize(merchant)
+        return nil if normalized.blank? || category.nil?
+
+        vector = CategorizationVector.find_or_initialize_by(
+          merchant_normalized: normalized,
+          category: category
+        )
+
+        if vector.new_record?
+          vector.assign_attributes(
+            occurrence_count: 1,
+            correction_count: 0,
+            confidence: 0.5,
+            description_keywords: Array(description_keywords).first(MAX_KEYWORDS),
+            last_seen_at: Time.current
+          )
+        else
+          vector.occurrence_count += 1
+          vector.last_seen_at = Time.current
+          vector.description_keywords = merge_keywords(vector.description_keywords, description_keywords)
+        end
+
+        vector.save!
+        vector
+      rescue => e
+        @logger.error "[VectorUpdater] upsert failed: #{e.class}: #{e.message}"
+        nil
+      end
+
+      # Record a user correction: bump correction_count on the old vector,
+      # upsert a vector for the new category.
+      #
+      # @param merchant [String] raw merchant name
+      # @param old_category [Category] the category being corrected from
+      # @param new_category [Category] the category being corrected to
+      # @return [Hash, nil] { old_vector:, new_vector: } or nil if inputs invalid
+      def record_correction(merchant:, old_category:, new_category:)
+        normalized = normalize(merchant)
+        return nil if normalized.blank?
+
+        old_vector = CategorizationVector.find_by(
+          merchant_normalized: normalized,
+          category: old_category
+        )
+
+        old_vector&.increment!(:correction_count)
+
+        new_vector = upsert(merchant: merchant, category: new_category)
+
+        { old_vector: old_vector, new_vector: new_vector }
+      rescue => e
+        @logger.error "[VectorUpdater] record_correction failed: #{e.class}: #{e.message}"
+        nil
+      end
+
+      private
+
+      def normalize(merchant)
+        Services::Categorization::MerchantNormalizer.normalize(merchant)
+      end
+
+      def merge_keywords(existing, incoming)
+        (Array(existing) | Array(incoming)).first(MAX_KEYWORDS)
+      end
+    end
+  end
+end

--- a/lib/tasks/categorization_vectors.rake
+++ b/lib/tasks/categorization_vectors.rake
@@ -10,19 +10,42 @@ namespace :categorization do
     total = scope.count
     logger.info "[BackfillVectors] Found #{total} categorizable expenses"
 
+    # Pre-load all categories to avoid N+1 queries
+    category_ids = scope.distinct.pluck(:category_id)
+    categories_by_id = Category.where(id: category_ids).index_by(&:id)
+
     processed = 0
 
+    # Extract keywords from descriptions (local lambda, not global method)
+    extract_keywords = ->(descriptions) {
+      word_counts = Hash.new(0)
+
+      descriptions.each do |desc|
+        next if desc.blank?
+
+        desc.downcase
+            .gsub(/[^a-z0-9\s]/, "")
+            .split
+            .reject { |w| w.length < 3 }
+            .each { |word| word_counts[word] += 1 }
+      end
+
+      word_counts.sort_by { |_word, count| -count }
+                 .first(5)
+                 .map(&:first)
+    }
+
     # Group by normalized merchant + category to batch-create vectors
-    scope.select(:merchant_name, :category_id, :description)
-         .group_by { |e| [ e.merchant_name, e.category_id ] }
+    scope.select(:id, :merchant_name, :category_id, :description)
+         .find_each.group_by { |e| [ e.merchant_name, e.category_id ] }
          .each do |(merchant_name, category_id), expenses|
       normalized = Services::Categorization::MerchantNormalizer.normalize(merchant_name)
       next if normalized.blank?
 
-      category = Category.find_by(id: category_id)
+      category = categories_by_id[category_id]
       next unless category
 
-      keywords = extract_keywords(expenses.map(&:description))
+      keywords = extract_keywords.call(expenses.map(&:description))
 
       vector = CategorizationVector.find_or_initialize_by(
         merchant_normalized: normalized,
@@ -56,26 +79,4 @@ namespace :categorization do
     vector_count = CategorizationVector.count
     logger.info "[BackfillVectors] Done. #{vector_count} vectors in database. #{processed} expenses processed."
   end
-end
-
-# Extract top 5 most common meaningful keywords from descriptions.
-#
-# @param descriptions [Array<String>] expense descriptions
-# @return [Array<String>] top 5 keywords
-def extract_keywords(descriptions)
-  word_counts = Hash.new(0)
-
-  descriptions.each do |desc|
-    next if desc.blank?
-
-    desc.downcase
-        .gsub(/[^a-z0-9\s]/, "")
-        .split
-        .reject { |w| w.length < 3 }
-        .each { |word| word_counts[word] += 1 }
-  end
-
-  word_counts.sort_by { |_word, count| -count }
-             .first(5)
-             .map(&:first)
 end

--- a/lib/tasks/categorization_vectors.rake
+++ b/lib/tasks/categorization_vectors.rake
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+namespace :categorization do
+  desc "Backfill categorization_vectors from existing expenses"
+  task backfill_vectors: :environment do
+    logger = Logger.new($stdout)
+    logger.info "[BackfillVectors] Starting backfill..."
+
+    scope = Expense.where.not(category_id: nil).where.not(merchant_name: [ nil, "" ])
+    total = scope.count
+    logger.info "[BackfillVectors] Found #{total} categorizable expenses"
+
+    processed = 0
+
+    # Group by normalized merchant + category to batch-create vectors
+    scope.select(:merchant_name, :category_id, :description)
+         .group_by { |e| [ e.merchant_name, e.category_id ] }
+         .each do |(merchant_name, category_id), expenses|
+      normalized = Services::Categorization::MerchantNormalizer.normalize(merchant_name)
+      next if normalized.blank?
+
+      category = Category.find_by(id: category_id)
+      next unless category
+
+      keywords = extract_keywords(expenses.map(&:description))
+
+      vector = CategorizationVector.find_or_initialize_by(
+        merchant_normalized: normalized,
+        category_id: category_id
+      )
+
+      if vector.new_record?
+        vector.assign_attributes(
+          occurrence_count: expenses.size,
+          correction_count: 0,
+          confidence: 0.5,
+          description_keywords: keywords,
+          last_seen_at: Time.current
+        )
+      else
+        # Idempotent: set occurrence_count to group size (not increment)
+        # so re-running produces the same result
+        vector.occurrence_count = expenses.size
+        vector.description_keywords = keywords
+        vector.last_seen_at = Time.current
+      end
+
+      vector.save!
+      processed += expenses.size
+
+      if (processed % 500).zero? || processed == total
+        logger.info "[BackfillVectors] Progress: #{processed}/#{total} expenses processed"
+      end
+    end
+
+    vector_count = CategorizationVector.count
+    logger.info "[BackfillVectors] Done. #{vector_count} vectors in database. #{processed} expenses processed."
+  end
+end
+
+# Extract top 5 most common meaningful keywords from descriptions.
+#
+# @param descriptions [Array<String>] expense descriptions
+# @return [Array<String>] top 5 keywords
+def extract_keywords(descriptions)
+  word_counts = Hash.new(0)
+
+  descriptions.each do |desc|
+    next if desc.blank?
+
+    desc.downcase
+        .gsub(/[^a-z0-9\s]/, "")
+        .split
+        .reject { |w| w.length < 3 }
+        .each { |word| word_counts[word] += 1 }
+  end
+
+  word_counts.sort_by { |_word, count| -count }
+             .first(5)
+             .map(&:first)
+end

--- a/spec/services/categorization/learning/vector_updater_spec.rb
+++ b/spec/services/categorization/learning/vector_updater_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::Learning::VectorUpdater, type: :service, unit: true do
+  let(:category) { create(:category) }
+  let(:other_category) { create(:category) }
+  let(:updater) { described_class.new }
+
+  describe "#upsert" do
+    context "when vector does not exist" do
+      it "creates a new categorization vector" do
+        expect {
+          updater.upsert(merchant: "Walmart Escazú", category: category)
+        }.to change(CategorizationVector, :count).by(1)
+      end
+
+      it "normalizes the merchant name" do
+        vector = updater.upsert(merchant: "Walmart Escazú!!", category: category)
+
+        expect(vector.merchant_normalized).to eq("walmart escaz")
+      end
+
+      it "sets default values on new vector" do
+        vector = updater.upsert(merchant: "Walmart", category: category)
+
+        expect(vector.occurrence_count).to eq(1)
+        expect(vector.confidence).to eq(0.5)
+        expect(vector.last_seen_at).to be_within(2.seconds).of(Time.current)
+        expect(vector.correction_count).to eq(0)
+      end
+
+      it "stores description keywords" do
+        vector = updater.upsert(
+          merchant: "Walmart",
+          category: category,
+          description_keywords: %w[groceries food weekly]
+        )
+
+        expect(vector.description_keywords).to eq(%w[groceries food weekly])
+      end
+
+      it "returns the vector record" do
+        result = updater.upsert(merchant: "Walmart", category: category)
+
+        expect(result).to be_a(CategorizationVector)
+        expect(result).to be_persisted
+      end
+    end
+
+    context "when vector already exists" do
+      let!(:existing_vector) do
+        CategorizationVector.create!(
+          merchant_normalized: "walmart",
+          category: category,
+          occurrence_count: 3,
+          correction_count: 1,
+          confidence: 0.5,
+          description_keywords: %w[groceries food],
+          last_seen_at: 1.week.ago
+        )
+      end
+
+      it "increments occurrence_count" do
+        updater.upsert(merchant: "Walmart", category: category)
+
+        expect(existing_vector.reload.occurrence_count).to eq(4)
+      end
+
+      it "updates last_seen_at" do
+        updater.upsert(merchant: "Walmart", category: category)
+
+        expect(existing_vector.reload.last_seen_at).to be_within(2.seconds).of(Time.current)
+      end
+
+      it "merges description keywords without duplicates" do
+        updater.upsert(
+          merchant: "Walmart",
+          category: category,
+          description_keywords: %w[food snacks beverages]
+        )
+
+        expect(existing_vector.reload.description_keywords).to match_array(
+          %w[groceries food snacks beverages]
+        )
+      end
+
+      it "does not create a new record" do
+        expect {
+          updater.upsert(merchant: "Walmart", category: category)
+        }.not_to change(CategorizationVector, :count)
+      end
+    end
+
+    context "keyword cap at 20" do
+      let!(:existing_vector) do
+        CategorizationVector.create!(
+          merchant_normalized: "walmart",
+          category: category,
+          occurrence_count: 1,
+          confidence: 0.5,
+          description_keywords: (1..18).map { |i| "keyword#{i}" },
+          last_seen_at: 1.day.ago
+        )
+      end
+
+      it "caps keywords at 20" do
+        updater.upsert(
+          merchant: "Walmart",
+          category: category,
+          description_keywords: %w[new1 new2 new3 new4 new5]
+        )
+
+        expect(existing_vector.reload.description_keywords.size).to eq(20)
+      end
+    end
+
+    context "with nil or blank merchant" do
+      it "returns nil for nil merchant" do
+        result = updater.upsert(merchant: nil, category: category)
+
+        expect(result).to be_nil
+      end
+
+      it "returns nil for blank merchant" do
+        result = updater.upsert(merchant: "   ", category: category)
+
+        expect(result).to be_nil
+      end
+
+      it "does not create a vector for blank merchant" do
+        expect {
+          updater.upsert(merchant: "", category: category)
+        }.not_to change(CategorizationVector, :count)
+      end
+    end
+
+    context "with nil category" do
+      it "returns nil" do
+        result = updater.upsert(merchant: "Walmart", category: nil)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#record_correction" do
+    context "when old vector exists" do
+      let!(:old_vector) do
+        CategorizationVector.create!(
+          merchant_normalized: "walmart",
+          category: category,
+          occurrence_count: 5,
+          correction_count: 1,
+          confidence: 0.5,
+          description_keywords: [],
+          last_seen_at: 1.day.ago
+        )
+      end
+
+      it "increments correction_count on the old vector" do
+        updater.record_correction(
+          merchant: "Walmart",
+          old_category: category,
+          new_category: other_category
+        )
+
+        expect(old_vector.reload.correction_count).to eq(2)
+      end
+
+      it "creates a new vector for the new category" do
+        expect {
+          updater.record_correction(
+            merchant: "Walmart",
+            old_category: category,
+            new_category: other_category
+          )
+        }.to change(CategorizationVector, :count).by(1)
+      end
+
+      it "returns old_vector and new_vector" do
+        result = updater.record_correction(
+          merchant: "Walmart",
+          old_category: category,
+          new_category: other_category
+        )
+
+        expect(result[:old_vector]).to eq(old_vector)
+        expect(result[:new_vector]).to be_a(CategorizationVector)
+        expect(result[:new_vector].category).to eq(other_category)
+      end
+    end
+
+    context "when old vector does not exist" do
+      it "still creates the new vector" do
+        expect {
+          updater.record_correction(
+            merchant: "Walmart",
+            old_category: category,
+            new_category: other_category
+          )
+        }.to change(CategorizationVector, :count).by(1)
+      end
+
+      it "returns nil for old_vector" do
+        result = updater.record_correction(
+          merchant: "Walmart",
+          old_category: category,
+          new_category: other_category
+        )
+
+        expect(result[:old_vector]).to be_nil
+        expect(result[:new_vector]).to be_a(CategorizationVector)
+      end
+    end
+
+    context "when new vector already exists" do
+      let!(:old_vector) do
+        CategorizationVector.create!(
+          merchant_normalized: "walmart",
+          category: category,
+          occurrence_count: 5,
+          correction_count: 0,
+          confidence: 0.5,
+          description_keywords: [],
+          last_seen_at: 1.day.ago
+        )
+      end
+
+      let!(:existing_new_vector) do
+        CategorizationVector.create!(
+          merchant_normalized: "walmart",
+          category: other_category,
+          occurrence_count: 2,
+          correction_count: 0,
+          confidence: 0.5,
+          description_keywords: [],
+          last_seen_at: 2.days.ago
+        )
+      end
+
+      it "increments the existing new vector instead of creating" do
+        expect {
+          updater.record_correction(
+            merchant: "Walmart",
+            old_category: category,
+            new_category: other_category
+          )
+        }.not_to change(CategorizationVector, :count)
+
+        expect(existing_new_vector.reload.occurrence_count).to eq(3)
+      end
+    end
+
+    context "with nil or blank merchant" do
+      it "returns nil for nil merchant" do
+        result = updater.record_correction(
+          merchant: nil,
+          old_category: category,
+          new_category: other_category
+        )
+
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/categorization/learning/vector_updater_spec.rb
+++ b/spec/services/categorization/learning/vector_updater_spec.rb
@@ -264,4 +264,36 @@ RSpec.describe Services::Categorization::Learning::VectorUpdater, type: :service
       end
     end
   end
+
+  describe "error handling" do
+    it "logs and returns nil when upsert fails" do
+      logger = instance_double(ActiveSupport::Logger)
+      allow(logger).to receive(:error)
+      error_updater = described_class.new(logger: logger)
+
+      allow(CategorizationVector).to receive(:find_or_initialize_by).and_raise(ActiveRecord::RecordInvalid)
+
+      result = error_updater.upsert(merchant: "Walmart", category: category)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:error).with(/upsert failed.*merchant=.*Walmart/)
+    end
+
+    it "logs and returns nil when record_correction fails" do
+      logger = instance_double(ActiveSupport::Logger)
+      allow(logger).to receive(:error)
+      error_updater = described_class.new(logger: logger)
+
+      allow(CategorizationVector).to receive(:find_by).and_raise(ActiveRecord::StatementInvalid)
+
+      result = error_updater.record_correction(
+        merchant: "Walmart",
+        old_category: category,
+        new_category: other_category
+      )
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:error).with(/record_correction failed.*merchant=.*Walmart/)
+    end
+  end
 end

--- a/spec/tasks/categorization_vectors_rake_spec.rb
+++ b/spec/tasks/categorization_vectors_rake_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "categorization:backfill_vectors", type: :task, unit: true do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rake.application.rake_require("tasks/categorization_vectors", [ Rails.root.join("lib").to_s ])
+    Rake::Task.define_task(:environment)
+  end
+
+  before { Rake::Task["categorization:backfill_vectors"].reenable }
+
+  let(:task) { Rake::Task["categorization:backfill_vectors"] }
+  let(:category) { create(:category) }
+  let(:other_category) { create(:category) }
+
+  it "creates vectors from expenses with merchant and category" do
+    create(:expense, merchant_name: "Walmart", category: category, description: "Weekly groceries")
+    create(:expense, merchant_name: "Walmart", category: category, description: "Food groceries shopping")
+
+    expect { task.invoke }.to change(CategorizationVector, :count).by(1)
+
+    vector = CategorizationVector.last
+    expect(vector.merchant_normalized).to eq("walmart")
+    expect(vector.category).to eq(category)
+    expect(vector.occurrence_count).to eq(2)
+  end
+
+  it "creates separate vectors for different categories" do
+    create(:expense, merchant_name: "Walmart", category: category)
+    create(:expense, merchant_name: "Walmart", category: other_category)
+
+    expect { task.invoke }.to change(CategorizationVector, :count).by(2)
+  end
+
+  it "skips expenses without a category" do
+    create(:expense, merchant_name: "Walmart", category: nil)
+
+    expect { task.invoke }.not_to change(CategorizationVector, :count)
+  end
+
+  it "skips expenses without a merchant_name" do
+    create(:expense, merchant_name: nil, category: category)
+    create(:expense, merchant_name: "", category: category)
+
+    expect { task.invoke }.not_to change(CategorizationVector, :count)
+  end
+
+  it "extracts top 5 keywords from descriptions" do
+    5.times { create(:expense, merchant_name: "Walmart", category: category, description: "weekly groceries food shopping supplies") }
+    create(:expense, merchant_name: "Walmart", category: category, description: "extra rare unique")
+
+    task.invoke
+
+    vector = CategorizationVector.find_by(merchant_normalized: "walmart", category: category)
+    expect(vector.description_keywords.size).to be <= 5
+    expect(vector.description_keywords).to include("weekly", "groceries")
+  end
+
+  it "is idempotent — running twice produces the same result" do
+    create(:expense, merchant_name: "Walmart", category: category, description: "groceries")
+
+    task.invoke
+    first_count = CategorizationVector.count
+    first_vector = CategorizationVector.last.attributes.except("updated_at", "last_seen_at")
+
+    task.reenable
+    task.invoke
+    second_count = CategorizationVector.count
+    second_vector = CategorizationVector.last.attributes.except("updated_at", "last_seen_at")
+
+    expect(second_count).to eq(first_count)
+    expect(second_vector).to eq(first_vector)
+  end
+end


### PR DESCRIPTION
## Summary
- Create `Services::Categorization::Learning::VectorUpdater` with `upsert()` and `record_correction()` methods
- `upsert()`: find-or-create vectors, increment occurrence_count, merge keywords (capped at 20)
- `record_correction()`: increment correction_count on old vector, upsert new category vector
- Add `categorization:backfill_vectors` rake task — idempotent backfill from historical expenses
- Extracts top 5 keywords from descriptions per merchant

## Test plan
- [x] 21 VectorUpdater unit specs (upsert, correction, edge cases)
- [x] 6 rake task specs (creation, categories, nil handling, keywords, idempotency)
- [x] Full unit suite: 7417 examples, 0 failures
- [x] RuboCop: 0 offenses
- [x] Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)