### PR TITLE
feat: weekly metrics summary job + ONNX trigger warnings (PER-476)

### DIFF
--- a/app/jobs/categorization_metrics_summary_job.rb
+++ b/app/jobs/categorization_metrics_summary_job.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Weekly background job that computes categorization performance summaries
+# and tracks ONNX evaluation trigger warnings.
+#
+# Computes per-layer accuracy, LLM fallback rate, user correction rate,
+# total API spend, and average confidence for the past 7 days.
+#
+# Tracks consecutive weeks of poor performance and logs warnings when
+# thresholds are sustained, recommending ONNX model evaluation.
+#
+# Runs weekly via Solid Queue recurring schedule (Sundays at 6am).
+#
+# Usage:
+#   CategorizationMetricsSummaryJob.perform_now   # Run immediately
+#   CategorizationMetricsSummaryJob.perform_later  # Enqueue for background execution
+class CategorizationMetricsSummaryJob < ApplicationJob
+  queue_as :low
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  REPORT_PERIOD = 7.days
+  FALLBACK_RATE_THRESHOLD = 0.15
+  CORRECTION_RATE_THRESHOLD = 0.10
+  WARNING_WEEKS = 3
+  STRONG_RECOMMENDATION_WEEKS = 12
+  COUNTER_TTL = 90.days
+
+  FALLBACK_COUNTER_KEY = "onnx_trigger:fallback_weeks"
+  CORRECTION_COUNTER_KEY = "onnx_trigger:correction_weeks"
+
+  def perform
+    metrics = CategorizationMetric.recent(REPORT_PERIOD)
+    total = metrics.count
+
+    if total.zero?
+      Rails.logger.info "[MetricsSummary] No categorization metrics found for the past #{REPORT_PERIOD.in_days.to_i} days"
+      return
+    end
+
+    summary = compute_summary(metrics, total)
+    log_summary(summary)
+    evaluate_onnx_triggers(summary)
+  end
+
+  private
+
+  def compute_summary(metrics, total)
+    corrections = metrics.corrected.count
+    haiku_count = metrics.for_layer("haiku").count
+    api_spend = metrics.sum(:api_cost)
+
+    layer_stats = compute_layer_stats(metrics)
+
+    {
+      total: total,
+      corrections: corrections,
+      haiku_count: haiku_count,
+      fallback_rate: haiku_count.to_f / total,
+      correction_rate: corrections.to_f / total,
+      api_spend: api_spend,
+      layer_stats: layer_stats
+    }
+  end
+
+  def compute_layer_stats(metrics)
+    layers = metrics.group(:layer_used).count
+    corrections_by_layer = metrics.corrected.group(:layer_used).count
+    confidence_by_layer = metrics.group(:layer_used).average(:confidence)
+
+    layers.each_with_object({}) do |(layer, count), stats|
+      corrected = corrections_by_layer[layer] || 0
+      accuracy = ((count - corrected).to_f / count * 100).round(1)
+      avg_confidence = confidence_by_layer[layer]&.round(4) || 0.0
+
+      stats[layer] = {
+        total: count,
+        corrected: corrected,
+        accuracy: accuracy,
+        avg_confidence: avg_confidence
+      }
+    end
+  end
+
+  def log_summary(summary)
+    Rails.logger.info "[MetricsSummary] === Weekly Categorization Metrics Report ==="
+    Rails.logger.info "[MetricsSummary] Period: past #{REPORT_PERIOD.in_days.to_i} days | Total: #{summary[:total]}"
+    Rails.logger.info "[MetricsSummary] Fallback rate: #{format_pct(summary[:fallback_rate])} " \
+                      "(#{summary[:haiku_count]} haiku / #{summary[:total]} total)"
+    Rails.logger.info "[MetricsSummary] Correction rate: #{format_pct(summary[:correction_rate])} " \
+                      "(#{summary[:corrections]} / #{summary[:total]} total)"
+    Rails.logger.info "[MetricsSummary] API spend: #{summary[:api_spend]}"
+
+    summary[:layer_stats].each do |layer, stats|
+      Rails.logger.info "[MetricsSummary] Layer #{layer}: accuracy=#{stats[:accuracy]}% " \
+                        "total=#{stats[:total]} corrected=#{stats[:corrected]} " \
+                        "avg_confidence=#{stats[:avg_confidence]}"
+    end
+  end
+
+  def evaluate_onnx_triggers(summary)
+    evaluate_fallback_trigger(summary[:fallback_rate])
+    evaluate_correction_trigger(summary[:correction_rate])
+    check_strong_recommendation
+  end
+
+  def evaluate_fallback_trigger(fallback_rate)
+    if fallback_rate > FALLBACK_RATE_THRESHOLD
+      counter = increment_counter(FALLBACK_COUNTER_KEY)
+      if counter >= WARNING_WEEKS
+        Rails.logger.warn "[MetricsSummary] ONNX WARNING: High fallback rate sustained for " \
+                          "#{counter} consecutive weeks. Consider evaluating ONNX model deployment."
+      end
+    else
+      reset_counter(FALLBACK_COUNTER_KEY)
+    end
+  end
+
+  def evaluate_correction_trigger(correction_rate)
+    if correction_rate > CORRECTION_RATE_THRESHOLD
+      counter = increment_counter(CORRECTION_COUNTER_KEY)
+      if counter >= WARNING_WEEKS
+        Rails.logger.warn "[MetricsSummary] ONNX WARNING: High correction rate sustained for " \
+                          "#{counter} consecutive weeks. Consider evaluating ONNX model deployment."
+      end
+    else
+      reset_counter(CORRECTION_COUNTER_KEY)
+    end
+  end
+
+  def check_strong_recommendation
+    fallback_weeks = Rails.cache.read(FALLBACK_COUNTER_KEY) || 0
+    correction_weeks = Rails.cache.read(CORRECTION_COUNTER_KEY) || 0
+
+    return unless fallback_weeks >= STRONG_RECOMMENDATION_WEEKS && correction_weeks >= STRONG_RECOMMENDATION_WEEKS
+
+    Rails.logger.warn "[MetricsSummary] STRONG RECOMMENDATION: Both fallback and correction rates " \
+                      "have been elevated for #{STRONG_RECOMMENDATION_WEEKS} weeks. " \
+                      "Strongly recommend evaluating ONNX model deployment to reduce API costs and improve accuracy."
+  end
+
+  def increment_counter(key)
+    current = Rails.cache.read(key) || 0
+    new_value = current + 1
+    Rails.cache.write(key, new_value, expires_in: COUNTER_TTL)
+    new_value
+  end
+
+  def reset_counter(key)
+    Rails.cache.write(key, 0, expires_in: COUNTER_TTL)
+  end
+
+  def format_pct(rate)
+    "#{(rate * 100).round(1)}%"
+  end
+end

