### PR TITLE
feat: Problem Merchants watchlist in admin dashboard (PER-471)

### DIFF
--- a/app/controllers/admin/categorization_metrics_controller.rb
+++ b/app/controllers/admin/categorization_metrics_controller.rb
@@ -7,6 +7,7 @@ module Admin
       service = Services::Categorization::Monitoring::MetricsDashboardService.new
       @overview = service.overview
       @layer_performance = service.layer_performance
+      @problem_merchants = service.problem_merchants
     end
   end
 end

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -49,11 +49,12 @@ module Services::Categorization
           end
       end
 
-      def problem_merchants(period: 30.days)
+      def problem_merchants(period: 30.days, limit: 20)
         CategorizationVector
           .includes(:category)
           .where(correction_count: 2.., last_seen_at: period.ago..)
           .order(correction_count: :desc)
+          .limit(limit)
           .map do |vector|
             {
               merchant: vector.merchant_normalized,

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -49,6 +49,21 @@ module Services::Categorization
           end
       end
 
+      def problem_merchants(period: 30.days)
+        CategorizationVector
+          .includes(:category)
+          .where(correction_count: 2.., last_seen_at: period.ago..)
+          .order(correction_count: :desc)
+          .map do |vector|
+            {
+              merchant: vector.merchant_normalized,
+              category_name: vector.category.display_name,
+              correction_count: vector.correction_count,
+              last_seen_at: vector.last_seen_at
+            }
+          end
+      end
+
       private
 
       def empty_overview

--- a/app/views/admin/categorization_metrics/index.html.erb
+++ b/app/views/admin/categorization_metrics/index.html.erb
@@ -132,5 +132,57 @@
         </table>
       </div>
     </div>
+
+    <!-- Problem Merchants -->
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden mt-6">
+      <div class="px-6 py-4 border-b border-slate-200">
+        <h2 class="text-lg font-semibold text-slate-900">Problem Merchants</h2>
+        <p class="text-sm text-slate-500 mt-1">Merchants with repeated categorization corrections (30 days)</p>
+      </div>
+      <% if @problem_merchants.empty? %>
+        <div class="p-8 text-center">
+          <div class="bg-emerald-100 text-emerald-600 p-3 rounded-full inline-block mb-3">
+            <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+          </div>
+          <p class="text-slate-500">No problem merchants in the last 30 days.</p>
+        </div>
+      <% else %>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-200">
+            <thead class="bg-slate-50">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Merchant</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Current Category</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Corrections (30d)</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Last Seen</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-slate-200">
+              <% @problem_merchants.each do |row| %>
+                <tr class="<%= 'bg-rose-50' if row[:correction_count] >= 3 %>">
+                  <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-slate-900"><%= row[:merchant] %></td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-700"><%= row[:category_name] %></td>
+                  <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                      <%= row[:correction_count] >= 3 ? 'bg-rose-100 text-rose-800' : 'bg-amber-100 text-amber-800' %>">
+                      <%= row[:correction_count] %>
+                    </span>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500"><%= time_ago_in_words(row[:last_seen_at]) %> ago</td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm">
+                    <%= link_to "View Expenses", expenses_path(search: row[:merchant]),
+                          class: "text-teal-600 hover:text-teal-800 font-medium" %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/spec/controllers/admin/categorization_metrics_controller_spec.rb
+++ b/spec/controllers/admin/categorization_metrics_controller_spec.rb
@@ -22,11 +22,19 @@ RSpec.describe Admin::CategorizationMetricsController, type: :controller, unit: 
       ]
     end
 
+    let(:problem_merchants_data) do
+      [
+        { merchant: "walmart", category_name: "Groceries", correction_count: 5,
+          last_seen_at: 3.days.ago }
+      ]
+    end
+
     before do
       service = instance_double(Services::Categorization::Monitoring::MetricsDashboardService)
       allow(Services::Categorization::Monitoring::MetricsDashboardService).to receive(:new).and_return(service)
       allow(service).to receive(:overview).and_return(overview_data)
       allow(service).to receive(:layer_performance).and_return(layer_data)
