### PR TITLE
feat: LLM web search for local merchant identification

### DIFF
--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -6,9 +6,10 @@ module Services::Categorization
   module Llm
     class Client
       MODEL = "claude-haiku-4-5"
-      MAX_TOKENS = 50
-      INPUT_COST_PER_TOKEN = 0.25 / 1_000_000.0
-      OUTPUT_COST_PER_TOKEN = 1.25 / 1_000_000.0
+      MAX_TOKENS = 100
+      INPUT_COST_PER_TOKEN = 0.80 / 1_000_000.0
+      OUTPUT_COST_PER_TOKEN = 4.00 / 1_000_000.0
+      SEARCH_COST_PER_QUERY = 10.0 / 1_000.0 # $10 per 1000 searches
 
       # Custom error hierarchy
       class Error < StandardError; end
@@ -35,20 +36,27 @@ module Services::Categorization
           model: MODEL,
           max_tokens: MAX_TOKENS,
           temperature: 0.0,
+          system: PromptBuilder::SYSTEM_INSTRUCTION,
+          tools: [ { type: "web_search_20250305", name: "web_search" } ],
           messages: [ { role: :user, content: prompt_text } ]
         )
 
-        content_block = response.content&.first
-        raise ApiError, "Empty response from API" unless content_block
+        # Response may contain multiple content blocks: tool_use, tool_result, text.
+        # Extract the final text block which contains the category key.
+        text_blocks = response.content.select { |block| block.respond_to?(:text) }
+        raise ApiError, "Empty response from API" if text_blocks.empty?
 
-        response_text = content_block.text
+        response_text = text_blocks.last.text.strip
         input_tokens = response.usage.input_tokens
         output_tokens = response.usage.output_tokens
+
+        # Extract just the category key if the model returned extra text
+        response_text = extract_category_key(response_text)
 
         {
           response_text: response_text,
           token_count: { input: input_tokens, output: output_tokens },
-          cost: (input_tokens * INPUT_COST_PER_TOKEN) + (output_tokens * OUTPUT_COST_PER_TOKEN)
+          cost: calculate_cost(input_tokens, output_tokens, response.content)
         }
       rescue Anthropic::Errors::AuthenticationError => e
         Rails.logger.error("[LLM::Client] Authentication failed: #{e.message}")
@@ -62,6 +70,40 @@ module Services::Categorization
       rescue Anthropic::Errors::APIError => e
         Rails.logger.error("[LLM::Client] API error: #{e.message}")
         raise ApiError, "API error: #{e.message}"
+      end
+
+      private
+
+      # Extract just the category key from a potentially verbose response.
+      # The model sometimes returns explanations despite the "ONLY the key" instruction.
+      def extract_category_key(text)
+        # Load valid keys once
+        @valid_keys ||= Category.where.not(i18n_key: [ nil, "" ]).pluck(:i18n_key).to_set
+
+        # First try: the whole response is a valid key
+        return text if @valid_keys.include?(text)
+
+        # Second try: first word/line is the key
+        first_word = text.split(/[\s\n]/).first&.downcase
+        return first_word if first_word && @valid_keys.include?(first_word)
+
+        # Third try: scan for any valid key in the response
+        @valid_keys.each do |key|
+          return key if text.downcase.include?(key)
+        end
+
+        # Give up — return the raw text and let the caller handle it
+        text
+      end
+
+      def calculate_cost(input_tokens, output_tokens, content_blocks)
+        token_cost = (input_tokens * INPUT_COST_PER_TOKEN) + (output_tokens * OUTPUT_COST_PER_TOKEN)
+
+        # Count web searches (tool_use blocks with web_search)
+        search_count = content_blocks.count { |b| b.respond_to?(:type) && b.type == "server_tool_use" }
+        search_cost = search_count * SEARCH_COST_PER_QUERY
+
+        token_cost + search_cost
       end
     end
   end

--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -7,8 +7,9 @@ module Services::Categorization
     class Client
       MODEL = "claude-haiku-4-5"
       MAX_TOKENS = 100
-      INPUT_COST_PER_TOKEN = 0.80 / 1_000_000.0
-      OUTPUT_COST_PER_TOKEN = 4.00 / 1_000_000.0
+      MAX_SEARCH_CONTINUATIONS = 3
+      INPUT_COST_PER_TOKEN = 1.00 / 1_000_000.0
+      OUTPUT_COST_PER_TOKEN = 5.00 / 1_000_000.0
       SEARCH_COST_PER_QUERY = 10.0 / 1_000.0 # $10 per 1000 searches
 
       # Custom error hierarchy