--- a/app/jobs/categorization_metrics_summary_job.rb
+++ b/app/jobs/categorization_metrics_summary_job.rb
@@ -98,32 +98,22 @@ class CategorizationMetricsSummaryJob < ApplicationJob
   end
 
   def evaluate_onnx_triggers(summary)
-    evaluate_fallback_trigger(summary[:fallback_rate])
-    evaluate_correction_trigger(summary[:correction_rate])
+    evaluate_trigger(rate: summary[:fallback_rate], threshold: FALLBACK_RATE_THRESHOLD,
+                     counter_key: FALLBACK_COUNTER_KEY, label: "fallback")
+    evaluate_trigger(rate: summary[:correction_rate], threshold: CORRECTION_RATE_THRESHOLD,
+                     counter_key: CORRECTION_COUNTER_KEY, label: "correction")
     check_strong_recommendation
   end
 
-  def evaluate_fallback_trigger(fallback_rate)
-    if fallback_rate > FALLBACK_RATE_THRESHOLD
-      counter = increment_counter(FALLBACK_COUNTER_KEY)
+  def evaluate_trigger(rate:, threshold:, counter_key:, label:)
+    if rate > threshold
+      counter = increment_counter(counter_key)
       if counter >= WARNING_WEEKS
-        Rails.logger.warn "[MetricsSummary] ONNX WARNING: High fallback rate sustained for " \
+        Rails.logger.warn "[MetricsSummary] ONNX WARNING: High #{label} rate sustained for " \
                           "#{counter} consecutive weeks. Consider evaluating ONNX model deployment."
       end
     else
