### PR TITLE
feat: clickable category badge for corrections

### DIFF
--- a/app/views/expenses/_category_with_confidence.html.erb
+++ b/app/views/expenses/_category_with_confidence.html.erb
@@ -9,16 +9,20 @@
        data-category-confidence-percentage-value="<%= expense.confidence_percentage %>"
        data-category-confidence-explanation-value="<%= expense.ml_confidence_explanation || '' %>">
 
-    <%# Category Badge %>
+    <%# Category Badge — clickable to correct %>
     <% if expense.category %>
-      <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full transition-all"
-            style="background-color: <%= expense.category.color %>20; color: <%= expense.category.color %>;">
+      <button class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full transition-all cursor-pointer hover:ring-2 hover:ring-teal-300"
+              style="background-color: <%= expense.category.color %>20; color: <%= expense.category.color %>;"
+              data-action="click->category-confidence#showCorrection"
+              title="<%= t('expenses.actions.change_category', default: 'Click to change category') %>">
         <%= expense.category.display_name %>
-      </span>
+      </button>
     <% else %>
-      <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-slate-100 text-slate-600">
+      <button class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-full bg-slate-100 text-slate-600 cursor-pointer hover:ring-2 hover:ring-teal-300"
+              data-action="click->category-confidence#showCorrection"
+              title="<%= t('expenses.actions.set_category', default: 'Click to set category') %>">
         Sin categoría
-      </span>
+      </button>
     <% end %>
 
     <%# Confidence Indicator %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,8 @@ en:
       delete_title: "Delete expense (Delete)"
       delete_aria: "Delete expense"
       menu_label: "Actions"
+      change_category: "Click to change category"
+      set_category: "Click to set category"
       mark_processed: "Mark Processed"
       mark_pending: "Mark Pending"
       duplicate: "Duplicate"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -238,6 +238,8 @@ es:
       delete_title: "Eliminar gasto (Delete)"
       delete_aria: "Eliminar gasto"
       menu_label: "Acciones"
+      change_category: "Click para cambiar categoría"
+      set_category: "Click para asignar categoría"
       mark_processed: "Marcar Procesado"
       mark_pending: "Marcar Pendiente"
       duplicate: "Duplicar"


### PR DESCRIPTION
## Summary
- Change category badge from `<span>` to `<button>` with click-to-correct behavior
- Clicking any expense's category badge opens the correction dropdown
- Uses the existing `category-confidence#showCorrection` Stimulus action
- Triggers `correct_category` → Engine → CorrectionHandler (full learning loop)
- Previously corrections only worked via edit form (bypassed learning) or hidden button (low-confidence only)
- Hover ring feedback (teal-300) indicates clickability
- i18n keys added for both locales

## Test plan
- [x] Full unit suite: 7571 examples, 0 failures
- [x] RuboCop: 0 offenses, Brakeman: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)