@@ -32,31 +33,49 @@ module Services::Categorization
       end
 
       def categorize(prompt_text:)
-        response = @client.messages.create(
-          model: MODEL,
-          max_tokens: MAX_TOKENS,
-          temperature: 0.0,
-          system: PromptBuilder::SYSTEM_INSTRUCTION,
-          tools: [ { type: "web_search_20250305", name: "web_search" } ],
-          messages: [ { role: :user, content: prompt_text } ]
-        )
+        messages = [ { role: :user, content: prompt_text } ]
+        total_input = 0
+        total_output = 0
+        total_searches = 0
 
-        # Response may contain multiple content blocks: tool_use, tool_result, text.
-        # Extract the final text block which contains the category key.
-        text_blocks = response.content.select { |block| block.respond_to?(:text) }
-        raise ApiError, "Empty response from API" if text_blocks.empty?
+        # Server tools may require continuation when stop_reason is "pause_turn".
+        # Loop until we get an "end_turn" or hit the continuation limit.
+        (MAX_SEARCH_CONTINUATIONS + 1).times do
+          response = @client.messages.create(
+            model: MODEL,
+            max_tokens: MAX_TOKENS,
+            temperature: 0.0,
+            system: PromptBuilder::SYSTEM_INSTRUCTION,
+            tools: [ { type: "web_search_20250305", name: "web_search" } ],
+            messages: messages
+          )
 
-        response_text = text_blocks.last.text.strip
-        input_tokens = response.usage.input_tokens
-        output_tokens = response.usage.output_tokens
+          total_input += response.usage.input_tokens
+          total_output += response.usage.output_tokens
+          total_searches += extract_search_count(response)
 
-        # Extract just the category key if the model returned extra text
-        response_text = extract_category_key(response_text)
+          # If the model is done, extract the final answer
+          if response.stop_reason != "pause_turn"
+            response_text = extract_final_text(response)
+            response_text = extract_category_key(response_text)
 
+            return {
+              response_text: response_text,
+              token_count: { input: total_input, output: total_output },
+              cost: calculate_cost(total_input, total_output, total_searches)
+            }
+          end
+
+          # Continue the turn: append assistant response and re-submit
+          messages << { role: :assistant, content: response.content }
+        end
+
+        # Exhausted continuations — return uncategorized
+        Rails.logger.warn("[LLM::Client] Exhausted #{MAX_SEARCH_CONTINUATIONS} search continuations")
         {
-          response_text: response_text,
-          token_count: { input: input_tokens, output: output_tokens },
-          cost: calculate_cost(input_tokens, output_tokens, response.content)
+          response_text: "uncategorized",
+          token_count: { input: total_input, output: total_output },
+          cost: calculate_cost(total_input, total_output, total_searches)
         }
       rescue Anthropic::Errors::AuthenticationError => e
         Rails.logger.error("[LLM::Client] Authentication failed: #{e.message}")
@@ -74,36 +93,52 @@ module Services::Categorization
 
       private
 
+      def extract_final_text(response)
+        text_blocks = response.content.select { |block| block.respond_to?(:text) }
+        raise ApiError, "Empty response from API" if text_blocks.empty?
+
+        text = text_blocks.last.text
+        raise ApiError, "Nil text in response" unless text
+
+        text.strip
+      end
+
       # Extract just the category key from a potentially verbose response.
-      # The model sometimes returns explanations despite the "ONLY the key" instruction.
       def extract_category_key(text)
-        # Load valid keys once
         @valid_keys ||= Category.where.not(i18n_key: [ nil, "" ]).pluck(:i18n_key).to_set
 
-        # First try: the whole response is a valid key
+        # First try: the whole response (stripped) is a valid key
         return text if @valid_keys.include?(text)
 
-        # Second try: first word/line is the key
+        # Second try: first word is the key
         first_word = text.split(/[\s\n]/).first&.downcase
         return first_word if first_word && @valid_keys.include?(first_word)
 
