### PR TITLE
feat: add 9 new expense categories + i18n keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,15 @@ en:
       clothing: "Clothing"
       electronics: "Electronics"
       household: "Household"
+      subscriptions: "Subscriptions"
+      pets: "Pets"
+      gym: "Gym"
+      personal_care: "Personal Care"
+      taxes: "Taxes"
+      parking: "Parking"
+      fast_food: "Fast Food"
+      bakery: "Bakery"
+      hardware_store: "Hardware Store"
 
   # Navigation
   nav:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -29,6 +29,15 @@ es:
       clothing: "Ropa"
       electronics: "Electrónicos"
       household: "Artículos del Hogar"
+      subscriptions: "Suscripciones"
+      pets: "Mascotas"
+      gym: "Gimnasio"
+      personal_care: "Cuidado Personal"
+      taxes: "Impuestos"
+      parking: "Estacionamiento"
+      fast_food: "Comida Rápida"
+      bakery: "Panadería"
+      hardware_store: "Ferretería"
 
   # Navigation
   nav:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,16 @@ root_categories = [
   { i18n_key: "shopping", description: "Ropa, electrónicos, artículos personales", color: "#DDA0DD" },
   { i18n_key: "education", description: "Cursos, libros, capacitación", color: "#98D8C8" },
   { i18n_key: "home", description: "Artículos para el hogar, mantenimiento", color: "#F7DC6F" },
-  { i18n_key: "uncategorized", description: "Gastos sin categorizar", color: "#BDC3C7" }
+  { i18n_key: "uncategorized", description: "Gastos sin categorizar", color: "#BDC3C7" },
+  { i18n_key: "subscriptions", description: "Streaming, software, servicios mensuales", color: "#8B5CF6" },
+  { i18n_key: "pets", description: "Veterinario, comida, accesorios para mascotas", color: "#F97316" },
+  { i18n_key: "gym", description: "Membresías de gimnasio, fitness", color: "#06B6D4" },
+  { i18n_key: "personal_care", description: "Peluquería, óptica, lavandería", color: "#EC4899" },
+  { i18n_key: "taxes", description: "Gobierno, municipalidad, impuestos", color: "#78716C" },
+  { i18n_key: "parking", description: "Parqueos", color: "#A3A3A3" },
+  { i18n_key: "fast_food", description: "McDonald's, KFC, comida rápida", color: "#EF4444" },
+  { i18n_key: "bakery", description: "Panaderías, reposterías", color: "#D97706" },
+  { i18n_key: "hardware_store", description: "EPA, ferreterías", color: "#737373" }
 ]
 
 root_categories.each do |category_data|


### PR DESCRIPTION
## Summary
Add 9 categories that were missing from the original set, identified by analyzing 338 expenses across Dec 2025 - Apr 2026:

- **Suscripciones** — Netflix, Spotify, Amazon Prime, Claude.AI, etc.
- **Mascotas** — pet stores, vet
- **Gimnasio** — fitness memberships
- **Cuidado Personal** — salon, optics, laundry
- **Impuestos** — government, municipal taxes
- **Estacionamiento** — parking
- **Comida Rápida** — McDonald's, KFC
- **Panadería** — bakeries
- **Ferretería** — hardware stores (EPA)

Also bulk-corrected 275 miscategorized expenses via Engine#learn_from_correction (vectors + metrics updated).

## Test plan
- [x] Full unit suite: 7571 examples, 0 failures
- [x] RuboCop: 0 offenses, Brakeman: 0 warnings
- [x] i18n keys added for en + es
- [x] Seeds updated for new installations

🤖 Generated with [Claude Code](https://claude.com/claude-code)