### PR TITLE
security: encrypt email_parsing_failures.raw_email_content + 30d retention (PER-496)

### DIFF
--- a/app/jobs/email_parsing_failure_cleanup_job.rb
+++ b/app/jobs/email_parsing_failure_cleanup_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Background job that purges EmailParsingFailure rows older than RETENTION_DAYS.
+#
+# EmailParsingFailure.raw_email_content holds bank PII (amounts, merchants,
+# account refs, recipient addresses, transaction times). PER-496 encrypts new
+# rows at rest; this job enforces the companion retention window so historical
+# failure data doesn't accumulate indefinitely.
+#
+# Scheduled daily at 4am via config/recurring.yml.
+class EmailParsingFailureCleanupJob < ApplicationJob
+  RETENTION_DAYS = 30
+
+  queue_as :low
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform
+    cutoff = RETENTION_DAYS.days.ago
+    Rails.logger.info "[EmailParsingFailureCleanup] Starting cleanup (cutoff=#{cutoff.iso8601})..."
+
+    count = EmailParsingFailure.where(created_at: ..cutoff).delete_all
+
+    Rails.logger.info "[EmailParsingFailureCleanup] Cleanup complete: cleaned_up=#{count}"
+  rescue StandardError => e
+    Rails.logger.error "[EmailParsingFailureCleanup] Cleanup failed: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise
+  end
+end

--- a/app/jobs/email_parsing_failure_cleanup_job.rb
+++ b/app/jobs/email_parsing_failure_cleanup_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Background job that purges EmailParsingFailure rows older than RETENTION_DAYS.
+# Background job that purges EmailParsingFailure rows older than
+# EmailParsingFailure::RETENTION_DAYS.
 #
 # EmailParsingFailure.raw_email_content holds bank PII (amounts, merchants,
 # account refs, recipient addresses, transaction times). PER-496 encrypts new
@@ -9,16 +10,16 @@
 #
 # Scheduled daily at 4am via config/recurring.yml.
 class EmailParsingFailureCleanupJob < ApplicationJob
-  RETENTION_DAYS = 30
-
   queue_as :low
   retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   def perform
-    cutoff = RETENTION_DAYS.days.ago
-    Rails.logger.info "[EmailParsingFailureCleanup] Starting cleanup (cutoff=#{cutoff.iso8601})..."
+    Rails.logger.info "[EmailParsingFailureCleanup] Starting cleanup (retention=#{EmailParsingFailure::RETENTION_DAYS}d)..."
 
-    count = EmailParsingFailure.where(created_at: ..cutoff).delete_all
+    # delete_all (not destroy_all): no before/after_destroy callbacks on
+    # EmailParsingFailure, so bulk SQL DELETE is correct and fast. If a
+    # callback is ever added, switch to destroy_all.
+    count = EmailParsingFailure.expired.delete_all
 
     Rails.logger.info "[EmailParsingFailureCleanup] Cleanup complete: cleaned_up=#{count}"
   rescue StandardError => e

--- a/app/models/email_parsing_failure.rb
+++ b/app/models/email_parsing_failure.rb
@@ -1,11 +1,19 @@
 class EmailParsingFailure < ApplicationRecord
+  RETENTION_DAYS = 30
+
   belongs_to :email_account
 
   # PER-496: raw_email_content holds bank PII (amounts, merchants, account
   # refs, recipient addresses, transaction times). Encrypt at rest.
   # support_unencrypted_data: true keeps existing plaintext rows readable
   # until the 30-day retention job purges them (EmailParsingFailureCleanupJob).
+  # TODO(PER-534): Remove support_unencrypted_data once legacy plaintext rows
+  # have aged out (30+ days after PR #428 reaches production).
   encrypts :raw_email_content, support_unencrypted_data: true
+
+  # Retention-window scope used by EmailParsingFailureCleanupJob. Inclusive
+  # endpoint so a row at exactly the cutoff is considered expired.
+  scope :expired, -> { where(created_at: ..RETENTION_DAYS.days.ago) }
 
   validate :error_messages_not_nil
 

--- a/app/models/email_parsing_failure.rb
+++ b/app/models/email_parsing_failure.rb
@@ -1,6 +1,12 @@
 class EmailParsingFailure < ApplicationRecord
   belongs_to :email_account
 