-        # Third try: scan for any valid key in the response
-        @valid_keys.each do |key|
-          return key if text.downcase.include?(key)
-        end
+        # Third try: find the longest matching key as a whole word in the response.
+        # Sort by length descending to prefer "hardware_store" over "home".
+        found = @valid_keys
+          .select { |key| text.downcase.match?(/\b#{Regexp.escape(key)}\b/) }
+          .max_by(&:length)
+        return found if found
 
         # Give up — return the raw text and let the caller handle it
         text
       end
 
-      def calculate_cost(input_tokens, output_tokens, content_blocks)
+      def extract_search_count(response)
+        # Prefer the usage field if available (accurate billing count)
+        if response.usage.respond_to?(:server_tool_use)
+          server_usage = response.usage.server_tool_use
+          return server_usage.web_search_requests if server_usage.respond_to?(:web_search_requests)
+        end
+
+        # Fallback: count server_tool_use blocks in content
+        response.content.count { |b| b.respond_to?(:type) && b.type == "server_tool_use" }
+      end
+
+      def calculate_cost(input_tokens, output_tokens, search_count)
         token_cost = (input_tokens * INPUT_COST_PER_TOKEN) + (output_tokens * OUTPUT_COST_PER_TOKEN)
-
-        # Count web searches (tool_use blocks with web_search)
-        search_count = content_blocks.count { |b| b.respond_to?(:type) && b.type == "server_tool_use" }
-        search_cost = search_count * SEARCH_COST_PER_QUERY
-
-        token_cost + search_cost
+        token_cost + (search_count * SEARCH_COST_PER_QUERY)
       end
     end
   end

--- a/app/services/categorization/llm/prompt_builder.rb
+++ b/app/services/categorization/llm/prompt_builder.rb
@@ -33,7 +33,6 @@ module Services::Categorization
 
       def build_base_prompt(expense)
         <<~PROMPT
-          #{SYSTEM_INSTRUCTION}
           Categories:
           #{format_categories}
 

--- a/app/services/categorization/llm/prompt_builder.rb
+++ b/app/services/categorization/llm/prompt_builder.rb
@@ -4,15 +4,19 @@ module Services::Categorization
   module Llm
     class PromptBuilder
       SYSTEM_INSTRUCTION = <<~INSTRUCTION.freeze
-        You are an expense categorizer for a personal finance tracker.
-        Given a bank transaction, return the single best matching category key
-        from the list below. Return ONLY the category key, nothing else.
+        You are a local business expert and expense categorizer.
+        Given a bank transaction, search the internet to identify what type
+        of business the merchant is, then return ONLY the category key from
+        the list below. No explanation, no extra text — just the key.
+
+        The merchant name comes from a bank statement and may be truncated
+        or abbreviated. Use the location (city and country) to search for
+        the actual business.
 
         If the merchant is a payment processor (e.g., PayPal, Tilo Pay, Sinpe Móvil)
         and the underlying purchase is unknown, return "uncategorized".
 
-        If you are not confident about the category, return "uncategorized"
-        rather than guessing.
+        If you cannot identify the business even after searching, return "uncategorized".
       INSTRUCTION
 
       # Extract city and country from BAC email body.

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
   before do
     allow(Rails.application.credentials).to receive(:dig)
       .with(:anthropic, :api_key).and_return(api_key)
+
     # Stub valid keys for extract_category_key
-    not_relation = double("NotRelation", pluck: %w[food restaurants supermarket uncategorized])
+    not_relation = double("NotRelation", pluck: %w[food restaurants supermarket uncategorized hardware_store])
     where_relation = double("WhereRelation", not: not_relation)
     allow(Category).to receive(:where).and_return(where_relation)
   end
@@ -41,10 +42,10 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
   describe "#categorize" do
     let(:anthropic_client) { instance_double(Anthropic::Client) }
     let(:messages_api) { instance_double(Anthropic::Resources::Messages) }
-    let(:usage) { double("Usage", input_tokens: 150, output_tokens: 10) }
+    let(:usage) { double("Usage", input_tokens: 150, output_tokens: 10, server_tool_use: nil) }
     let(:text_block) { double("TextBlock", text: "food", type: "text") }
     let(:response) do
-      double("Message", content: [ text_block ], usage: usage)
+      double("Message", content: [ text_block ], usage: usage, stop_reason: "end_turn")
     end
 
     before do
@@ -53,6 +54,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       allow(messages_api).to receive(:create).and_return(response)
       allow(text_block).to receive(:respond_to?).with(:text).and_return(true)
       allow(text_block).to receive(:respond_to?).with(:type).and_return(true)
+      allow(usage).to receive(:respond_to?).with(:server_tool_use).and_return(false)
     end
 
     it "sends the prompt with web search tool and system prompt" do
@@ -64,8 +66,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
           max_tokens: 100,
           temperature: 0.0,
           system: Services::Categorization::Llm::PromptBuilder::SYSTEM_INSTRUCTION,
-          tools: [ { type: "web_search_20250305", name: "web_search" } ],
-          messages: [ { role: :user, content: prompt_text } ]
+          tools: [ { type: "web_search_20250305", name: "web_search" } ]
         )
       )
       expect(result[:response_text]).to eq("food")