-      reset_counter(FALLBACK_COUNTER_KEY)
-    end
-  end
-
-  def evaluate_correction_trigger(correction_rate)
-    if correction_rate > CORRECTION_RATE_THRESHOLD
-      counter = increment_counter(CORRECTION_COUNTER_KEY)
-      if counter >= WARNING_WEEKS
-        Rails.logger.warn "[MetricsSummary] ONNX WARNING: High correction rate sustained for " \
-                          "#{counter} consecutive weeks. Consider evaluating ONNX model deployment."
-      end
-    else
-      reset_counter(CORRECTION_COUNTER_KEY)
+      reset_counter(counter_key)
     end
   end
 
@@ -139,10 +129,13 @@ class CategorizationMetricsSummaryJob < ApplicationJob
   end
 
   def increment_counter(key)
-    current = Rails.cache.read(key) || 0
-    new_value = current + 1
-    Rails.cache.write(key, new_value, expires_in: COUNTER_TTL)
-    new_value
+    # Use atomic increment when available (Solid Cache supports it)
+    result = Rails.cache.increment(key, 1, expires_in: COUNTER_TTL)
+    return result if result
+
+    # Fallback: initialize counter if it doesn't exist yet
+    Rails.cache.write(key, 1, expires_in: COUNTER_TTL)
+    1
   end
 
   def reset_counter(key)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -49,6 +49,14 @@ default: &default
     schedule: every month
     description: "Remove stale categorization vectors not seen in 6+ months"
 
+  # Weekly categorization metrics summary with ONNX trigger warnings
+  categorization_metrics_summary:
+    class: CategorizationMetricsSummaryJob
+    queue: low
+    priority: 10
+    schedule: every Sunday at 6am
+    description: "Compute weekly categorization performance summary and evaluate ONNX trigger warnings"
+
   # Run data quality audit daily to check pattern coverage and detect issues
   data_quality_audit:
     class: DataQualityAuditJob

--- a/lib/tasks/categorization_metrics.rake
+++ b/lib/tasks/categorization_metrics.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :categorization do
+  desc "Print categorization metrics summary report for the past 7 days"
+  task metrics_report: :environment do
+    CategorizationMetricsSummaryJob.perform_now
+  end
+end

