### PR TITLE
feat: enrich LLM categorization prompt with bank, location, and Spanish names

### DIFF
--- a/app/services/categorization/llm/prompt_builder.rb
+++ b/app/services/categorization/llm/prompt_builder.rb
@@ -4,10 +4,20 @@ module Services::Categorization
   module Llm
     class PromptBuilder
       SYSTEM_INSTRUCTION = <<~INSTRUCTION.freeze
-        You are an expense categorizer. Given an expense, return the single best
-        matching category from the list below. Return ONLY the category key,
-        nothing else.
+        You are an expense categorizer for a personal finance tracker.
+        Given a bank transaction, return the single best matching category key
+        from the list below. Return ONLY the category key, nothing else.
+
+        If the merchant is a payment processor (e.g., PayPal, Tilo Pay, Sinpe Móvil)
+        and the underlying purchase is unknown, return "uncategorized".
+
+        If you are not confident about the category, return "uncategorized"
+        rather than guessing.
       INSTRUCTION
+
+      # Extract city and country from BAC email body.
+      # Format: "Ciudad y país: <city>, <country> Fecha: ..."
+      COUNTRY_REGEX = /Ciudad y pa[ií]s:\s*(.+?)\s+Fecha:/i
 
       def build(expense:, correction_history: nil)
         prompt = build_base_prompt(expense)
@@ -23,17 +33,52 @@ module Services::Categorization
           Categories:
           #{format_categories}
 
-          Expense:
-          Merchant: #{expense.merchant_name}
-          Description: #{expense.description}
-          Amount: #{expense.amount} #{expense.currency}
+          Transaction:
+          #{format_transaction(expense)}
         PROMPT
+      end
+
+      def format_transaction(expense)
+        lines = []
+        lines << "Bank: #{expense.bank_name}" if expense.bank_name?
+        lines << "Merchant: #{expense.merchant_name}" if expense.merchant_name?
+        lines << "Amount: #{format_amount(expense)}"
+
+        city, country = extract_location(expense)
+        lines << "Location: #{[ city, country ].compact.join(', ')}" if city || country
+
+        lines.join("\n")
+      end
+
+      def format_amount(expense)
+        currency = expense.currency&.upcase || "CRC"
+        formatted = number_with_delimiter(expense.amount)
+        "#{formatted} #{currency}"
+      end
+
+      def extract_location(expense)
+        body = expense.email_body.presence || expense.raw_email_content.presence || expense.parsed_data&.to_s
+        return [ nil, nil ] unless body
+
+        match = body.match(COUNTRY_REGEX)
+        return [ nil, nil ] unless match
+
+        raw = match[1].strip
+        if raw.include?(",")
+          city, country = raw.split(",", 2).map(&:strip)
+          country = nil if country == "Pais no Definido"
+          [ city, country ]
+        else
+          country = raw == "Pais no Definido" ? nil : raw
+          [ nil, country ]
+        end
       end
 
       def format_categories
         @formatted_categories ||= begin
-          category_keys = Category.where.not(i18n_key: [ nil, "" ]).pluck(:i18n_key)
-          category_keys.map { |key| "- #{key}" }.join("\n")
+          categories = Category.where.not(i18n_key: [ nil, "" ])
+                               .pluck(:i18n_key, :name)
+          categories.map { |key, name| "- #{key} (#{name})" }.join("\n")
         end
       end
 
@@ -41,6 +86,14 @@ module Services::Categorization
         old_key = correction_history[:old]
         new_key = correction_history[:new]
         "\nNote: This merchant was previously categorized as #{old_key} but corrected to #{new_key} by the user.\n"
+      end
+
+      def number_with_delimiter(number)
+        return "0" unless number
+
+        whole, decimal = number.to_s.split(".")
+        whole_with_delimiters = whole.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+        decimal ? "#{whole_with_delimiters}.#{decimal}" : whole_with_delimiters
       end
     end
   end

--- a/spec/services/categorization/llm/prompt_builder_spec.rb
+++ b/spec/services/categorization/llm/prompt_builder_spec.rb
@@ -7,11 +7,21 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
 
   let(:expense) do
     build(:expense, merchant_name: "McDonald's", description: "Compra en restaurante",
-                    amount: 5500.0, currency: "crc")
+                    amount: 5500.0, currency: "crc", bank_name: "BAC",
+                    email_body: "Comercio: McDonald's Ciudad y país: SAN JOSE, Costa Rica Fecha: Ene 5, 2026")
   end
 