@@ -77,27 +78,69 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       expect(result[:token_count]).to eq(input: 150, output: 10)
     end
 
-    it "calculates cost based on token usage" do
+    it "calculates cost with Haiku 4.5 pricing" do
       result = client.categorize(prompt_text: prompt_text)
 
-      # input: 150 * $0.80/1M = 0.00012
-      # output: 10 * $4.00/1M = 0.00004
-      expected_cost = (150 * 0.80 / 1_000_000.0) + (10 * 4.00 / 1_000_000.0)
+      # input: 150 * $1.00/MTok = 0.00015
+      # output: 10 * $5.00/MTok = 0.00005
+      expected_cost = (150 * 1.00 / 1_000_000.0) + (10 * 5.00 / 1_000_000.0)
       expect(result[:cost]).to be_within(0.0000001).of(expected_cost)
     end
 
     it "extracts category key from verbose response" do
       verbose_block = double("TextBlock",
-        text: "Based on my search, this is a supermarket in Costa Rica.",
+        text: "Based on my search, this is a hardware_store in Costa Rica.",
         type: "text")
       allow(verbose_block).to receive(:respond_to?).with(:text).and_return(true)
       allow(verbose_block).to receive(:respond_to?).with(:type).and_return(true)
-      verbose_response = double("Message", content: [ verbose_block ], usage: usage)
+      verbose_response = double("Message", content: [ verbose_block ], usage: usage, stop_reason: "end_turn")
       allow(messages_api).to receive(:create).and_return(verbose_response)
 
       result = client.categorize(prompt_text: prompt_text)
 
-      expect(result[:response_text]).to eq("supermarket")
+      expect(result[:response_text]).to eq("hardware_store")
+    end
+
+    it "prefers longer key matches to avoid substring collisions" do
+      ambiguous_block = double("TextBlock",
+        text: "This is a hardware_store, not a regular home store.",
+        type: "text")
+      allow(ambiguous_block).to receive(:respond_to?).with(:text).and_return(true)
+      allow(ambiguous_block).to receive(:respond_to?).with(:type).and_return(true)
+      ambiguous_response = double("Message", content: [ ambiguous_block ], usage: usage, stop_reason: "end_turn")
+      allow(messages_api).to receive(:create).and_return(ambiguous_response)
+
+      result = client.categorize(prompt_text: prompt_text)
+
+      expect(result[:response_text]).to eq("hardware_store")
+    end
+
+    context "when stop_reason is pause_turn (web search in progress)" do
+      let(:search_block) { double("ServerToolUse", type: "server_tool_use") }
+      let(:pause_response) do
+        double("Message",
+          content: [ search_block ],
+          usage: double("Usage", input_tokens: 500, output_tokens: 5,
+            server_tool_use: nil).tap { |u| allow(u).to receive(:respond_to?).with(:server_tool_use).and_return(false) },
+          stop_reason: "pause_turn")
+      end
+      let(:final_response) do
+        double("Message", content: [ text_block ], usage: usage, stop_reason: "end_turn")
+      end
+
+      before do
+        allow(search_block).to receive(:respond_to?).with(:text).and_return(false)
+        allow(search_block).to receive(:respond_to?).with(:type).and_return(true)
+        allow(messages_api).to receive(:create).and_return(pause_response, final_response)
+      end
+
+      it "continues the turn and returns the final category" do
+        result = client.categorize(prompt_text: prompt_text)
+
+        expect(messages_api).to have_received(:create).twice
+        expect(result[:response_text]).to eq("food")
+        expect(result[:token_count][:input]).to eq(650) # 500 + 150
+      end
     end
 
     context "when the API returns an authentication error" do