+      allow(service).to receive(:problem_merchants).and_return(problem_merchants_data)
     end
 
     it "returns http success" do
@@ -42,6 +50,11 @@ RSpec.describe Admin::CategorizationMetricsController, type: :controller, unit: 
     it "assigns layer performance data" do
       get :index
       expect(assigns(:layer_performance)).to eq(layer_data)
+    end
+
+    it "assigns problem merchants data" do
+      get :index
+      expect(assigns(:problem_merchants)).to eq(problem_merchants_data)
     end
 
     it "renders the index template" do

--- a/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
+++ b/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
@@ -154,4 +154,118 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
       end
     end
   end
+
+  describe "#problem_merchants" do
+    context "with no vectors meeting threshold" do
+      it "returns an empty array" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "with vectors below correction threshold" do
+      before do
+        create(:categorization_vector, correction_count: 1, last_seen_at: 5.days.ago)
+      end
+
+      it "excludes merchants with fewer than 2 corrections" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "with vectors outside period" do
+      before do
+        create(:categorization_vector, correction_count: 3, last_seen_at: 60.days.ago)
+      end
+
+      it "excludes merchants outside the period" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "with problem merchants" do
+      let(:category) { create(:category, name: "Groceries") }
+      let(:category2) { create(:category, name: "Transport") }
+
+      before do
+        create(:categorization_vector,
+          merchant_normalized: "walmart",
+          category: category,
+          correction_count: 5,
+          last_seen_at: 3.days.ago)
+        create(:categorization_vector,
+          merchant_normalized: "uber",
+          category: category2,
+          correction_count: 2,
+          last_seen_at: 10.days.ago)
+        # Below threshold - should be excluded
+        create(:categorization_vector,
+          merchant_normalized: "starbucks",
+          correction_count: 1,
+          last_seen_at: 2.days.ago)
+      end
+
+      it "returns merchants with correction_count >= 2" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.length).to eq(2)
+      end
+
+      it "sorts by correction_count descending" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.first[:merchant]).to eq("walmart")
+        expect(result.last[:merchant]).to eq("uber")
+      end
+
+      it "includes merchant name" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.first[:merchant]).to eq("walmart")
+      end
+
+      it "includes category display_name" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.first[:category_name]).to eq(category.display_name)
+      end
+
+      it "includes correction_count" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.first[:correction_count]).to eq(5)
+      end
+
+      it "includes last_seen_at" do
+        result = service.problem_merchants(period: 30.days)
+
+        expect(result.first[:last_seen_at]).to be_within(1.second).of(3.days.ago)
+      end
+    end
+
+    context "with custom period" do
+      before do
+        create(:categorization_vector,
+          merchant_normalized: "recent_merchant",
+          correction_count: 3,
+          last_seen_at: 5.days.ago)
+        create(:categorization_vector,
+          merchant_normalized: "old_merchant",
+          correction_count: 3,
+          last_seen_at: 15.days.ago)
+      end
+
+      it "respects the period parameter" do
+        result = service.problem_merchants(period: 10.days)
+
+        expect(result.length).to eq(1)
+        expect(result.first[:merchant]).to eq("recent_merchant")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add Problem Merchants section to `/admin/categorization_metrics` dashboard
- Table showing merchants with 2+ corrections in 30 days (three-strike watchlist)
- Rows with 3+ corrections highlighted in rose
- "View Expenses" link filtered by merchant name
- `MetricsDashboardService#problem_merchants` with period filtering
- Empty state with emerald checkmark

## Test plan
- [x] 10 new service specs for problem_merchants
- [x] Controller spec updated for @problem_merchants
- [x] Full unit suite: 7467 examples, 0 failures
- [x] RuboCop: 0 offenses, Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)