--- a/spec/jobs/categorization_metrics_summary_job_spec.rb
+++ b/spec/jobs/categorization_metrics_summary_job_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CategorizationMetricsSummaryJob, :unit, type: :job do
+  subject(:job) { described_class.new }
+
+  let(:category) { create(:category) }
+  let(:other_category) { create(:category) }
+
+  def create_metric(layer:, corrected: false, confidence: 0.85, api_cost: 0.0, created_at: 2.days.ago)
+    expense = create(:expense)
+    traits = []
+    traits << :corrected if corrected
+    attrs = {
+      expense: expense,
+      category: category,
+      layer_used: layer,
+      confidence: confidence,
+      api_cost: api_cost,
+      created_at: created_at
+    }
+    if corrected
+      attrs[:was_corrected] = true
+      attrs[:corrected_to_category] = other_category
+      attrs[:time_to_correction_hours] = 2
+    end
+    create(:categorization_metric, **attrs)
+  end
+
+  before do
+    # Clear any ONNX trigger counters
+    Rails.cache.delete("onnx_trigger:fallback_weeks")
+    Rails.cache.delete("onnx_trigger:correction_weeks")
+  end
+
+  describe "#perform" do
+    context "with no metrics in the past 7 days" do
+      it "logs that no data was found" do
+        expect(Rails.logger).to receive(:info).with(/No categorization metrics found/)
+        job.perform
+      end
+    end
+
+    context "with metrics from older than 7 days" do
+      before do
+        create_metric(layer: "pattern", created_at: 10.days.ago)
+      end
+
+      it "does not include them in the summary" do
+        expect(Rails.logger).to receive(:info).with(/No categorization metrics found/)
+        job.perform
+      end
+    end
+
+    context "with per-layer accuracy computation" do
+      before do
+        # pattern layer: 8 total, 2 corrected => accuracy 75%
+        6.times { create_metric(layer: "pattern") }
+        2.times { create_metric(layer: "pattern", corrected: true) }
+
+        # pg_trgm layer: 4 total, 1 corrected => accuracy 75%
+        3.times { create_metric(layer: "pg_trgm") }
+        1.times { create_metric(layer: "pg_trgm", corrected: true) }
+
+        # haiku layer: 3 total, 0 corrected => accuracy 100%
+        3.times { create_metric(layer: "haiku", api_cost: 0.001) }
+      end
+
+      it "computes correct per-layer accuracy" do
+        expect(Rails.logger).to receive(:info).with(/pattern.*75\.0%/).at_least(:once)
+        expect(Rails.logger).to receive(:info).with(/pg_trgm.*75\.0%/).at_least(:once)
+        expect(Rails.logger).to receive(:info).with(/haiku.*100\.0%/).at_least(:once)
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+      end
+
+      it "computes LLM fallback rate" do
+        # haiku_count = 3, total = 15 => 20%
+        expect(Rails.logger).to receive(:info).with(/Fallback rate.*20\.0%/).at_least(:once)
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+      end
+
+      it "computes user correction rate" do
+        # corrections = 3, total = 15 => 20%
+        expect(Rails.logger).to receive(:info).with(/Correction rate.*20\.0%/).at_least(:once)
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+      end
+
+      it "computes total API spend" do
+        # 3 haiku metrics * 0.001 = 0.003
+        expect(Rails.logger).to receive(:info).with(/API spend.*0\.003/).at_least(:once)
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+      end
+
+      it "computes average confidence per layer" do
+        expect(Rails.logger).to receive(:info).with(/pattern.*avg_confidence/).at_least(:once)
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+      end
+    end
+
+    it "logs summary at info level" do
+      create_metric(layer: "pattern")
+
+      allow(Rails.logger).to receive(:info)
+      job.perform
+
+      expect(Rails.logger).to have_received(:info).at_least(:once)
+    end
+  end
+
+  describe "ONNX trigger warnings" do
+    context "when fallback rate exceeds 15%" do
+      before do
+        # 5 haiku out of 10 total => 50% fallback rate
+        5.times { create_metric(layer: "haiku", api_cost: 0.001) }
+        5.times { create_metric(layer: "pattern") }
+      end
+
+      it "increments the fallback weeks counter" do
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+
+        job.perform
+
+        expect(Rails.cache.read("onnx_trigger:fallback_weeks")).to eq(1)
+      end
+    end
+
+    context "when correction rate exceeds 10%" do
+      before do
+        # 3 corrected out of 10 total => 30% correction rate
+        7.times { create_metric(layer: "pattern") }
+        3.times { create_metric(layer: "pattern", corrected: true) }
+      end
+
+      it "increments the correction weeks counter" do
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+
+        job.perform
+
+        expect(Rails.cache.read("onnx_trigger:correction_weeks")).to eq(1)
+      end
+    end
+
+    context "when metrics return to healthy range" do
+      before do
+        Rails.cache.write("onnx_trigger:fallback_weeks", 2, expires_in: 90.days)
+        Rails.cache.write("onnx_trigger:correction_weeks", 2, expires_in: 90.days)
+
+        # All pattern, no corrections => healthy
+        10.times { create_metric(layer: "pattern") }
+      end
+
+      it "resets fallback counter to zero" do
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+
+        expect(Rails.cache.read("onnx_trigger:fallback_weeks")).to eq(0)
+      end
+
+      it "resets correction counter to zero" do
+        allow(Rails.logger).to receive(:info)
+
+        job.perform
+
+        expect(Rails.cache.read("onnx_trigger:correction_weeks")).to eq(0)
+      end
+    end
+
+    context "when fallback counter reaches 3 consecutive weeks" do
+      before do
+        Rails.cache.write("onnx_trigger:fallback_weeks", 2, expires_in: 90.days)
+
+        # High fallback rate to trigger increment to 3
+        8.times { create_metric(layer: "haiku", api_cost: 0.001) }
+        2.times { create_metric(layer: "pattern") }
+      end
+
+      it "logs a warning about sustained high fallback rate" do
+        allow(Rails.logger).to receive(:info)
+
+        expect(Rails.logger).to receive(:warn).with(/ONNX.*fallback rate.*3 consecutive weeks/)
+
+        job.perform
+      end
+    end
+
+    context "when correction counter reaches 3 consecutive weeks" do
+      before do
+        Rails.cache.write("onnx_trigger:correction_weeks", 2, expires_in: 90.days)
+
+        # High correction rate to trigger increment to 3
+        5.times { create_metric(layer: "pattern") }
+        5.times { create_metric(layer: "pattern", corrected: true) }
+      end
+
+      it "logs a warning about sustained high correction rate" do
+        allow(Rails.logger).to receive(:info)
+
+        expect(Rails.logger).to receive(:warn).with(/ONNX.*correction rate.*3 consecutive weeks/)
+
+        job.perform
+      end
+    end
+
+    context "when both counters reach 12 consecutive weeks" do
+      before do
+        Rails.cache.write("onnx_trigger:fallback_weeks", 11, expires_in: 90.days)
+        Rails.cache.write("onnx_trigger:correction_weeks", 11, expires_in: 90.days)
+
+        # Both high fallback and high correction
+        5.times { create_metric(layer: "haiku", api_cost: 0.001) }
+        3.times { create_metric(layer: "pattern") }
+        2.times { create_metric(layer: "pattern", corrected: true) }
+      end
+
+      it "logs a strong recommendation to evaluate ONNX" do
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+
+        job.perform
+
+        expect(Rails.logger).to have_received(:warn).with(/STRONG RECOMMENDATION.*12 weeks.*ONNX/)
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "is enqueued in the low queue" do
+      expect(described_class.new.queue_name).to eq("low")
+    end
+
+    it "inherits from ApplicationJob" do
+      expect(described_class.superclass).to eq(ApplicationJob)
+    end
+  end
+end