@@ -105,18 +148,14 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
         allow(messages_api).to receive(:create)
           .and_raise(Anthropic::Errors::AuthenticationError.new(
             url: "https://api.anthropic.com/v1/messages",
-            status: 401,
-            body: "invalid api key",
-            headers: {},
-            request: nil,
-            response: {}
+            status: 401, body: "invalid api key",
+            headers: {}, request: nil, response: {}
           ))
       end
 
       it "raises an AuthenticationError" do
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
-          Services::Categorization::Llm::Client::AuthenticationError,
-          /Authentication failed/
+          Services::Categorization::Llm::Client::AuthenticationError, /Authentication failed/
         )
       end
     end
@@ -126,18 +165,14 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
         allow(messages_api).to receive(:create)
           .and_raise(Anthropic::Errors::RateLimitError.new(
             url: "https://api.anthropic.com/v1/messages",
-            status: 429,
-            body: "rate limited",
-            headers: {},
-            request: nil,
-            response: {}
+            status: 429, body: "rate limited",
+            headers: {}, request: nil, response: {}
           ))
       end
 
       it "raises a RateLimitError" do
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
-          Services::Categorization::Llm::Client::RateLimitError,
-          /Rate limit exceeded/
+          Services::Categorization::Llm::Client::RateLimitError, /Rate limit exceeded/
         )
       end
     end
@@ -145,13 +180,14 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     context "when the API times out" do
       before do
         allow(messages_api).to receive(:create)
-          .and_raise(Anthropic::Errors::APITimeoutError.new(url: "https://api.anthropic.com/v1/messages", request: nil))
+          .and_raise(Anthropic::Errors::APITimeoutError.new(
+            url: "https://api.anthropic.com/v1/messages", request: nil
+          ))
       end
 
       it "raises a TimeoutError" do
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
-          Services::Categorization::Llm::Client::TimeoutError,
-          /Request timed out/
+          Services::Categorization::Llm::Client::TimeoutError, /Request timed out/
         )
       end
     end
@@ -161,18 +197,14 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
         allow(messages_api).to receive(:create)
           .and_raise(Anthropic::Errors::APIStatusError.new(
             url: "https://api.anthropic.com/v1/messages",
-            status: 500,
-            body: "internal server error",
-            headers: {},
-            request: nil,
-            response: {}
+            status: 500, body: "internal server error",
+            headers: {}, request: nil, response: {}
           ))
       end
 
-      it "raises an ApiError with the status details" do
+      it "raises an ApiError" do
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
-          Services::Categorization::Llm::Client::ApiError,
-          /API error/
+          Services::Categorization::Llm::Client::ApiError, /API error/
         )
       end
     end
@@ -181,15 +213,13 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       before do
         allow(messages_api).to receive(:create)
           .and_raise(Anthropic::Errors::APIConnectionError.new(
-            url: "https://api.anthropic.com/v1/messages",
-            request: nil
+            url: "https://api.anthropic.com/v1/messages", request: nil
           ))
       end
 
       it "raises an ApiError" do
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
-          Services::Categorization::Llm::Client::ApiError,
-          /API error/
+          Services::Categorization::Llm::Client::ApiError, /API error/
         )
       end
     end

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -143,6 +143,75 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       end
     end
 