+  # PER-496: raw_email_content holds bank PII (amounts, merchants, account
+  # refs, recipient addresses, transaction times). Encrypt at rest.
+  # support_unencrypted_data: true keeps existing plaintext rows readable
+  # until the 30-day retention job purges them (EmailParsingFailureCleanupJob).
+  encrypts :raw_email_content, support_unencrypted_data: true
+
   validate :error_messages_not_nil
 
   private

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -73,6 +73,16 @@ default: &default
     schedule: every day at 3am
     description: "Run data quality audit to check pattern coverage, detect duplicates, and identify issues"
 
+  # Purge email parsing failures older than 30 days. raw_email_content holds
+  # bank PII — encrypted at rest (PER-496), this job enforces the retention
+  # window so historical failure data doesn't accumulate indefinitely.
+  cleanup_email_parsing_failures:
+    class: EmailParsingFailureCleanupJob
+    queue: low
+    priority: 10
+    schedule: every day at 4am
+    description: "Purge email parsing failures older than 30 days (PER-496 retention)"
+
 development:
   <<: *default
   # In development, run metrics calculation more frequently for testing

--- a/spec/jobs/email_parsing_failure_cleanup_job_spec.rb
+++ b/spec/jobs/email_parsing_failure_cleanup_job_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe EmailParsingFailureCleanupJob, type: :job, unit: true do
     allow(Rails.logger).to receive(:error)
   end
 
-  describe "constants" do
-    it "defines RETENTION_DAYS as 30" do
-      expect(described_class::RETENTION_DAYS).to eq(30)
+  describe "retention policy" do
+    # The retention threshold lives on the model (PER-496 review feedback —
+    # matches the LlmCategorizationCacheEntry.expired convention).
+    it "uses EmailParsingFailure::RETENTION_DAYS (currently 30)" do
+      expect(EmailParsingFailure::RETENTION_DAYS).to eq(30)
     end
   end
 
@@ -21,22 +23,36 @@ RSpec.describe EmailParsingFailureCleanupJob, type: :job, unit: true do
       expect { job.perform }.not_to raise_error
     end
 
-    it "logs the count of cleaned up rows" do
-      expect(Rails.logger).to receive(:info).with(/cleaned_up=0/)
+    it "logs a completion line with the cleaned-up count" do
+      expect(Rails.logger).to receive(:info).with(/Cleanup complete: cleaned_up=0/)
       job.perform
     end
 
-    context "with a mix of stale and recent failures" do
+    context "with a mix of stale, boundary, and recent failures" do
+      # travel_to freezes `Time.current` so the job's `.expired` scope
+      # evaluates the cutoff to the same instant our fixtures are anchored
+      # against — no race between spec and job clock reads.
+      around do |example|
+        travel_to(Time.zone.local(2026, 4, 17, 4, 0, 0)) { example.run }
+      end
+
       let!(:stale_failure) do
         create(:email_parsing_failure).tap do |f|
           f.update_columns(created_at: 31.days.ago)
         end
       end
 
-      let!(:boundary_failure) do
+      let!(:exact_cutoff_failure) do
         create(:email_parsing_failure).tap do |f|
-          # 30 days 1 second ago — should be purged (older than the cutoff)
-          f.update_columns(created_at: 30.days.ago - 1.second)
+          # Exactly at cutoff — `.expired` uses an inclusive range so this
+          # row IS expired.
+          f.update_columns(created_at: EmailParsingFailure::RETENTION_DAYS.days.ago)
+        end
+      end
+
+      let!(:just_before_cutoff_failure) do
+        create(:email_parsing_failure).tap do |f|
+          f.update_columns(created_at: (EmailParsingFailure::RETENTION_DAYS.days.ago + 1.second))
         end
       end
 
@@ -46,23 +62,24 @@ RSpec.describe EmailParsingFailureCleanupJob, type: :job, unit: true do
         end
       end
 
-      it "deletes rows older than 30 days" do
+      it "deletes rows older than or equal to the cutoff" do
         expect { job.perform }.to change(EmailParsingFailure, :count).by(-2)
       end
 
-      it "preserves rows newer than 30 days" do
+      it "preserves rows newer than the cutoff (including the row 1 second younger)" do
         job.perform
         expect(EmailParsingFailure.exists?(recent_failure.id)).to be true
+        expect(EmailParsingFailure.exists?(just_before_cutoff_failure.id)).to be true
       end
 
