### PR TITLE
feat: LlmStrategy + Engine assembly with all 3 layers (PER-475)

### DIFF
--- a/app/services/categorization/engine.rb
+++ b/app/services/categorization/engine.rb
@@ -6,6 +6,8 @@ require_relative "ml_confidence_integration"
 require_relative "service_registry"
 require_relative "strategies/base_strategy"
 require_relative "strategies/pattern_strategy"
+require_relative "strategies/similarity_strategy"
+require_relative "strategies/llm_strategy"
 require_relative "learning/metrics_recorder"
 require_relative "learning/correction_handler"
 
@@ -582,7 +584,9 @@ module Services::Categorization
           fuzzy_matcher: @fuzzy_matcher,
           confidence_calculator: @confidence_calculator,
           logger: @logger
-        )
+        ),
+        Strategies::SimilarityStrategy.new(logger: @logger),
+        Strategies::LlmStrategy.new(logger: @logger)
       ]
     end
 

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -89,7 +89,7 @@ module Services::Categorization
         build_llm_result(parsed, duration_ms(start_time))
       end
 
-      def store_cache(normalized, parsed, api_result, total_tokens, existing_entry)
+      def store_cache(normalized, parsed, api_result, total_tokens, _existing_entry)
         attrs = {
           category: parsed[:category],
           confidence: parsed[:confidence],
@@ -99,11 +99,14 @@ module Services::Categorization
           expires_at: CACHE_TTL.from_now
         }
 
-        if existing_entry
-          existing_entry.update!(attrs)
-        else
-          LlmCategorizationCacheEntry.create!(attrs.merge(merchant_normalized: normalized))
+        # Use find_or_create + update to handle concurrent requests safely.
+        # Rescues RecordNotUnique from the unique index on merchant_normalized.
+        entry = LlmCategorizationCacheEntry.find_or_create_by!(merchant_normalized: normalized) do |e|
+          e.assign_attributes(attrs)
         end
