### PR TITLE
fix: confidence calculator text-match gate prevents false positives

### DIFF
--- a/app/javascript/controllers/category_confidence_controller.js
+++ b/app/javascript/controllers/category_confidence_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { shouldSuppressShortcut } from "utilities/keyboard_shortcut_helpers"
+import { t } from "services/i18n"
 
 export default class extends Controller {
   static targets = ["badge", "tooltip", "correctionPanel", "correctionTrigger", "categorySelect"]
@@ -79,32 +80,28 @@ export default class extends Controller {
   }
 
   getTooltipContent() {
-    let content = `<div class="font-semibold mb-1">Confianza: ${this.percentageValue}%</div>`
-    
+    let content = `<div class="font-semibold mb-1">${t("categories.confidence.display", { percentage: this.percentageValue })}</div>`
+
     if (this.explanationValue) {
       content += `<div class="text-slate-300">${this.explanationValue}</div>`
     }
-    
-    const levelDescriptions = {
-      high: "Alta probabilidad de categorización correcta",
-      medium: "Categorización probable pero puede requerir revisión",
-      low: "Baja confianza - se recomienda revisar",
-      very_low: "Muy baja confianza - requiere revisión manual"
-    }
-    
-    if (levelDescriptions[this.levelValue]) {
+
+    const levelKey = this.levelValue // high, medium, low, very_low
+    const levelText = t(`categories.confidence.${levelKey}`)
+
+    if (levelText !== `categories.confidence.${levelKey}`) {
       content += `<div class="mt-1 pt-1 border-t border-slate-600 text-slate-400">
-                    ${levelDescriptions[this.levelValue]}
+                    ${levelText}
                   </div>`
     }
-    
+
     // Add keyboard shortcut hint
     if (this.levelValue === "low" || this.levelValue === "very_low") {
       content += `<div class="mt-1 text-slate-500">
-                    Presiona 'C' para corregir
+                    ${t("categories.confidence.shortcut_hint")}
                   </div>`
     }
-    
+
     return content
   }
 
@@ -142,20 +139,20 @@ export default class extends Controller {
     panel.setAttribute("data-category-confidence-target", "correctionPanel")
     
     panel.innerHTML = `
-      <div class="text-sm font-medium text-slate-700 mb-2">Corregir categoría</div>
+      <div class="text-sm font-medium text-slate-700 mb-2">${t("categories.actions.correct")}</div>
       <div class="space-y-2">
         <select data-category-confidence-target="categorySelect"
                 class="w-full rounded-md border-slate-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-          <option value="">Seleccionar categoría...</option>
+          <option value="">${t("categories.labels.select")}</option>
         </select>
         <div class="flex gap-2">
           <button data-action="click->category-confidence#applyCorrection"
                   class="flex-1 px-3 py-1.5 bg-teal-700 text-white text-sm rounded-lg hover:bg-teal-800">
-            Aplicar
+            ${t("categories.actions.apply")}
           </button>
           <button data-action="click->category-confidence#hideCorrection"
                   class="flex-1 px-3 py-1.5 bg-slate-200 text-slate-700 text-sm rounded-lg hover:bg-slate-300">
-            Cancelar
+            ${t("categories.actions.cancel")}
           </button>
         </div>
       </div>
@@ -180,7 +177,7 @@ export default class extends Controller {
       
       if (this.hasCategorySelectTarget) {
         const select = this.categorySelectTarget
-        select.innerHTML = '<option value="">Seleccionar categoría...</option>'
+        select.innerHTML = `<option value="">${t("categories.labels.select")}</option>`
         
         categories.forEach(category => {
           const option = document.createElement("option")
@@ -200,7 +197,7 @@ export default class extends Controller {
     
     const categoryId = this.categorySelectTarget.value
     if (!categoryId) {
-      this.showError("Por favor selecciona una categoría")
+      this.showError(t("expenses.errors.category_required"))
       return
     }
     
@@ -216,7 +213,7 @@ export default class extends Controller {
       
       if (response.ok) {
         // Show success feedback
-        this.showSuccess("Categoría actualizada correctamente")
+        this.showSuccess(t("expenses.notifications.category_updated"))
         this.hideCorrection()
 
         // Reload the page to reflect the change
@@ -227,11 +224,11 @@ export default class extends Controller {
           window.location.reload()
         }
       } else {
-        this.showError("Error al actualizar la categoría")
+        this.showError(t("expenses.errors.category_update_failed"))
       }
     } catch (error) {
       console.error("Error applying correction:", error)
-      this.showError("Error de conexión")
+      this.showError(t("common.errors.connection"))
     }
   }
 

--- a/app/javascript/services/i18n.js
+++ b/app/javascript/services/i18n.js
@@ -241,6 +241,7 @@ const translations = {
       },
       confidence: {
         display: "Confianza: %{percentage}%",
+        very_high: "Confianza muy alta - categorización altamente precisa",
         high: "Alta probabilidad de categorización correcta",
         medium: "Categorización probable pero puede requerir revisión",
         low: "Baja confianza - se recomienda revisar",
@@ -663,6 +664,7 @@ const translations = {
       },
       confidence: {
         display: "Confidence: %{percentage}%",
+        very_high: "Very high confidence - highly accurate categorization",
         high: "High probability of correct categorization",
         medium: "Probable categorization but may require review",
         low: "Low confidence - recommended to review",

--- a/app/javascript/services/i18n.js
+++ b/app/javascript/services/i18n.js
@@ -229,13 +229,23 @@ const translations = {
     },
     categories: {
       actions: {
-        correct: "Corregir categoría"
+        correct: "Corregir categoría",
+        apply: "Aplicar",
+        cancel: "Cancelar"
       },
       labels: {
         select: "Seleccionar categoría..."
       },
       errors: {
         auto_failed: "La categorización automática falló"
+      },
+      confidence: {
+        display: "Confianza: %{percentage}%",
+        high: "Alta probabilidad de categorización correcta",
+        medium: "Categorización probable pero puede requerir revisión",
+        low: "Baja confianza - se recomienda revisar",
+        very_low: "Muy baja confianza - requiere revisión manual",
+        shortcut_hint: "Presiona 'C' para corregir"
       }
     },
     filters: {
@@ -641,13 +651,23 @@ const translations = {
     },
     categories: {
       actions: {
-        correct: "Correct category"
+        correct: "Correct category",
+        apply: "Apply",
+        cancel: "Cancel"
       },
       labels: {
         select: "Select category..."
       },
       errors: {
         auto_failed: "Auto-categorization failed"
+      },
+      confidence: {
+        display: "Confidence: %{percentage}%",
+        high: "High probability of correct categorization",
+        medium: "Probable categorization but may require review",
+        low: "Low confidence - recommended to review",
+        very_low: "Very low confidence - requires manual review",
+        shortcut_hint: "Press 'C' to correct"
       }
     },
     filters: {

--- a/app/services/categorization/confidence_calculator.rb
+++ b/app/services/categorization/confidence_calculator.rb
@@ -92,16 +92,22 @@ module Services::Categorization
         # Gate: if text_match is below threshold, other factors cannot
         # inflate the score. Time/amount/usage are boosters for real
         # matches, not standalone confidence generators.
+        # Gate: if text_match is below threshold, other factors cannot
+        # inflate the score. The score is still sigmoid-normalized so
+        # downstream callers (Engine#high_confidence?, auto-update) see
+        # values on the same scale as non-gated results.
+        # Note: TEXT_MATCH_GATE_THRESHOLD is aligned with
+        # FuzzyMatcher::DEFAULT_OPTIONS[:min_confidence] (both 0.75).
         text_match_value = factors[:text_match] || 0.0
         if text_match_value < TEXT_MATCH_GATE_THRESHOLD
-          # Use text_match directly as the score — no inflation from other factors
+          normalized_gated_score = apply_sigmoid_normalization(text_match_value)
           return ConfidenceScore.new(
-            score: text_match_value,
+            score: normalized_gated_score,
             raw_score: text_match_value,
             factors: factors,
             pattern: pattern,
             expense: expense,
-            metadata: build_metadata(factors, text_match_value, text_match_value, false).merge(
+            metadata: build_metadata(factors, text_match_value, normalized_gated_score, true).merge(
               gated: true,
               gate_reason: "text_match #{text_match_value.round(3)} < #{TEXT_MATCH_GATE_THRESHOLD}"
             )

--- a/app/services/categorization/confidence_calculator.rb
+++ b/app/services/categorization/confidence_calculator.rb
@@ -38,6 +38,12 @@ module Services::Categorization
     SIGMOID_STEEPNESS = 10.0  # Controls how aggressive the push to 0/1 is
     SIGMOID_MIDPOINT = 0.5    # The inflection point
 
+    # Text match gate: if the text_match factor is below this threshold,
+    # other factors (usage, time, amount) cannot inflate the score.
+    # This prevents unrelated merchants from getting high confidence
+    # just because they match on time-of-day or amount range.
+    TEXT_MATCH_GATE_THRESHOLD = 0.75
+
     # Performance thresholds
     PERFORMANCE_THRESHOLD_MS = 1.0
     CACHE_TTL = 5.minutes
@@ -82,6 +88,25 @@ module Services::Categorization
         # Validate required factors
         validation_result = validate_factors(factors)
         return validation_result unless validation_result.nil?
+
+        # Gate: if text_match is below threshold, other factors cannot
+        # inflate the score. Time/amount/usage are boosters for real
+        # matches, not standalone confidence generators.
+        text_match_value = factors[:text_match] || 0.0
+        if text_match_value < TEXT_MATCH_GATE_THRESHOLD
+          # Use text_match directly as the score — no inflation from other factors
+          return ConfidenceScore.new(
+            score: text_match_value,
+            raw_score: text_match_value,
+            factors: factors,
+            pattern: pattern,
+            expense: expense,
+            metadata: build_metadata(factors, text_match_value, text_match_value, false).merge(
+              gated: true,
+              gate_reason: "text_match #{text_match_value.round(3)} < #{TEXT_MATCH_GATE_THRESHOLD}"
+            )
+          )
+        end
 
         # Calculate weighted score
         weighted_score = calculate_weighted_score(factors)

--- a/app/services/categorization/matchers/fuzzy_matcher.rb
+++ b/app/services/categorization/matchers/fuzzy_matcher.rb
@@ -22,7 +22,7 @@ module Services::Categorization
       # Default configuration
       DEFAULT_OPTIONS = {
         algorithms: [ :jaro_winkler, :trigram ],
-        min_confidence: 0.6,
+        min_confidence: 0.75,
         max_results: 5,
         timeout_ms: 10,
         enable_caching: true,

--- a/app/services/categorization/matchers/fuzzy_matcher.rb
+++ b/app/services/categorization/matchers/fuzzy_matcher.rb
@@ -556,7 +556,7 @@ module Services::Categorization
         return [] if search_text.blank? || patterns.empty?
 
         matches = []
-        min_confidence = options[:min_confidence] || 0.70
+        min_confidence = options[:min_confidence] || @options[:min_confidence]
         max_patterns_to_check = 20 # Limit for performance
 
         # Pre-process search text once

--- a/app/services/categorization/strategies/pattern_strategy.rb
+++ b/app/services/categorization/strategies/pattern_strategy.rb
@@ -95,7 +95,14 @@ module Services::Categorization
         load_patterns_in_batches(options).each do |patterns|
           matches.concat(match_merchant_patterns(expense, patterns, options))
           matches.concat(match_description_patterns(expense, patterns, options))
-          matches.concat(match_other_patterns(expense, patterns))
+
+          # Time/amount patterns are boosters only — they add signal to
+          # existing merchant/keyword matches but don't create standalone
+          # matches. Without a text-based match, these broad patterns
+          # would match almost any expense and prevent L2/L3 from running.
+          if matches.any?
+            matches.concat(match_other_patterns(expense, patterns))
+          end
 
           break if matches.size >= options.fetch(:max_results, 10) * 2
         end

--- a/spec/services/categorization/confidence_calculator_spec.rb
+++ b/spec/services/categorization/confidence_calculator_spec.rb
@@ -745,4 +745,81 @@ RSpec.describe Services::Categorization::ConfidenceCalculator do
       expect(calculator).to have_received(:calculate_weighted_score).once
     end
   end
+
+  describe "TEXT_MATCH_GATE_THRESHOLD", :unit do
+    let(:high_usage_pattern) do
+      create(:categorization_pattern,
+             category: category,
+             pattern_type: "merchant",
+             pattern_value: "test merchant",
+             usage_count: 500,
+             success_count: 475,
+             success_rate: 0.95,
+             metadata: {
+               "amount_stats" => { "count" => 100, "mean" => 100.0, "std_dev" => 20.0, "min" => 10, "max" => 500 }
+             })
+    end
+
+    context "when text_match is below threshold (< 0.75)" do
+      let(:low_match) do
+        Services::Categorization::Matchers::MatchResult.new(
+          success: true,
+          matches: [ { score: 0.60, text: "unrelated" } ]
+        )
+      end
+
+      it "gates the score — other factors cannot inflate it" do
+        result = calculator.calculate(expense, high_usage_pattern, low_match)
+
+        expect(result).to be_valid
+        # Score should be sigmoid of text_match only, not boosted by usage/success
+        expect(result.score).to be < 0.75
+        expect(result.metadata[:gated]).to eq(true)
+        expect(result.metadata[:gate_reason]).to include("text_match")
+      end
+
+      it "still applies sigmoid normalization for downstream consistency" do
+        result = calculator.calculate(expense, high_usage_pattern, low_match)
+
+        # raw_score is the text_match value, score is sigmoid-normalized
+        expect(result.raw_score).to be < result.score  # sigmoid pushes toward extremes
+        expect(result.score).to be > 0  # not zero
+      end
+    end
+
+    context "when text_match is at boundary (exactly 0.75)" do
+      let(:boundary_match) do
+        Services::Categorization::Matchers::MatchResult.new(
+          success: true,
+          matches: [ { score: 0.75, text: "boundary" } ]
+        )
+      end
+
+      it "does NOT gate — uses full weighted scoring with all factors" do
+        result = calculator.calculate(expense, high_usage_pattern, boundary_match)
+
+        expect(result).to be_valid
+        expect(result.metadata[:gated]).to be_nil
+        # Full weighted scoring with usage/success boost should push score higher
+        expect(result.score).to be > 0.75
+      end
+    end
+
+    context "when text_match is above threshold" do
+      let(:strong_match) do
+        Services::Categorization::Matchers::MatchResult.new(
+          success: true,
+          matches: [ { score: 0.90, text: "amazon" } ]
+        )
+      end
+
+      it "uses full multi-factor scoring with sigmoid normalization" do
+        result = calculator.calculate(expense, high_usage_pattern, strong_match)
+
+        expect(result).to be_valid
+        expect(result.metadata[:gated]).to be_nil
+        expect(result.score).to be > 0.85
+      end
+    end
+  end
 end

--- a/spec/services/categorization/engine_spec.rb
+++ b/spec/services/categorization/engine_spec.rb
@@ -786,11 +786,11 @@ RSpec.describe Services::Categorization::Engine, type: :service do
                category: amount_category)
       end
 
-      it "new amount_range pattern can produce a match" do
+      it "amount_range pattern alone does not produce a standalone match" do
+        # amount_range/time patterns are boosters only — they require
+        # a text-based match (merchant/keyword) to exist first.
         result = engine.categorize(expense)
-        expect(result).to be_successful
-        expect(result.category).to eq(amount_category)
-        expect(result.confidence).to be >= 0.5
+        expect(result).not_to be_successful
       end
     end
   end

--- a/spec/services/categorization/engine_spec.rb
+++ b/spec/services/categorization/engine_spec.rb
@@ -791,6 +791,7 @@ RSpec.describe Services::Categorization::Engine, type: :service do
         # a text-based match (merchant/keyword) to exist first.
         result = engine.categorize(expense)
         expect(result).not_to be_successful
+        expect(result.category).to be_nil
       end
     end
   end

--- a/spec/services/categorization/strategies/pattern_strategy_spec.rb
+++ b/spec/services/categorization/strategies/pattern_strategy_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe Services::Categorization::Strategies::PatternStrategy, :unit, typ
         result = strategy.call(expense)
 
         expect(result).not_to be_successful
+        expect(result.category).to be_nil
       end
     end
 

--- a/spec/services/categorization/strategies/pattern_strategy_spec.rb
+++ b/spec/services/categorization/strategies/pattern_strategy_spec.rb
@@ -210,12 +210,12 @@ RSpec.describe Services::Categorization::Strategies::PatternStrategy, :unit, typ
                category: amount_category)
       end
 
-      it "matches non-fuzzy pattern types" do
-        # Clear any other patterns that might match
+      it "amount_range patterns only boost existing text matches, not standalone" do
+        # amount_range/time patterns are boosters — they cannot produce
+        # matches on their own without a merchant/keyword match first.
         result = strategy.call(expense)
 
-        expect(result).to be_successful
-        expect(result.category).to eq(amount_category)
+        expect(result).not_to be_successful
       end
     end
 


### PR DESCRIPTION
## Summary
- **ConfidenceCalculator**: Added text_match gate (threshold 0.75) — if the merchant name doesn't match, time/amount/usage factors cannot inflate the score. This prevents "XYLOPHONE MEGASTORE" from being categorized as "Entretenimiento" at 0.85 confidence.
- **PatternStrategy**: Time and amount_range patterns are now boosters only. They require an existing merchant/keyword match to fire, preventing broad catch-all patterns from matching every expense.
- **FuzzyMatcher**: Raised `min_confidence` from 0.6 to 0.75 to filter out Jaro-Winkler false positives (e.g., 0.61 for completely unrelated strings).
- **i18n**: Extracted 8 hardcoded Spanish strings from `category_confidence_controller.js` into the JS i18n service (both es/en locales).

## Why
The Jaro-Winkler algorithm was producing false matches (0.6+ scores for unrelated strings), and the sigmoid normalization was inflating these into 0.85+ confidence. This meant Layer 2 (pg_trgm similarity) and Layer 3 (Haiku LLM) were never exercised — all expenses were caught by L1 pattern matching, even completely unknown merchants.

After the fix, known merchants still get high confidence via L1, while unknown merchants correctly fall through to L2/L3.

## Test plan
- [x] 1202 categorization tests pass (0 failures)
- [x] 8550 unit tests pass (1 known flaky: MetricsCalculationJob concurrency)
- [x] RuboCop clean
- [x] Brakeman clean
- [x] Verified L1 catches known merchants (NETFLIX → 0.991, CAFE BRITT → 0.972)
- [x] Verified unknown merchants fall through L1 (XYLOPHONE MEGASTORE → no match)
- [x] Verified L3 Haiku categorizes unknowns when API key is set
- [x] Verified L2 pg_trgm catches similar merchants (CAFE BRITT → vector match at 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)