-      it "deletes the stale and boundary rows" do
+      it "deletes the stale and exact-cutoff rows (inclusive boundary)" do
         job.perform
         expect(EmailParsingFailure.exists?(stale_failure.id)).to be false
-        expect(EmailParsingFailure.exists?(boundary_failure.id)).to be false
+        expect(EmailParsingFailure.exists?(exact_cutoff_failure.id)).to be false
       end
 
-      it "logs the count of cleaned up rows" do
-        expect(Rails.logger).to receive(:info).with(/cleaned_up=2/)
+      it "logs the completion line with the cleaned-up count" do
+        expect(Rails.logger).to receive(:info).with(/Cleanup complete: cleaned_up=2/)
         job.perform
       end
     end

--- a/spec/jobs/email_parsing_failure_cleanup_job_spec.rb
+++ b/spec/jobs/email_parsing_failure_cleanup_job_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EmailParsingFailureCleanupJob, type: :job, unit: true do
+  let(:job) { described_class.new }
+
+  before do
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  describe "constants" do
+    it "defines RETENTION_DAYS as 30" do
+      expect(described_class::RETENTION_DAYS).to eq(30)
+    end
+  end
+
+  describe "#perform" do
+    it "runs without error when no failures exist" do
+      expect { job.perform }.not_to raise_error
+    end
+
+    it "logs the count of cleaned up rows" do
+      expect(Rails.logger).to receive(:info).with(/cleaned_up=0/)
+      job.perform
+    end
+
+    context "with a mix of stale and recent failures" do
+      let!(:stale_failure) do
+        create(:email_parsing_failure).tap do |f|
+          f.update_columns(created_at: 31.days.ago)
+        end
+      end
+
+      let!(:boundary_failure) do
+        create(:email_parsing_failure).tap do |f|
+          # 30 days 1 second ago — should be purged (older than the cutoff)
+          f.update_columns(created_at: 30.days.ago - 1.second)
+        end
+      end
+
+      let!(:recent_failure) do
+        create(:email_parsing_failure).tap do |f|
+          f.update_columns(created_at: 29.days.ago)
+        end
+      end
+
+      it "deletes rows older than 30 days" do
+        expect { job.perform }.to change(EmailParsingFailure, :count).by(-2)
+      end
+
+      it "preserves rows newer than 30 days" do
+        job.perform
+        expect(EmailParsingFailure.exists?(recent_failure.id)).to be true
+      end
+
+      it "deletes the stale and boundary rows" do
+        job.perform
+        expect(EmailParsingFailure.exists?(stale_failure.id)).to be false
+        expect(EmailParsingFailure.exists?(boundary_failure.id)).to be false
+      end
+
+      it "logs the count of cleaned up rows" do
+        expect(Rails.logger).to receive(:info).with(/cleaned_up=2/)
+        job.perform
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "is queued on the low-priority queue" do
+      expect(described_class.new.queue_name).to eq("low")
+    end
+  end
+end

--- a/spec/models/email_parsing_failure_spec.rb
+++ b/spec/models/email_parsing_failure_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe EmailParsingFailure, type: :model, unit: true do
 
     # support_unencrypted_data allows the 30-day retention window to age out
     # any rows that were written as plaintext before this PR.
+    # update_all bypasses the encrypt writer (same effect as pre-PR legacy
+    # rows) without raw SQL string interpolation.
     it 'still reads existing plaintext rows during the retention window' do
       failure = create(:email_parsing_failure)
-      ActiveRecord::Base.connection.execute(
-        "UPDATE email_parsing_failures SET raw_email_content = 'legacy plaintext' WHERE id = #{failure.id}"
-      )
+      described_class.where(id: failure.id).update_all(raw_email_content: 'legacy plaintext')
 
-      expect(failure.reload.raw_email_content).to eq("legacy plaintext")
+      expect(failure.reload.raw_email_content).to eq('legacy plaintext')
     end
   end
 end

--- a/spec/models/email_parsing_failure_spec.rb
+++ b/spec/models/email_parsing_failure_spec.rb
@@ -44,4 +44,41 @@ RSpec.describe EmailParsingFailure, type: :model, unit: true do
       expect { email_account.destroy }.to change(described_class, :count).by(-1)
     end
   end