--- a/spec/tasks/categorization_metrics_rake_spec.rb
+++ b/spec/tasks/categorization_metrics_rake_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "categorization:metrics_report", :unit, type: :task do
+  let(:rake) { Rake::Application.new }
+
+  before do
+    Rake.application = rake
+    Rake::Task.define_task(:environment)
+    load Rails.root.join("lib/tasks/categorization_metrics.rake")
+  end
+
+  it "invokes CategorizationMetricsSummaryJob.perform_now" do
+    allow(CategorizationMetricsSummaryJob).to receive(:perform_now)
+
+    Rake::Task["categorization:metrics_report"].invoke
+
+    expect(CategorizationMetricsSummaryJob).to have_received(:perform_now)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `CategorizationMetricsSummaryJob` (weekly, Sundays at 6am)
- Computes per-layer accuracy, fallback rate, correction rate, API spend, avg confidence
- ONNX evaluation trigger: warns at 3 consecutive weeks of poor metrics, strong recommendation at 12 weeks
- Add `categorization:metrics_report` rake task for on-demand summaries
- Registered in `config/recurring.yml` for Solid Queue

## Test plan
- [x] 17 job unit specs + 1 rake task spec
- [x] Full unit suite: 7474 examples, 0 failures
- [x] RuboCop: 0 offenses, Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)