### PR TITLE
deploy(kamal): add health check + readiness_delay + pending-migration hook (PER-493)

### DIFF
--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -16,7 +16,9 @@ output="$(kamal app exec --reuse "bin/rails db:migrate:status" 2>&1 || true)"
 
 if echo "$output" | grep -q "^[[:space:]]*down[[:space:]]"; then
   echo "ERROR: Pending migrations detected. Refusing to deploy." >&2
-  echo "$output" | grep "^[[:space:]]*down[[:space:]]" >&2
+  # Print status + version only, not migration filenames, to avoid leaking
+  # schema evolution detail into deploy logs (CWE-532).
+  echo "$output" | awk '/^[[:space:]]*down[[:space:]]/ { print $1, $2 }' >&2
   echo "Run \`kamal app exec \"bin/rails db:migrate\"\` from a safe window first." >&2
   exit 1
 fi

--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Kamal pre-deploy hook (PER-493): block the deploy if migrations are pending.
+#
+# Without this, an engineer can push an image whose schema doesn't match the
+# production DB, causing immediate 500s on ActiveRecord::PendingMigrationError
+# until `kamal app exec "bin/rails db:migrate"` is run manually.
+#
+# Kamal passes deploy metadata via env vars; we don't need them here — we run
+# migrate:status inside the currently-running container so we check the image
+# that is about to ship.
+set -euo pipefail
+
+echo "  Verifying no pending migrations..."
+
+output="$(kamal app exec --reuse "bin/rails db:migrate:status" 2>&1 || true)"
+
+if echo "$output" | grep -q "^[[:space:]]*down[[:space:]]"; then
+  echo "ERROR: Pending migrations detected. Refusing to deploy." >&2
+  echo "$output" | grep "^[[:space:]]*down[[:space:]]" >&2
+  echo "Run \`kamal app exec \"bin/rails db:migrate\"\` from a safe window first." >&2
+  exit 1
+fi
+
+echo "  No pending migrations."

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -13,6 +13,20 @@ servers:
 proxy:
   ssl: true
   host: expense-tracker.estebansoto.dev
+  app_port: 3000
+  # kamal-proxy polls the Rails /up endpoint (see config/routes.rb) before
+  # cutting traffic to a new container. Without this, a broken boot would
+  # silently serve errors to users (deploy-blocker B3, PER-493).
+  healthcheck:
+    path: /up
+    interval: 10
+    timeout: 5
+
+# Grace period after health check passes before the old container is retired.
+# Orchestrator#warm_caches (app/services/categorization/orchestrator.rb:106)
+# runs on boot and can take several seconds — this avoids serving first
+# requests against an unwarmed app.
+readiness_delay: 15
 
 # GitHub Container Registry
 registry:


### PR DESCRIPTION
## Summary

Closes [PER-493](https://linear.app/personal-brand-esoto/issue/PER-493) — deploy-blocker **B3** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

Kamal had no explicit healthcheck block and no `readiness_delay`, so a broken boot (syntax error in initializer, missing env var, failed migration) would cut traffic to the new container without ever checking it responded. Users would see errors until a manual rollback.

## Changes

**`config/deploy.yml`**
- `proxy.healthcheck` polls `/up` every 10s with a 5s timeout. The `/up` route is served by Rails 8's built-in `rails/health#show` and is already wired at [config/routes.rb:219](config/routes.rb:219).
- `readiness_delay: 15` grace period so `Orchestrator#warm_caches` ([app/services/categorization/orchestrator.rb:106](app/services/categorization/orchestrator.rb:106)) has time to finish before traffic hits the new container.
- `app_port: 3000` made explicit (previously relying on Kamal default).

**`.kamal/hooks/pre-deploy`** (new, executable)
- Runs `bin/rails db:migrate:status` inside the live container before shipping and aborts the deploy if any migration is still `down`. Prevents a `ActiveRecord::PendingMigrationError` 500 loop on cutover.

## Test plan

- [x] `ruby -ryaml -e "YAML.load_file('config/deploy.yml')"` — parses cleanly
- [x] `bundle exec kamal config` — no schema errors, all proxy/healthcheck/readiness_delay fields resolved
- [x] `chmod +x .kamal/hooks/pre-deploy` — executable bit set (verified in git index)
- [ ] On next staging deploy: verify `kamal deploy` pauses until `/up` returns 200
- [ ] On next staging deploy: intentionally break boot (e.g. syntax error in a config initializer) and verify Kamal rolls back
- [ ] On next staging deploy: stage a down migration locally, attempt deploy, verify pre-deploy hook aborts