+
+  # PER-496: raw_email_content contains bank PII (amounts, merchants, account
+  # refs, transaction times) — must be encrypted at rest.
+  describe 'encryption' do
+    it 'encrypts raw_email_content at rest' do
+      expect(described_class.type_for_attribute(:raw_email_content).class).to be(
+        ActiveRecord::Encryption::EncryptedAttributeType
+      )
+    end
+
+    it 'round-trips plaintext through encrypt/decrypt transparently' do
+      failure = create(:email_parsing_failure, raw_email_content: "BAC statement: $123.45 to MERCHANT")
+      failure.reload
+      expect(failure.raw_email_content).to eq("BAC statement: $123.45 to MERCHANT")
+    end
+
+    it 'stores ciphertext in the underlying column (not plaintext)' do
+      plaintext = "sensitive bank content #{SecureRandom.hex(8)}"
+      create(:email_parsing_failure, raw_email_content: plaintext)
+
+      raw_row = ActiveRecord::Base.connection.execute(
+        "SELECT raw_email_content FROM email_parsing_failures ORDER BY id DESC LIMIT 1"
+      ).first
+      expect(raw_row["raw_email_content"]).not_to include(plaintext)
+    end
+
+    # support_unencrypted_data allows the 30-day retention window to age out
+    # any rows that were written as plaintext before this PR.
+    it 'still reads existing plaintext rows during the retention window' do
+      failure = create(:email_parsing_failure)
+      ActiveRecord::Base.connection.execute(
+        "UPDATE email_parsing_failures SET raw_email_content = 'legacy plaintext' WHERE id = #{failure.id}"
+      )
+
+      expect(failure.reload.raw_email_content).to eq("legacy plaintext")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes [PER-496](https://linear.app/personal-brand-esoto/issue/PER-496) — deploy-blocker **B6** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

\`email_parsing_failures.raw_email_content\` holds bank PII (amounts, merchants, account refs, recipient addresses, transaction times). Before this PR it was persisted as plaintext with no expiration — the table accumulated sensitive financial data indefinitely.

## Changes

**\`app/models/email_parsing_failure.rb\`**
\`\`\`ruby
encrypts :raw_email_content, support_unencrypted_data: true
\`\`\`
Per-attribute scope (not the global Rails config) keeps blast radius limited to this field. \`support_unencrypted_data: true\` keeps existing plaintext rows readable until the retention job purges them.

**\`app/jobs/email_parsing_failure_cleanup_job.rb\`** (new)
- \`RETENTION_DAYS = 30\`
- Single \`EmailParsingFailure.where(created_at: ..cutoff).delete_all\`
- \`queue_as :low\` + \`retry_on StandardError, wait: :polynomially_longer, attempts: 3\`
- Mirrors \`LlmCacheCleanupJob\` / \`StaleVectorCleanupJob\` convention

**\`config/recurring.yml\`**
\`\`\`yaml
cleanup_email_parsing_failures:
  class: EmailParsingFailureCleanupJob
  queue: low
  priority: 10
  schedule: every day at 4am
\`\`\`
Away from the 3am job cluster to avoid lock contention with \`data_quality_audit\` and \`categorization_learning\`.

## Test plan

- [x] \`bundle exec rspec spec/models/email_parsing_failure_spec.rb\` — 11 pass (4 new encryption specs: type check, round-trip, ciphertext-in-row, legacy-plaintext-readable)
- [x] \`bundle exec rspec spec/jobs/email_parsing_failure_cleanup_job_spec.rb\` — 8 pass (RETENTION_DAYS constant, boundary case, count logging, queue assignment)
- [x] \`bundle exec rspec spec/jobs/process_email_job_spec.rb\` — 27 pass (writer path still works with encryption)
- [x] \`bundle exec rubocop\` on changed Ruby files — clean
- [x] \`bundle exec brakeman\` — no warnings
- [x] \`ruby -ryaml -e "YAML.load_file('config/recurring.yml', aliases: true)"\` — parses, \`default\` block inherited to \`production\` correctly

## Legacy plaintext rows

Not backfilled. \`support_unencrypted_data: true\` keeps them readable; the retention job will purge them within 30 days of merge. Explicitly chose this over a backfill rake task because:
- Data is bounded (30-day rotation post-merge)
- No reader code path depends on the exact ciphertext/plaintext mix
- Avoids a long-running migration-style job

## Follow-ups (out of scope)

- Once production has run for 30+ days, consider removing \`support_unencrypted_data: true\` to enforce encryption strictly — separate ticket.