### PR TITLE
fix(llm): override Anthropic SDK timeout + max_retries (PER-491)

### DIFF
--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -28,7 +28,11 @@ module Services::Categorization
           api_key = Rails.application.credentials.dig(:anthropic, :api_key)
           raise ConfigurationError, "Anthropic API key not configured" unless api_key
 
-          @client = Anthropic::Client.new(api_key: api_key)
+          @client = Anthropic::Client.new(
+            api_key: api_key,
+            max_retries: 0,
+            timeout: (ENV["ANTHROPIC_TIMEOUT_SECONDS"] || 30).to_i
+          )
         end
       end
 

--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -11,6 +11,7 @@ module Services::Categorization
       INPUT_COST_PER_TOKEN = 1.00 / 1_000_000.0
       OUTPUT_COST_PER_TOKEN = 5.00 / 1_000_000.0
       SEARCH_COST_PER_QUERY = 10.0 / 1_000.0 # $10 per 1000 searches
+      DEFAULT_TIMEOUT_S = 30
 
       # Custom error hierarchy
       class Error < StandardError; end
@@ -31,9 +32,19 @@ module Services::Categorization
           @client = Anthropic::Client.new(
             api_key: api_key,
             max_retries: 0,
-            timeout: (ENV["ANTHROPIC_TIMEOUT_SECONDS"] || 30).to_i
+            timeout: self.class.anthropic_timeout
           )
         end
+      end
+
+      # Resolves the Anthropic SDK timeout with defensive parsing so that an
+      # invalid ANTHROPIC_TIMEOUT_SECONDS cannot produce a 0s timeout (which
+      # would hard-fail every request and defeat the B1 mitigation).
+      def self.anthropic_timeout
+        value = Integer(ENV.fetch("ANTHROPIC_TIMEOUT_SECONDS", nil), 10)
+        value.positive? ? value : DEFAULT_TIMEOUT_S
+      rescue TypeError, ArgumentError
+        DEFAULT_TIMEOUT_S
       end
 
       def categorize(prompt_text:)

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -19,13 +19,33 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
   end
 
   describe "#initialize" do
-    it "creates an Anthropic client with the configured API key" do
-      allow(Anthropic::Client).to receive(:new)
-        .with(api_key: api_key).and_call_original
+    it "creates an Anthropic client with the configured API key, no SDK retries, and a 30s timeout" do
+      allow(Anthropic::Client).to receive(:new).and_call_original
 
       client
 
-      expect(Anthropic::Client).to have_received(:new).with(api_key: api_key)
+      expect(Anthropic::Client).to have_received(:new).with(
+        api_key: api_key,
+        max_retries: 0,
+        timeout: 30
+      )
+    end
+
+    it "honors ANTHROPIC_TIMEOUT_SECONDS when set" do
+      allow(Anthropic::Client).to receive(:new).and_call_original
+      original = ENV["ANTHROPIC_TIMEOUT_SECONDS"]
+      ENV["ANTHROPIC_TIMEOUT_SECONDS"] = "45"
+      begin
+        described_class.new
+      ensure
+        ENV["ANTHROPIC_TIMEOUT_SECONDS"] = original
+      end
+
+      expect(Anthropic::Client).to have_received(:new).with(
+        api_key: api_key,
+        max_retries: 0,
+        timeout: 45
+      )
     end
 
     it "raises an error when API key is not configured" do

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -19,7 +19,19 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
   end
 
   describe "#initialize" do
-    it "creates an Anthropic client with the configured API key, no SDK retries, and a 30s timeout" do
+    # Every #initialize spec isolates ANTHROPIC_TIMEOUT_SECONDS so the suite
+    # is not sensitive to the developer's or CI's ambient shell env.
+    around do |example|
+      original = ENV["ANTHROPIC_TIMEOUT_SECONDS"]
+      ENV.delete("ANTHROPIC_TIMEOUT_SECONDS")
+      begin
+        example.run
+      ensure
+        ENV["ANTHROPIC_TIMEOUT_SECONDS"] = original
+      end
+    end
+
+    it "creates an Anthropic client with the configured API key, no SDK retries, and a 30s default timeout" do
       allow(Anthropic::Client).to receive(:new).and_call_original
 
       client