-  let(:category_keys) { %w[food restaurants supermarket coffee_shop transport utilities] }
-  let(:not_relation) { double("ActiveRecord::Relation", pluck: category_keys) }
+  let(:category_data) do
+    [
+      %w[food Alimentación],
+      %w[restaurants Restaurantes],
+      %w[supermarket Supermercado],
+      %w[coffee_shop Cafetería],
+      %w[transport Transporte],
+      %w[utilities Servicios]
+    ]
+  end
+  let(:not_relation) { double("ActiveRecord::Relation", pluck: category_data) }
   let(:where_relation) { double("ActiveRecord::Relation", not: not_relation) }
 
   before do
@@ -26,13 +36,12 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
       expect(result).to include("Return ONLY the category key")
     end
 
-    it "includes dynamically generated categories from the database" do
+    it "includes categories with Spanish display names" do
       result = builder.build(expense: expense)
 
       expect(result).to include("Categories:")
-      category_keys.each do |key|
-        expect(result).to include(key)
-      end
+      expect(result).to include("- food (Alimentación)")
+      expect(result).to include("- restaurants (Restaurantes)")
     end
 
     it "includes merchant name from the expense" do
@@ -41,30 +50,59 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
       expect(result).to include("Merchant: McDonald's")
     end
 
-    it "includes description from the expense" do
+    it "includes bank name" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("Description: Compra en restaurante")
+      expect(result).to include("Bank: BAC")
     end
 
-    it "includes amount and currency from the expense" do
+    it "includes formatted amount with currency" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("Amount: 5500.0 crc")
+      expect(result).to include("Amount: 5,500.0 CRC")
     end
 
-    it "handles expenses with nil description" do
-      expense.description = nil
+    it "extracts and includes location from email body" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("Description: ")
+      expect(result).to include("Location: SAN JOSE, Costa Rica")
     end
 
     it "handles expenses with nil merchant_name" do
       expense.merchant_name = nil
       result = builder.build(expense: expense)
 
-      expect(result).to include("Merchant: ")
+      expect(result).not_to include("Merchant:")
+    end
+
+    it "handles expenses with nil bank_name" do
+      expense.bank_name = nil
+      result = builder.build(expense: expense)
+
+      expect(result).not_to include("Bank:")
+    end
+
+    it "handles Pais no Definido as nil country" do
+      expense.email_body = "Comercio: Apple Ciudad y país: CUPERTNO, Pais no Definido Fecha: Ene 5, 2026"
+      result = builder.build(expense: expense)
+
+      expect(result).to include("Location: CUPERTNO")
+      expect(result).not_to include("Pais no Definido")
+    end
+
+    it "handles expenses with no email body" do
+      expense.email_body = nil
+      expense.raw_email_content = nil
+      result = builder.build(expense: expense)
+
+      expect(result).not_to include("Location:")
+    end
+
+    it "includes payment processor guidance in system instruction" do
+      result = builder.build(expense: expense)
+
+      expect(result).to include("payment processor")
+      expect(result).to include("uncategorized")
     end
 
     context "when correction_history is provided" do
@@ -94,7 +132,7 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
         result = builder.build(expense: expense)
 
         expect(result).to include("Categories:")
-        expect(result).to include("Expense:")
+        expect(result).to include("Transaction:")
       end
     end
   end


### PR DESCRIPTION
## Summary

- Adds bank name, city/country location (from BAC's `Ciudad y país` field), and Spanish category display names to the LLM categorization prompt
- Formats amounts with thousand separators and uppercase currency
- Adds payment processor guidance (Tilo Pay, PayPal → return "uncategorized")
- Removes raw description field (was just the authorization code, not useful)
- Handles "Pais no Definido" gracefully (omits from location)

## Before / After

**Before:**
```
Merchant: MATHEUS HOLDINGS
Description: 329599
Amount: 16000.0 crc
```

**After:**
```
Bank: BAC
Merchant: MATHEUS HOLDINGS
Amount: 16,000.0 CRC
Location: SAN JOSE, Costa Rica
```

Categories now shown as `- food (Alimentación)` instead of just `- food`.

## Test plan

- [x] 14 prompt_builder specs pass (0 failures)
- [x] All 32 LLM specs pass
- [x] Rubocop clean
- [x] Brakeman clean
- [x] Rails Best Practices clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)