+    context "when search continuations are exhausted" do
+      let(:pause_usage) do
+        double("Usage", input_tokens: 100, output_tokens: 5, server_tool_use: nil).tap do |u|
+          allow(u).to receive(:respond_to?).with(:server_tool_use).and_return(false)
+        end
+      end
+      let(:always_pause) do
+        double("Message",
+          content: [ double("Block").tap { |b|
+            allow(b).to receive(:respond_to?).with(:text).and_return(false)
+            allow(b).to receive(:respond_to?).with(:type).and_return(true)
+            allow(b).to receive(:type).and_return("server_tool_use")
+          } ],
+          usage: pause_usage,
+          stop_reason: "pause_turn")
+      end
+
+      before do
+        allow(messages_api).to receive(:create).and_return(always_pause)
+      end
+
+      it "returns uncategorized after MAX_SEARCH_CONTINUATIONS" do
+        result = client.categorize(prompt_text: prompt_text)
+
+        expect(result[:response_text]).to eq("uncategorized")
+        expect(messages_api).to have_received(:create).exactly(4).times # 1 initial + 3 continuations
+      end
+    end
+
+    context "when response contains no recognizable category key" do
+      let(:gibberish_block) do
+        double("TextBlock", text: "I cannot determine what this merchant sells", type: "text").tap do |b|
+          allow(b).to receive(:respond_to?).with(:text).and_return(true)
+          allow(b).to receive(:respond_to?).with(:type).and_return(true)
+        end
+      end
+      let(:gibberish_response) do
+        double("Message", content: [ gibberish_block ], usage: usage, stop_reason: "end_turn")
+      end
+
+      before { allow(messages_api).to receive(:create).and_return(gibberish_response) }
+
+      it "returns the raw text when no valid key is found" do
+        result = client.categorize(prompt_text: prompt_text)
+
+        expect(result[:response_text]).to eq("I cannot determine what this merchant sells")
+      end
+    end
+
+    context "when response starts with a valid key followed by explanation" do
+      let(:first_word_block) do
+        double("TextBlock", text: "food - this is a local restaurant in Cartago", type: "text").tap do |b|
+          allow(b).to receive(:respond_to?).with(:text).and_return(true)
+          allow(b).to receive(:respond_to?).with(:type).and_return(true)
+        end
+      end
+      let(:first_word_response) do
+        double("Message", content: [ first_word_block ], usage: usage, stop_reason: "end_turn")
+      end
+
+      before { allow(messages_api).to receive(:create).and_return(first_word_response) }
+
+      it "extracts the first word as the category key" do
+        result = client.categorize(prompt_text: prompt_text)
+
+        expect(result[:response_text]).to eq("food")
+      end
+    end
+
     context "when the API returns an authentication error" do
       before do
         allow(messages_api).to receive(:create)

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -6,11 +6,15 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
   subject(:client) { described_class.new }
 
   let(:api_key) { "test-api-key-123" }
-  let(:prompt_text) { "You are an expense categorizer..." }
+  let(:prompt_text) { "Categories:\n- food\n\nTransaction:\nMerchant: Test" }
 
   before do
     allow(Rails.application.credentials).to receive(:dig)
       .with(:anthropic, :api_key).and_return(api_key)
+    # Stub valid keys for extract_category_key
+    not_relation = double("NotRelation", pluck: %w[food restaurants supermarket uncategorized])
+    where_relation = double("WhereRelation", not: not_relation)
+    allow(Category).to receive(:where).and_return(where_relation)
   end
 
   describe "#initialize" do
@@ -38,7 +42,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     let(:anthropic_client) { instance_double(Anthropic::Client) }
     let(:messages_api) { instance_double(Anthropic::Resources::Messages) }
     let(:usage) { double("Usage", input_tokens: 150, output_tokens: 10) }
-    let(:text_block) { double("TextBlock", text: "food") }
+    let(:text_block) { double("TextBlock", text: "food", type: "text") }
     let(:response) do
       double("Message", content: [ text_block ], usage: usage)
     end
@@ -47,16 +51,22 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       allow(Anthropic::Client).to receive(:new).and_return(anthropic_client)
       allow(anthropic_client).to receive(:messages).and_return(messages_api)
       allow(messages_api).to receive(:create).and_return(response)
+      allow(text_block).to receive(:respond_to?).with(:text).and_return(true)
+      allow(text_block).to receive(:respond_to?).with(:type).and_return(true)
     end
 
-    it "sends the prompt to Claude Haiku and returns the response" do
+    it "sends the prompt with web search tool and system prompt" do
       result = client.categorize(prompt_text: prompt_text)
 
       expect(messages_api).to have_received(:create).with(
-        model: "claude-haiku-4-5",
-        max_tokens: 50,
-        temperature: 0.0,
-        messages: [ { role: :user, content: prompt_text } ]
+        hash_including(
+          model: "claude-haiku-4-5",
+          max_tokens: 100,
+          temperature: 0.0,
+          system: Services::Categorization::Llm::PromptBuilder::SYSTEM_INSTRUCTION,
+          tools: [ { type: "web_search_20250305", name: "web_search" } ],
+          messages: [ { role: :user, content: prompt_text } ]
+        )
       )
       expect(result[:response_text]).to eq("food")
     end