@@ -28,24 +40,43 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
         api_key: api_key,
         max_retries: 0,
         timeout: 30
-      )
+      ).once
     end
 
-    it "honors ANTHROPIC_TIMEOUT_SECONDS when set" do
+    it "honors ANTHROPIC_TIMEOUT_SECONDS when set to a positive integer" do
       allow(Anthropic::Client).to receive(:new).and_call_original
-      original = ENV["ANTHROPIC_TIMEOUT_SECONDS"]
       ENV["ANTHROPIC_TIMEOUT_SECONDS"] = "45"
-      begin
-        described_class.new
-      ensure
-        ENV["ANTHROPIC_TIMEOUT_SECONDS"] = original
-      end
+
+      described_class.new
 
       expect(Anthropic::Client).to have_received(:new).with(
         api_key: api_key,
         max_retries: 0,
         timeout: 45
       )
+    end
+
+    # The whole point of PER-491 is to cap the timeout so a worker thread
+    # cannot hang. A misconfigured env var that silently becomes 0, negative,
+    # or garbage must NOT defeat that cap — it must fall back to the default.
+    [
+      [ "non-numeric string", "disabled" ],
+      [ "empty string", "" ],
+      [ "zero", "0" ],
+      [ "negative integer", "-5" ]
+    ].each do |label, value|
+      it "falls back to the default timeout when ANTHROPIC_TIMEOUT_SECONDS is a #{label}" do
+        allow(Anthropic::Client).to receive(:new).and_call_original
+        ENV["ANTHROPIC_TIMEOUT_SECONDS"] = value
+
+        described_class.new
+
+        expect(Anthropic::Client).to have_received(:new).with(
+          api_key: api_key,
+          max_retries: 0,
+          timeout: 30
+        )
+      end
     end
 
     it "raises an error when API key is not configured" do


### PR DESCRIPTION
## Summary

Closes [PER-491](https://linear.app/experiments-esoto/issue/PER-491) — deploy-blocker **B1** from the production-readiness review ([epic PER-490](https://linear.app/experiments-esoto/issue/PER-490)).

- Override Anthropic SDK defaults (`timeout: 600s`, `max_retries: 2`) at the single `Anthropic::Client.new` call site in `app/services/categorization/llm/client.rb:31`.
- Now: `max_retries: 0` (retry policy centralized in `LlmStrategy#call_with_rate_limit_handling`, PR #421) and `timeout: 30` (env-tunable via `ANTHROPIC_TIMEOUT_SECONDS`).

## Why

Anthropic gem 1.32.0 defaults `timeout` to 600s and `max_retries` to 2. Combined with the app-layer retry loop added in #421 (3 attempts, backoff `[10, 30, 60]`s), a single stuck LLM call could tie up a Solid Queue worker thread for 30+ minutes and double-retry transient errors.

Quoting the production-readiness review:
> Anthropic gem 1.32.0 defaults to `timeout: 600s`, `max_retries: 2`. Combined with our retry layer (3 × [10, 30, 60] s backoff), a single LLM call can hang 30+ min on a tied-up Solid Queue worker thread.

## Test plan

- [x] Added `#initialize` spec asserting `Anthropic::Client.new` is called with `api_key:`, `max_retries: 0`, and `timeout: 30`
- [x] Added spec asserting `ANTHROPIC_TIMEOUT_SECONDS` env var is honored
- [x] Full client spec: `bundle exec rspec spec/services/categorization/llm/client_spec.rb` — **17 examples, 0 failures**
- [x] Downstream: `bundle exec rspec spec/services/categorization/strategies/llm_strategy_spec.rb` — **35 examples, 0 failures**
- [x] Full unit suite for categorization: `bundle exec rspec spec/services/categorization/ --tag unit` — **1232 examples, 0 failures, 1 pending**
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec brakeman` — no warnings
- [ ] Smoke check after merge: trigger one LLM categorization in production and confirm no regression