+        entry.update!(attrs) unless entry.previously_new_record?
+      rescue ActiveRecord::RecordNotUnique
+        LlmCategorizationCacheEntry.find_by!(merchant_normalized: normalized).update!(attrs)
       end
 
       def feed_vector_updater(expense, category)

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module Services::Categorization
+  module Strategies
+    # Layer 3 categorization strategy that uses an LLM (Claude Haiku) to
+    # categorize expenses when pattern matching (Layer 1) and similarity
+    # matching (Layer 2) fail to produce a confident result.
+    #
+    # Implements a cache-first approach: checks LlmCategorizationCacheEntry
+    # before making an API call. Successful results are cached for 90 days
+    # and fed into VectorUpdater so Layer 2 can learn from them.
+    class LlmStrategy < BaseStrategy
+      CACHE_TTL = 90.days
+
+      # @param client [Llm::Client, nil] injectable LLM client for testing
+      # @param logger [Logger]
+      def initialize(client: nil, logger: Rails.logger)
+        @client = client
+        @logger = logger
+      end
+
+      # @return [String]
+      def layer_name
+        "haiku"
+      end
+
+      # Attempt to categorize an expense via LLM with cache lookup.
+      #
+      # @param expense [Expense]
+      # @param _options [Hash] unused
+      # @return [CategorizationResult]
+      def call(expense, _options = {})
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        normalized = normalize_merchant(expense)
+        if normalized.blank?
+          return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+        end
+
+        # Check cache first
+        cached = lookup_cache(normalized)
+        if cached && !cached.expired?
+          cached.refresh_ttl!(CACHE_TTL)
+          return build_cached_result(cached, duration_ms(start_time))
+        end
+
+        # Cache miss or expired — call LLM
+        call_llm_and_cache(expense, normalized, cached, start_time)
+      rescue Llm::Client::Error => e
+        @logger.error "[LlmStrategy] LLM client error: #{e.message}"
+        CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+      end
+
+      private
+
+      def client
+        @client ||= Llm::Client.new
+      end
+
+      def normalize_merchant(expense)
+        return "" unless expense.merchant_name?
+
+        MerchantNormalizer.normalize(expense.merchant_name)
+      end
+
+      def lookup_cache(normalized)
+        LlmCategorizationCacheEntry.find_by(merchant_normalized: normalized)
+      end
+
+      def call_llm_and_cache(expense, normalized, existing_entry, start_time)
+        prompt = Llm::PromptBuilder.new.build(expense: expense)
+        api_result = client.categorize(prompt_text: prompt)
+
+        parsed = Llm::ResponseParser.new.parse(response_text: api_result[:response_text])
+
+        # If parser found no category, return no_match
+        unless parsed[:category]
+          return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+        end
+
+        total_tokens = api_result[:token_count][:input] + api_result[:token_count][:output]
+
+        # Store or update cache
+        store_cache(normalized, parsed, api_result, total_tokens, existing_entry)
+
+        # Feed Layer 2 so similarity strategy learns from LLM results
+        feed_vector_updater(expense, parsed[:category])
+
+        build_llm_result(parsed, duration_ms(start_time))
+      end
+
+      def store_cache(normalized, parsed, api_result, total_tokens, existing_entry)
+        attrs = {
+          category: parsed[:category],
+          confidence: parsed[:confidence],
+          model_used: Llm::Client::MODEL,
+          token_count: total_tokens,
+          cost: api_result[:cost],
+          expires_at: CACHE_TTL.from_now
+        }
+
+        if existing_entry
+          existing_entry.update!(attrs)
+        else
+          LlmCategorizationCacheEntry.create!(attrs.merge(merchant_normalized: normalized))
+        end
+      end
+
+      def feed_vector_updater(expense, category)
+        Learning::VectorUpdater.new.upsert(
+          merchant: expense.merchant_name,
+          category: category,
+          description_keywords: []
+        )
+      rescue StandardError => e
+        @logger.warn "[LlmStrategy] VectorUpdater failed: #{e.message}"
+      end
+
+      def build_cached_result(cache_entry, processing_time_ms)
+        CategorizationResult.new(
+          category: cache_entry.category,
+          confidence: cache_entry.confidence,
+          method: "llm_haiku",
+          patterns_used: [ "llm_cache:#{cache_entry.merchant_normalized}" ],
+          processing_time_ms: processing_time_ms,
+          metadata: {
+            cache_hit: true,
+            merchant_normalized: cache_entry.merchant_normalized
+          }
+        )
+      end
+
+      def build_llm_result(parsed, processing_time_ms)
+        CategorizationResult.new(
+          category: parsed[:category],
+          confidence: parsed[:confidence],
+          method: "llm_haiku",
+          patterns_used: [ "llm_api" ],
+          processing_time_ms: processing_time_ms,
+          metadata: {
+            cache_hit: false,
+            model_used: Llm::Client::MODEL
+          }
+        )
+      end
+
+      def duration_ms(start_time)
+        (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
+      end
+    end
+  end
+end

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -1,0 +1,307 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
+  subject(:strategy) { described_class.new(client: mock_client, logger: logger) }
+
+  let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:mock_client) { instance_double(Services::Categorization::Llm::Client) }
+  let(:category) { create(:category) }
+  let(:expense) { create(:expense, merchant_name: "Automercado San Pedro", description: "groceries") }
+  let(:normalized_merchant) { Services::Categorization::MerchantNormalizer.normalize(expense.merchant_name) }
+
+  describe "#layer_name" do
+    it "returns 'haiku'" do
+      expect(strategy.layer_name).to eq("haiku")
+    end
+  end
+
+  describe "BaseStrategy interface" do
+    it "inherits from BaseStrategy" do
+      expect(described_class.superclass).to eq(Services::Categorization::Strategies::BaseStrategy)
+    end
+
+    it "responds to #call" do
+      expect(strategy).to respond_to(:call)
+    end
+
+    it "responds to #layer_name" do
+      expect(strategy).to respond_to(:layer_name)
+    end
+  end
+
+  describe "#call" do
+    context "when expense has no merchant_name" do
+      let(:expense) { create(:expense, merchant_name: nil, description: "some payment") }
+
+      it "returns no_match without calling the API" do
+        result = strategy.call(expense)
+
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+        expect(mock_client).not_to have_received(:categorize) if mock_client.respond_to?(:categorize)
+      end
+    end
+
+    context "when expense has blank merchant_name" do
+      let(:expense) { create(:expense, merchant_name: "", description: "some payment") }
+
+      it "returns no_match" do
+        result = strategy.call(expense)
+
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+    end
+
+    context "when cache hit exists (not expired)" do
+      let!(:cache_entry) do
+        create(:llm_categorization_cache_entry,
+          merchant_normalized: normalized_merchant,
+          category: category,
+          confidence: 0.85,
+          model_used: "claude-haiku-4-5",
+          token_count: 100,
+          cost: 0.001,
+          expires_at: 30.days.from_now)
+      end
+
+      it "returns cached result without calling the API" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+        expect(result.confidence).to eq(0.85)
+        expect(result.method).to eq("llm_haiku")
+        expect(mock_client).not_to have_received(:categorize) if mock_client.respond_to?(:categorize)
+      end
+
+      it "refreshes the TTL on the cache entry" do
+        freeze_time do
+          strategy.call(expense)
+          cache_entry.reload
+
+          expect(cache_entry.expires_at).to be_within(1.second).of(90.days.from_now)
+        end
+      end
+
+      it "includes cache_hit metadata" do
+        result = strategy.call(expense)
+
+        expect(result.metadata).to include(cache_hit: true)
+      end
+    end
+
+    context "when cache miss (no entry)" do
+      let(:prompt_text) { "categorize this merchant" }
+      let(:api_response) do
+        {
+          response_text: category.i18n_key,
+          token_count: { input: 80, output: 5 },
+          cost: 0.0003
+        }
+      end
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize).with(prompt_text: prompt_text).and_return(api_response)
+        allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+            parse: { category: category, confidence: 0.85, raw_response: category.i18n_key }))
+      end
+
+      it "calls the LLM client and returns a successful result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+        expect(result.confidence).to eq(0.85)
+        expect(result.method).to eq("llm_haiku")
+        expect(mock_client).to have_received(:categorize).with(prompt_text: prompt_text)
+      end
+
+      it "stores the result in cache with 90-day TTL" do
+        freeze_time do
+          expect { strategy.call(expense) }
+            .to change(LlmCategorizationCacheEntry, :count).by(1)
+
+          entry = LlmCategorizationCacheEntry.last
+          expect(entry.merchant_normalized).to eq(normalized_merchant)
+          expect(entry.category).to eq(category)
+          expect(entry.confidence).to eq(0.85)
+          expect(entry.model_used).to eq("claude-haiku-4-5")
+          expect(entry.token_count).to eq(85)
+          expect(entry.cost).to eq(0.0003)
+          expect(entry.expires_at).to be_within(1.second).of(90.days.from_now)
+        end
+      end
+
+      it "feeds the result into VectorUpdater" do
+        vector_updater = instance_double(Services::Categorization::Learning::VectorUpdater)
+        allow(Services::Categorization::Learning::VectorUpdater).to receive(:new).and_return(vector_updater)
+        allow(vector_updater).to receive(:upsert)
+
+        strategy.call(expense)
+
+        expect(vector_updater).to have_received(:upsert).with(
+          merchant: expense.merchant_name,
+          category: category,
+          description_keywords: []
+        )
+      end
+
+      it "includes metadata about the LLM call" do
+        result = strategy.call(expense)
+
+        expect(result.metadata).to include(
+          cache_hit: false,
+          model_used: "claude-haiku-4-5"
+        )
+      end
+    end
+
+    context "when cache entry exists but is expired" do
+      let!(:expired_entry) do
+        create(:llm_categorization_cache_entry,
+          merchant_normalized: normalized_merchant,
+          category: category,
+          confidence: 0.85,
+          model_used: "claude-haiku-4-5",
+          token_count: 100,
+          cost: 0.001,
+          expires_at: 1.day.ago)
+      end
+
+      let(:new_category) { create(:category) }
+      let(:prompt_text) { "categorize this merchant" }
+      let(:api_response) do
+        {
+          response_text: new_category.i18n_key,
+          token_count: { input: 80, output: 5 },
+          cost: 0.0003
+        }
+      end
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize).with(prompt_text: prompt_text).and_return(api_response)
+        allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+            parse: { category: new_category, confidence: 0.85, raw_response: new_category.i18n_key }))
+      end
+
+      it "calls the API again instead of using expired cache" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(new_category)
+        expect(mock_client).to have_received(:categorize)
+      end
+
+      it "updates the existing cache entry" do
+        expect { strategy.call(expense) }
+          .not_to change(LlmCategorizationCacheEntry, :count)
+
+        expired_entry.reload
+        expect(expired_entry.category).to eq(new_category)
+        expect(expired_entry.expires_at).to be > Time.current
+      end
+    end
+
+    context "when LLM client raises an error" do
+      let(:prompt_text) { "categorize this merchant" }
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize)
+          .and_raise(Services::Categorization::Llm::Client::Error, "API unavailable")
+      end
+
+      it "returns no_match gracefully" do
+        result = strategy.call(expense)
+
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+
+      it "logs the error" do
+        strategy.call(expense)
+
+        expect(logger).to have_received(:error).with(/API unavailable/)
+      end
+    end
+
+    context "when LLM returns no matching category" do
+      let(:prompt_text) { "categorize this merchant" }
+      let(:api_response) do
+        {
+          response_text: "unknown_category",
+          token_count: { input: 80, output: 5 },
+          cost: 0.0003
+        }
+      end
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize).with(prompt_text: prompt_text).and_return(api_response)
+        allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+            parse: { category: nil, confidence: 0.0, raw_response: "unknown_category" }))
+      end
+
+      it "returns no_match when parser finds no category" do
+        result = strategy.call(expense)
+
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+
+      it "does not create a cache entry" do
+        expect { strategy.call(expense) }
+          .not_to change(LlmCategorizationCacheEntry, :count)
+      end
+    end
+
+    context "when VectorUpdater fails" do
+      let(:prompt_text) { "categorize this merchant" }
+      let(:api_response) do
+        {
+          response_text: category.i18n_key,
+          token_count: { input: 80, output: 5 },
+          cost: 0.0003
+        }
+      end
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize).with(prompt_text: prompt_text).and_return(api_response)
+        allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+            parse: { category: category, confidence: 0.85, raw_response: category.i18n_key }))
+
+        vector_updater = instance_double(Services::Categorization::Learning::VectorUpdater)
+        allow(Services::Categorization::Learning::VectorUpdater).to receive(:new).and_return(vector_updater)
+        allow(vector_updater).to receive(:upsert).and_raise(StandardError, "DB error")
+      end
+
+      it "still returns the successful result" do
+        result = strategy.call(expense)
+
+        expect(result).to be_successful
+        expect(result.category).to eq(category)
+      end
+
+      it "logs the VectorUpdater error" do
+        strategy.call(expense)
+
+        expect(logger).to have_received(:warn).with(/VectorUpdater/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `LlmStrategy` (Layer 3): cache-first Claude Haiku categorization
  - Cache hit refreshes 90-day TTL, cache miss stores new entry
  - Feeds results into VectorUpdater so Layer 2 learns from LLM
  - Graceful error handling (API errors → no_match)
  - Lazy client init (missing API key doesn't crash at boot)
- Wire all 3 strategies into Engine chain:
  PatternStrategy (L1) → SimilarityStrategy (L2) → LlmStrategy (L3)

## Test plan
- [x] 21 LlmStrategy unit specs (cache hit/miss, TTL, VectorUpdater, errors)
- [x] All 47 Engine specs pass (no behavior regression)
- [x] Full unit suite: 7534 examples, 0 failures
- [x] RuboCop: 0 offenses, Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)