### PR TITLE
fix(llm): atomic budget counter + env-tunable cap (PER-492)

### DIFF
--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -81,13 +81,13 @@ module Services::Categorization
       private
 
       # The LlmStrategy budget counter stores spend in integer units scaled by
-      # BUDGET_CENTS_SCALE (PER-492). Rescale to USD on read. If the cache is
+      # BUDGET_UNITS_PER_USD (PER-492). Rescale to USD on read. If the cache is
       # empty (first call of the month, or cache flush), fall back to the DB.
       def fetch_current_spend
-        cache_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        cache_key = "#{Strategies::LlmStrategy::BUDGET_KEY_PREFIX}:#{Date.current.strftime('%Y-%m')}"
         cached = Rails.cache.read(cache_key)
         if cached
-          return cached.to_f / Strategies::LlmStrategy::BUDGET_CENTS_SCALE
+          return cached.to_f / Strategies::LlmStrategy::BUDGET_UNITS_PER_USD
         end
 
         CategorizationMetric.recent(30.days).sum(:api_cost).to_f

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -5,8 +5,6 @@ module Services::Categorization
     # Aggregates categorization metrics for the admin dashboard.
     # Uses single-query conditional aggregation for efficiency.
     class MetricsDashboardService
-      MONTHLY_BUDGET = 5.0
-
       def overview(period: 30.days)
         result = CategorizationMetric.recent(period).pick(
           Arel.sql("COUNT(*)"),
@@ -68,7 +66,7 @@ module Services::Categorization
       end
 
       def api_budget_status
-        budget = MONTHLY_BUDGET
+        budget = Strategies::LlmStrategy.monthly_budget
         current_spend = fetch_current_spend
         percentage = budget.zero? ? 0.0 : (current_spend / budget * 100).round(2)
 
@@ -82,10 +80,15 @@ module Services::Categorization
 
       private
 
+      # The LlmStrategy budget counter stores spend in integer units scaled by
+      # BUDGET_CENTS_SCALE (PER-492). Rescale to USD on read. If the cache is
+      # empty (first call of the month, or cache flush), fall back to the DB.
       def fetch_current_spend
         cache_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
         cached = Rails.cache.read(cache_key)
-        return cached.to_f if cached
+        if cached
+          return cached.to_f / Strategies::LlmStrategy::BUDGET_CENTS_SCALE
+        end
 
         CategorizationMetric.recent(30.days).sum(:api_cost).to_f
       end

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -12,13 +12,17 @@ module Services::Categorization
     class LlmStrategy < BaseStrategy
       CACHE_TTL = 90.days
       DEFAULT_MONTHLY_BUDGET_USD = 5.0
-      BUDGET_KEY_PREFIX = "llm_budget"
+      # Bumped from "llm_budget" when PER-492 changed the cached value encoding
+      # from USD floats to integer units. The _v2 suffix orphans pre-deploy
+      # float values so the guard doesn't misread 4.99 (USD) as 4 (units =
+      # $0.0004) during the 35-day BUDGET_TTL window after rollout.
+      BUDGET_KEY_PREFIX = "llm_budget_v2"
       BUDGET_TTL = 35.days
-      # Budget is stored in the cache as an integer scaled by this factor so
+      # Budget is stored in the cache as an integer in "budget units" so
       # Rails.cache.increment (integer-only) can be used atomically. LLM calls
       # can cost fractions of a cent (e.g. $0.0003), so cents (×100) would
-      # truncate to 0. ×10_000 preserves tenths-of-a-cent precision.
-      BUDGET_CENTS_SCALE = 10_000
+      # truncate to 0. BUDGET_UNITS_PER_USD = 10_000 preserves tenths-of-a-cent.
+      BUDGET_UNITS_PER_USD = 10_000
       CORRECTION_KEY_PREFIX = "llm_correction"
 
       # Rate limit handling.
@@ -43,11 +47,13 @@ module Services::Categorization
 
       # Resolves the monthly LLM budget cap in USD. Reads LLM_MONTHLY_BUDGET_USD
       # from the environment and falls back defensively: a non-numeric, empty,
-      # zero, or negative value collapses to the default so a misconfigured env
-      # var cannot silently disable the budget guard.
+      # zero, negative, or infinite value collapses to the default so a
+      # misconfigured env var cannot silently disable the budget guard. (Note
+      # that Float("1e400") == Float::INFINITY, and Infinity.positive? is true,
+      # so the .finite? check is load-bearing, not cosmetic.)
       def self.monthly_budget
         value = Float(ENV.fetch("LLM_MONTHLY_BUDGET_USD", nil))
-        value.positive? ? value : DEFAULT_MONTHLY_BUDGET_USD
+        value.positive? && value.finite? ? value : DEFAULT_MONTHLY_BUDGET_USD
       rescue TypeError, ArgumentError
         DEFAULT_MONTHLY_BUDGET_USD
       end
@@ -252,19 +258,24 @@ module Services::Categorization
 
       def budget_exceeded?
         current_spend_units = Rails.cache.read(budget_key).to_i
-        (current_spend_units.to_f / BUDGET_CENTS_SCALE) >= self.class.monthly_budget
+        (current_spend_units.to_f / BUDGET_UNITS_PER_USD) >= self.class.monthly_budget
       end
 
       def increment_budget(cost)
         # Atomic increment at the cache layer so concurrent workers cannot lose
         # updates to a read-modify-write race (PER-492). Rails.cache.increment
-        # is integer-only, so we store cost in units of 1 / BUDGET_CENTS_SCALE
+        # is integer-only, so we store cost in units of 1 / BUDGET_UNITS_PER_USD
         # of a USD (tenths of a cent) and rescale on read in #budget_exceeded?.
-        units = (cost * BUDGET_CENTS_SCALE).ceil
-        return if units.zero?
+        units = (cost * BUDGET_UNITS_PER_USD).ceil
+        return if units <= 0
 
-        Rails.cache.increment(budget_key, units, expires_in: BUDGET_TTL) ||
-          Rails.cache.write(budget_key, units, expires_in: BUDGET_TTL)
+        # `write(unless_exist: true)` atomically seeds the counter at 0 on the
+        # first call of the month without overwriting an existing value. The
+        # subsequent `increment` is then always against an existing integer
+        # key — no `|| write` fallback race where two concurrent first-callers
+        # both see `nil` and each `write(units)`, clobbering one update.
+        Rails.cache.write(budget_key, 0, expires_in: BUDGET_TTL, unless_exist: true)
+        Rails.cache.increment(budget_key, units, expires_in: BUDGET_TTL)
       end
 
       def build_budget_exceeded_result(start_time)

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -11,9 +11,14 @@ module Services::Categorization
     # and fed into VectorUpdater so Layer 2 can learn from them.
     class LlmStrategy < BaseStrategy
       CACHE_TTL = 90.days
-      MONTHLY_BUDGET = 5.0
+      DEFAULT_MONTHLY_BUDGET_USD = 5.0
       BUDGET_KEY_PREFIX = "llm_budget"
       BUDGET_TTL = 35.days
+      # Budget is stored in the cache as an integer scaled by this factor so
+      # Rails.cache.increment (integer-only) can be used atomically. LLM calls
+      # can cost fractions of a cent (e.g. $0.0003), so cents (×100) would
+      # truncate to 0. ×10_000 preserves tenths-of-a-cent precision.
+      BUDGET_CENTS_SCALE = 10_000
       CORRECTION_KEY_PREFIX = "llm_correction"
 
       # Rate limit handling.
@@ -34,6 +39,17 @@ module Services::Categorization
       class << self
         attr_accessor :last_llm_call_at
         attr_reader :rate_limit_mutex
+      end
+
+      # Resolves the monthly LLM budget cap in USD. Reads LLM_MONTHLY_BUDGET_USD
+      # from the environment and falls back defensively: a non-numeric, empty,
+      # zero, or negative value collapses to the default so a misconfigured env
+      # var cannot silently disable the budget guard.
+      def self.monthly_budget
+        value = Float(ENV.fetch("LLM_MONTHLY_BUDGET_USD", nil))
+        value.positive? ? value : DEFAULT_MONTHLY_BUDGET_USD
+      rescue TypeError, ArgumentError
+        DEFAULT_MONTHLY_BUDGET_USD
       end
 
       # @param client [Llm::Client, nil] injectable LLM client for testing
@@ -235,16 +251,20 @@ module Services::Categorization
       end
 
       def budget_exceeded?
-        current_spend = Rails.cache.read(budget_key) || 0.0
-        current_spend.to_f >= MONTHLY_BUDGET
+        current_spend_units = Rails.cache.read(budget_key).to_i
+        (current_spend_units.to_f / BUDGET_CENTS_SCALE) >= self.class.monthly_budget
       end
 
       def increment_budget(cost)
-        # Atomic-safe: read + write with the new total.
-        # Acceptable for single-user app — concurrent LLM calls are serialized
-        # by the strategy chain (one expense at a time).
-        current = Rails.cache.read(budget_key) || 0.0
-        Rails.cache.write(budget_key, current.to_f + cost, expires_in: BUDGET_TTL)
+        # Atomic increment at the cache layer so concurrent workers cannot lose
+        # updates to a read-modify-write race (PER-492). Rails.cache.increment
+        # is integer-only, so we store cost in units of 1 / BUDGET_CENTS_SCALE
+        # of a USD (tenths of a cent) and rescale on read in #budget_exceeded?.
+        units = (cost * BUDGET_CENTS_SCALE).ceil
+        return if units.zero?
+
+        Rails.cache.increment(budget_key, units, expires_in: BUDGET_TTL) ||
+          Rails.cache.write(budget_key, units, expires_in: BUDGET_TTL)
       end
 
       def build_budget_exceeded_result(start_time)

--- a/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
+++ b/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
@@ -270,7 +270,10 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
   end
 
   describe "#api_budget_status" do
-    let(:cache_key) { "llm_budget:#{Date.current.strftime('%Y-%m')}" }
+    let(:cache_key) do
+      "#{Services::Categorization::Strategies::LlmStrategy::BUDGET_KEY_PREFIX}:" \
+      "#{Date.current.strftime('%Y-%m')}"
+    end
 
     context "when cache has current month spend" do
       before do
@@ -313,7 +316,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "with healthy status (under 50%)" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(2.0)
+        # 2.0 USD in scaled units = 20_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(20_000)
       end
 
       it "returns healthy status" do
@@ -381,7 +385,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "return value structure" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(1.0)
+        # 1.0 USD in scaled units = 10_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(10_000)
       end
 
       it "returns all required keys" do

--- a/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
+++ b/spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb
@@ -274,17 +274,18 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "when cache has current month spend" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(2.50)
+        # Spend is stored as scaled integer units (PER-492): 2.50 USD = 25_000.
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(25_000)
       end
 
-      it "returns spend from cache" do
+      it "returns spend from cache rescaled back to USD" do
         result = service.api_budget_status
         expect(result[:current_spend]).to eq(2.50)
       end
 
-      it "returns the budget amount" do
+      it "returns the budget amount from LlmStrategy.monthly_budget" do
         result = service.api_budget_status
-        expect(result[:budget]).to eq(5.0)
+        expect(result[:budget]).to eq(Services::Categorization::Strategies::LlmStrategy.monthly_budget)
       end
 
       it "calculates percentage correctly" do
@@ -322,7 +323,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "with warning status (exactly 50%)" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(2.5)
+        # 2.5 USD in scaled units = 25_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(25_000)
       end
 
       it "returns warning status" do
@@ -332,7 +334,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "with warning status (between 50% and 80%)" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(3.5)
+        # 3.5 USD in scaled units = 35_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(35_000)
       end
 
       it "returns warning status" do
@@ -342,7 +345,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "with critical status (exactly 80%)" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(4.0)
+        # 4.0 USD in scaled units = 40_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(40_000)
       end
 
       it "returns critical status" do
@@ -352,7 +356,8 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "with critical status (exceeds budget)" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(6.0)
+        # 6.0 USD in scaled units = 60_000
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(60_000)
       end
 
       it "returns critical status" do
@@ -362,7 +367,7 @@ RSpec.describe Services::Categorization::Monitoring::MetricsDashboardService, ty
 
     context "when spend is zero" do
       before do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(0.0)
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(0)
       end
 
       it "returns healthy status" do

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
   end
 
   describe "constants" do
-    it "defines BUDGET_KEY_PREFIX" do
-      expect(described_class::BUDGET_KEY_PREFIX).to eq("llm_budget")
+    it "defines BUDGET_KEY_PREFIX with the v2 suffix (PER-492 encoding change)" do
+      expect(described_class::BUDGET_KEY_PREFIX).to eq("llm_budget_v2")
     end
 
-    it "defines BUDGET_CENTS_SCALE as 10_000" do
-      expect(described_class::BUDGET_CENTS_SCALE).to eq(10_000)
+    it "defines BUDGET_UNITS_PER_USD as 10_000" do
+      expect(described_class::BUDGET_UNITS_PER_USD).to eq(10_000)
     end
   end
 
@@ -69,21 +69,81 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
       expect(described_class.monthly_budget).to eq(5.0)
     end
 
-    it "falls back to the default for a zero or negative value" do
+    it "falls back to the default for zero" do
       ENV["LLM_MONTHLY_BUDGET_USD"] = "0"
       expect(described_class.monthly_budget).to eq(5.0)
+    end
 
+    it "falls back to the default for a negative value" do
       ENV["LLM_MONTHLY_BUDGET_USD"] = "-1"
       expect(described_class.monthly_budget).to eq(5.0)
+    end
+
+    # Float("1e400") == Float::INFINITY, and Infinity.positive? is true, so
+    # without the .finite? guard a misconfigured env would silently disable
+    # the cap.
+    it "falls back to the default for a value that parses to Infinity" do
+      ENV["LLM_MONTHLY_BUDGET_USD"] = "1e400"
+      expect(described_class.monthly_budget).to eq(5.0)
+    end
+  end
+
+  describe "#budget_exceeded? boundary" do
+    let(:budget_key) { "llm_budget_v2:#{Date.current.strftime('%Y-%m')}" }
+
+    it "returns false at 49_999 units (1 unit under the $5 cap)" do
+      Rails.cache.write(budget_key, 49_999, expires_in: 35.days)
+      expect(strategy.send(:budget_exceeded?)).to be false
+    end
+
+    it "returns true at 50_000 units (exactly at the $5 cap)" do
+      Rails.cache.write(budget_key, 50_000, expires_in: 35.days)
+      expect(strategy.send(:budget_exceeded?)).to be true
+    end
+
+    it "returns true at 50_001 units (1 unit over the $5 cap)" do
+      Rails.cache.write(budget_key, 50_001, expires_in: 35.days)
+      expect(strategy.send(:budget_exceeded?)).to be true
+    end
+  end
+
+  describe "#increment_budget edge cases" do
+    let(:budget_key) { "llm_budget_v2:#{Date.current.strftime('%Y-%m')}" }
+
+    before { Rails.cache.delete(budget_key) }
+
+    it "no-ops when cost is exactly zero" do
+      strategy.send(:increment_budget, 0.0)
+      expect(Rails.cache.read(budget_key)).to be_nil
+    end
+
+    it "no-ops when cost rounds down to zero units (e.g. tiny negative)" do
+      strategy.send(:increment_budget, -0.00001)
+      expect(Rails.cache.read(budget_key)).to be_nil
+    end
+
+    # Guards against provider refund / upstream bug producing a negative cost,
+    # which would otherwise decrement the counter via Rails.cache.increment.
+    it "no-ops for a larger negative cost instead of decrementing" do
+      strategy.send(:increment_budget, -0.50)
+      expect(Rails.cache.read(budget_key)).to be_nil
+    end
+
+    # Exercises the write(unless_exist:) + increment pair on a fresh key —
+    # the production path on the first LLM call of each month.
+    it "seeds and increments on the first call when the key is absent" do
+      strategy.send(:increment_budget, 0.25)
+      # ceil(0.25 * 10_000) = 2_500 units
+      expect(Rails.cache.read(budget_key)).to eq(2_500)
     end
   end
 
   describe "#call" do
     context "when budget is exceeded" do
       before do
-        # Cache stores spend in integer units scaled by BUDGET_CENTS_SCALE (10_000).
+        # Cache stores spend in integer units scaled by BUDGET_UNITS_PER_USD (10_000).
         # 5.50 USD = 55_000 units (over the 5.00 cap).
-        budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        budget_key = "llm_budget_v2:#{Date.current.strftime('%Y-%m')}"
         Rails.cache.write(budget_key, 55_000, expires_in: 35.days)
       end
 
@@ -108,7 +168,7 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
     context "when budget is exactly at the limit" do
       before do
         # 5.00 USD = 50_000 units (exactly at the cap).
-        budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        budget_key = "llm_budget_v2:#{Date.current.strftime('%Y-%m')}"
         Rails.cache.write(budget_key, 50_000, expires_in: 35.days)
       end
 
@@ -132,7 +192,7 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
 
       before do
         # 4.99 USD = 49_900 units.
-        budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        budget_key = "llm_budget_v2:#{Date.current.strftime('%Y-%m')}"
         Rails.cache.write(budget_key, 49_900, expires_in: 35.days)
 
         allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
@@ -150,10 +210,10 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
         expect(mock_client).to have_received(:categorize)
       end
 
-      it "increments the budget counter atomically by (cost * BUDGET_CENTS_SCALE).ceil" do
+      it "increments the budget counter atomically by (cost * BUDGET_UNITS_PER_USD).ceil" do
         strategy.call(expense)
 
-        budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        budget_key = "llm_budget_v2:#{Date.current.strftime('%Y-%m')}"
         # 49_900 seed + ceil(0.0003 * 10_000) = 49_900 + 3 = 49_903
         expect(Rails.cache.read(budget_key)).to eq(49_903)
       end
@@ -179,7 +239,7 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
       end
 
       it "initializes the counter from zero when no prior spend exists" do
-        budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
+        budget_key = "llm_budget_v2:#{Date.current.strftime('%Y-%m')}"
         Rails.cache.delete(budget_key)
 
         strategy.call(expense)
@@ -193,7 +253,7 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
     # Under burst load, RMW silently undercounts by 10-20% and the $5/mo cap
     # stops triggering. This test spins up 10 threads hitting the same key.
     context "atomic budget increment under concurrency", :integration do
-      let(:budget_key) { "llm_budget:#{Date.current.strftime('%Y-%m')}" }
+      let(:budget_key) { "llm_budget_v2:#{Date.current.strftime('%Y-%m')}" }
 
       it "produces the correct total when 10 threads each increment $0.50" do
         Rails.cache.delete(budget_key)

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -32,20 +32,59 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
   end
 
   describe "constants" do
-    it "defines MONTHLY_BUDGET as 5.0" do
-      expect(described_class::MONTHLY_BUDGET).to eq(5.0)
-    end
-
     it "defines BUDGET_KEY_PREFIX" do
       expect(described_class::BUDGET_KEY_PREFIX).to eq("llm_budget")
+    end
+
+    it "defines BUDGET_CENTS_SCALE as 10_000" do
+      expect(described_class::BUDGET_CENTS_SCALE).to eq(10_000)
+    end
+  end
+
+  describe ".monthly_budget" do
+    around do |example|
+      original = ENV["LLM_MONTHLY_BUDGET_USD"]
+      ENV.delete("LLM_MONTHLY_BUDGET_USD")
+      example.run
+    ensure
+      ENV["LLM_MONTHLY_BUDGET_USD"] = original
+    end
+
+    it "defaults to 5.0 when LLM_MONTHLY_BUDGET_USD is not set" do
+      expect(described_class.monthly_budget).to eq(5.0)
+    end
+
+    it "reads LLM_MONTHLY_BUDGET_USD from env when set" do
+      ENV["LLM_MONTHLY_BUDGET_USD"] = "12.50"
+      expect(described_class.monthly_budget).to eq(12.50)
+    end
+
+    it "falls back to the default for a non-numeric value" do
+      ENV["LLM_MONTHLY_BUDGET_USD"] = "disabled"
+      expect(described_class.monthly_budget).to eq(5.0)
+    end
+
+    it "falls back to the default for an empty value" do
+      ENV["LLM_MONTHLY_BUDGET_USD"] = ""
+      expect(described_class.monthly_budget).to eq(5.0)
+    end
+
+    it "falls back to the default for a zero or negative value" do
+      ENV["LLM_MONTHLY_BUDGET_USD"] = "0"
+      expect(described_class.monthly_budget).to eq(5.0)
+
+      ENV["LLM_MONTHLY_BUDGET_USD"] = "-1"
+      expect(described_class.monthly_budget).to eq(5.0)
     end
   end
 
   describe "#call" do
     context "when budget is exceeded" do
       before do
+        # Cache stores spend in integer units scaled by BUDGET_CENTS_SCALE (10_000).
+        # 5.50 USD = 55_000 units (over the 5.00 cap).
         budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
-        Rails.cache.write(budget_key, 5.50, expires_in: 35.days)
+        Rails.cache.write(budget_key, 55_000, expires_in: 35.days)
       end
 
       it "returns no_match with budget_exceeded reason" do
@@ -68,8 +107,9 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
 
     context "when budget is exactly at the limit" do
       before do
+        # 5.00 USD = 50_000 units (exactly at the cap).
         budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
-        Rails.cache.write(budget_key, 5.0, expires_in: 35.days)
+        Rails.cache.write(budget_key, 50_000, expires_in: 35.days)
       end
 
       it "returns no_match with budget_exceeded reason" do
@@ -91,8 +131,9 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
       end
 
       before do
+        # 4.99 USD = 49_900 units.
         budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
-        Rails.cache.write(budget_key, 4.99, expires_in: 35.days)
+        Rails.cache.write(budget_key, 49_900, expires_in: 35.days)
 
         allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
           .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
@@ -109,11 +150,12 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
         expect(mock_client).to have_received(:categorize)
       end
 
-      it "increments the budget counter by the call cost" do
+      it "increments the budget counter atomically by (cost * BUDGET_CENTS_SCALE).ceil" do
         strategy.call(expense)
 
         budget_key = "llm_budget:#{Date.current.strftime('%Y-%m')}"
-        expect(Rails.cache.read(budget_key)).to be_within(0.0001).of(4.9903)
+        # 49_900 seed + ceil(0.0003 * 10_000) = 49_900 + 3 = 49_903
+        expect(Rails.cache.read(budget_key)).to eq(49_903)
       end
     end
 
@@ -142,7 +184,29 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
 
         strategy.call(expense)
 
-        expect(Rails.cache.read(budget_key)).to be_within(0.0001).of(0.0005)
+        # ceil(0.0005 * 10_000) = 5
+        expect(Rails.cache.read(budget_key)).to eq(5)
+      end
+    end
+
+    # PER-492: Replaces the read-modify-write pattern with atomic cache increment.
+    # Under burst load, RMW silently undercounts by 10-20% and the $5/mo cap
+    # stops triggering. This test spins up 10 threads hitting the same key.
+    context "atomic budget increment under concurrency", :integration do
+      let(:budget_key) { "llm_budget:#{Date.current.strftime('%Y-%m')}" }
+
+      it "produces the correct total when 10 threads each increment $0.50" do
+        Rails.cache.delete(budget_key)
+
+        # Build 10 strategy instances so each thread has its own (throttle mutex
+        # is class-level; we want to exercise the cache increment, not the throttle).
+        threads = 10.times.map do
+          Thread.new { described_class.new.send(:increment_budget, 0.50) }
+        end
+        threads.each(&:join)
+
+        # 10 threads * ceil(0.50 * 10_000) = 10 * 5_000 = 50_000
+        expect(Rails.cache.read(budget_key)).to eq(50_000)
       end
     end
     context "when expense has no merchant_name" do


### PR DESCRIPTION
## Summary

Closes [PER-492](https://linear.app/personal-brand-esoto/issue/PER-492) — deploy-blocker **B2** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

Replaces the read-modify-write pattern in `LlmStrategy#increment_budget` with atomic `Rails.cache.increment` so concurrent workers cannot lose budget updates.

## Why

Two concurrent callers can both read `4.99`, both add `0.02`, only one write wins → real spend `$5.03`, recorded `$5.01`. The `$5/mo` hard cap (our only cost control) then fails to trigger. Round 2 of the production-readiness review measured 10-20% undercount under burst load.

## What changed

- **`LlmStrategy#increment_budget`** — atomic `Rails.cache.increment`, falls back to `Rails.cache.write` on the first call of the month (when the key is absent). Integer-only, so cost is scaled by `BUDGET_CENTS_SCALE = 10_000` (tenths of a cent). Scaling by cents (×100) would truncate every sub-cent LLM call to 0.
- **`LlmStrategy#budget_exceeded?`** — rescales integer units back to USD before comparison.
- **`LlmStrategy.monthly_budget`** — new env-tunable class method reading `LLM_MONTHLY_BUDGET_USD` with defensive parsing (non-numeric / empty / zero / negative → `DEFAULT_MONTHLY_BUDGET_USD`, so a misconfigured env cannot silently disable the guard). Same pattern used for PER-491 (`ANTHROPIC_TIMEOUT_SECONDS`).
- **`MetricsDashboardService`** — dropped its duplicate `MONTHLY_BUDGET = 5.0` constant, now delegates to `LlmStrategy.monthly_budget`. `#fetch_current_spend` rescales the cache value so the admin dashboard keeps reporting the right number under the new encoding.

## Test plan

- [x] New `.monthly_budget` specs covering default / non-numeric / empty / zero / negative env fallback
- [x] New concurrency spec (integration-tagged): 10 threads × `increment_budget(0.50)` → exactly `50_000` cache units
- [x] Existing `LlmStrategy` budget specs updated to seed integer units
- [x] Existing `MetricsDashboardService` specs updated to seed integer units and assert shared budget source
- [x] \`bundle exec rspec spec/services/categorization/strategies/llm_strategy_spec.rb\` — **41 examples, 0 failures**
- [x] \`bundle exec rspec spec/services/categorization/monitoring/metrics_dashboard_service_spec.rb\` — **37 examples, 0 failures**
- [x] \`bundle exec rspec spec/services/categorization/ --tag unit\` — **1242 examples, 0 failures, 1 pending** (unrelated flaky perf test)
- [x] \`bundle exec rubocop\` on changed files — clean (after autocorrect)
- [x] \`bundle exec brakeman\` — no warnings