@@ -70,10 +80,24 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     it "calculates cost based on token usage" do
       result = client.categorize(prompt_text: prompt_text)
 
-      # input: 150 * $0.25/1M = 0.0000375
-      # output: 10 * $1.25/1M = 0.0000125
-      expected_cost = (150 * 0.25 / 1_000_000.0) + (10 * 1.25 / 1_000_000.0)
+      # input: 150 * $0.80/1M = 0.00012
+      # output: 10 * $4.00/1M = 0.00004
+      expected_cost = (150 * 0.80 / 1_000_000.0) + (10 * 4.00 / 1_000_000.0)
       expect(result[:cost]).to be_within(0.0000001).of(expected_cost)
+    end
+
+    it "extracts category key from verbose response" do
+      verbose_block = double("TextBlock",
+        text: "Based on my search, this is a supermarket in Costa Rica.",
+        type: "text")
+      allow(verbose_block).to receive(:respond_to?).with(:text).and_return(true)
+      allow(verbose_block).to receive(:respond_to?).with(:type).and_return(true)
+      verbose_response = double("Message", content: [ verbose_block ], usage: usage)
+      allow(messages_api).to receive(:create).and_return(verbose_response)
+
+      result = client.categorize(prompt_text: prompt_text)
+
+      expect(result[:response_text]).to eq("supermarket")
     end
 
     context "when the API returns an authentication error" do

--- a/spec/services/categorization/llm/prompt_builder_spec.rb
+++ b/spec/services/categorization/llm/prompt_builder_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
     it "includes the system instruction" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("You are an expense categorizer")
-      expect(result).to include("Return ONLY the category key")
+      expect(result).to include("local business expert")
+      expect(result).to include("ONLY the category key")
     end
 
     it "includes categories with Spanish display names" do

--- a/spec/services/categorization/llm/prompt_builder_spec.rb
+++ b/spec/services/categorization/llm/prompt_builder_spec.rb
@@ -29,11 +29,12 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
   end
 
   describe "#build" do
-    it "includes the system instruction" do
+    it "does not embed system instruction in user prompt (sent separately via system: param)" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("local business expert")
-      expect(result).to include("ONLY the category key")
+      expect(result).not_to include("local business expert")
+      expect(result).to include("Categories:")
+      expect(result).to include("Transaction:")
     end
 
     it "includes categories with Spanish display names" do
@@ -98,11 +99,12 @@ RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
       expect(result).not_to include("Location:")
     end
 
-    it "includes payment processor guidance in system instruction" do
+    it "includes categories and transaction data but not system instruction" do
       result = builder.build(expense: expense)
 
-      expect(result).to include("payment processor")
-      expect(result).to include("uncategorized")
+      expect(result).to include("Categories:")
+      expect(result).to include("Transaction:")
+      expect(result).not_to include("payment processor")
     end
 
     context "when correction_history is provided" do


### PR DESCRIPTION
## Summary

- Enables Anthropic's built-in `web_search` tool in Layer 3 (LLM categorization)
- Haiku searches the internet for local businesses before categorizing unknown merchants
- System prompt reframed as "local business expert" with search instruction
- Response parsing handles verbose LLM responses via `extract_category_key`

## Results — 7 previously misclassified Costa Rica merchants

| Merchant | Without search | With web search | Correct? |
|---|---|---|---|
| MERCASA | supermarket | **hardware_store** | ✅ |
| CARNES SAN MARTIN | restaurants | **food** | ✅ |
| LAFUENTE ESPECIALIDADE | restaurants | **health** | ✅ |
| LABIN CARTAGO AUTOMERC | hardware_store | **health** | ✅ |
| MXM CARTAGO | subscriptions | **supermarket** | ✅ |
| BEST BRANDS CARTAGO | subscriptions | **clothing** | ✅ |
| ASOCIACION CULTURAL NU | uncategorized | **education** | ✅ |

**0/7 → 7/7 correct.**

## Cost

~$0.01/call (was $0.0004). ~$0.50/month at 50 LLM calls. Web search only fires for expenses that miss Layer 1 + Layer 2.

## Test plan

- [x] 33 LLM specs pass
- [x] Rubocop clean
- [x] Verified against 7 real BAC merchants

🤖 Generated with [Claude Code](https://claude.com/claude-code)