### PR TITLE
fix(db): close manual-expense duplicate-check hole (PER-498)

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -52,6 +52,20 @@ class Api::WebhooksController < ApplicationController
         errors: expense.errors.full_messages
       }, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique
+    # PER-498: return the existing row (idempotent) instead of a 500 when the
+    # iPhone Shortcuts retries a webhook or a user double-taps the action.
+    existing = Expense.where(
+      amount: expense.amount,
+      transaction_date: expense.transaction_date,
+      merchant_name: expense.merchant_name,
+      deleted_at: nil
+    ).first
+    render json: {
+      status: "success",
+      message: "Expense already exists (idempotent retry)",
+      expense: existing ? format_expense(existing) : nil
+    }, status: :ok
   end
 
   def recent_expenses

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -54,18 +54,36 @@ class Api::WebhooksController < ApplicationController
     end
   rescue ActiveRecord::RecordNotUnique
     # PER-498: return the existing row (idempotent) instead of a 500 when the
-    # iPhone Shortcuts retries a webhook or a user double-taps the action.
+    # iPhone Shortcuts retries or a user double-taps. Scope the lookup by
+    # email_account_id so we always return the row that the unique index
+    # actually collided on — both the pre-existing idx_expenses_duplicate_check
+    # (email_account_id IS NOT NULL) and the new idx_expenses_manual_duplicate_check
+    # (email_account_id IS NULL) reduce to "a row with the same email_account_id
+    # tuple." Matches either.
     existing = Expense.where(
+      email_account_id: expense.email_account_id,
       amount: expense.amount,
       transaction_date: expense.transaction_date,
       merchant_name: expense.merchant_name,
       deleted_at: nil
     ).first
-    render json: {
-      status: "success",
-      message: "Expense already exists (idempotent retry)",
-      expense: existing ? format_expense(existing) : nil
-    }, status: :ok
+
+    if existing
+      render json: {
+        status: "success",
+        message: "Expense already exists (idempotent retry)",
+        expense: format_expense(existing)
+      }, status: :ok
+    else
+      # Belt-and-braces: the unique-index predicate says the row must exist,
+      # but if lookup doesn't find it (e.g. soft-deleted between the INSERT
+      # attempt and this SELECT) return a 409 rather than a silent success.
+      Rails.logger.warn "[WebhooksController] RecordNotUnique but existing row not found for expense params (#{expense.amount}, #{expense.transaction_date}, #{expense.merchant_name})"
+      render json: {
+        status: "error",
+        message: "Duplicate detected but existing expense could not be located"
+      }, status: :conflict
+    end
   end
 
   def recent_expenses

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -88,10 +88,11 @@ class ExpensesController < ApplicationController
       render :new, status: :unprocessable_content
     end
   rescue ActiveRecord::RecordNotUnique
-    # PER-498: idx_expenses_manual_duplicate_check raises RecordNotUnique for
-    # double-submits of the same manual expense. Show the user a friendly
-    # error instead of a 500.
-    @expense.errors.add(:base, t("expenses.flash.duplicate"))
+    # PER-498: idx_expenses_manual_duplicate_check (email_account_id IS NULL)
+    # or idx_expenses_duplicate_check (email_account_id IS NOT NULL) raise
+    # RecordNotUnique on double-submit. Show a friendly error instead of 500.
+    @expense.errors.add(:base, t("expenses.flash.duplicate",
+      default: "A matching expense already exists."))
     @categories = Category.all.order(:name)
     @email_accounts = EmailAccount.all.order(:email)
     render :new, status: :unprocessable_content

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -87,6 +87,14 @@ class ExpensesController < ApplicationController
       @email_accounts = EmailAccount.all.order(:email)
       render :new, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique
+    # PER-498: idx_expenses_manual_duplicate_check raises RecordNotUnique for
+    # double-submits of the same manual expense. Show the user a friendly
+    # error instead of a 500.
+    @expense.errors.add(:base, t("expenses.flash.duplicate"))
+    @categories = Category.all.order(:name)
+    @email_accounts = EmailAccount.all.order(:email)
+    render :new, status: :unprocessable_content
   end
 
   # PATCH/PUT /expenses/1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,7 @@ en:
       deleted: "Expense deleted. You can undo this action."
       delete_error: "Error deleting expense. Please try again."
       duplicated: "Expense duplicated successfully"
+      duplicate: "A matching expense already exists for this amount, date, and merchant."
       sync_error: "Error starting synchronization. Please try again."
       not_found: "Expense not found or you don't have permission to view it."
       not_authorized: "You don't have permission to modify this expense."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -221,6 +221,7 @@ es:
       deleted: "Gasto eliminado. Puedes deshacer esta acción."
       delete_error: "Error al eliminar el gasto. Por favor, inténtalo de nuevo."
       duplicated: "Gasto duplicado exitosamente"
+      duplicate: "Ya existe un gasto con el mismo monto, fecha y comercio."
       sync_error: "Error al iniciar la sincronización. Por favor, inténtalo de nuevo."
       not_found: "Gasto no encontrado o no tienes permiso para verlo."
       not_authorized: "No tienes permiso para modificar este gasto."

--- a/db/migrate/20260417030000_add_manual_expense_duplicate_check_index.rb
+++ b/db/migrate/20260417030000_add_manual_expense_duplicate_check_index.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# PER-498 (B8): close the manual-expense duplicate-check hole.
+#
+# The pre-existing `idx_expenses_duplicate_check` index has
+#   WHERE deleted_at IS NULL AND merchant_name IS NOT NULL AND email_account_id IS NOT NULL
+# — the last clause means manual expenses (email_account_id IS NULL, created
+# via the web form or the iPhone Shortcuts webhook) bypass deduplication. A
+# double-tap on the UI or a retried webhook would create two identical rows.
+#
+# This migration adds a companion partial unique index for the NULL case. The
+# app is single-user (one admin account, no expense-owner scoping), so
+# (amount, transaction_date, merchant_name) is a sufficient dedup key for
+# manual entries.
+#
+# Concurrently added so it can run on prod without locking writes.
+class AddManualExpenseDuplicateCheckIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    # Defensive: if the upgrade ever reruns, don't fail.
+    return if index_exists?(:expenses, %i[amount transaction_date merchant_name],
+                            name: :idx_expenses_manual_duplicate_check)
+
+    add_index :expenses,
+              %i[amount transaction_date merchant_name],
+              name: :idx_expenses_manual_duplicate_check,
+              unique: true,
+              where: "deleted_at IS NULL AND merchant_name IS NOT NULL AND email_account_id IS NULL",
+              algorithm: :concurrently,
+              comment: "Unique constraint for detecting duplicate manual expenses (email_account_id IS NULL)"
+  end
+
+  def down
+    remove_index :expenses,
+                 name: :idx_expenses_manual_duplicate_check,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_193205) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_030000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -338,6 +338,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_193205) do
     t.datetime "updated_at", null: false
     t.index "EXTRACT(hour FROM transaction_date), EXTRACT(dow FROM transaction_date)", name: "idx_expenses_hour_dow"
     t.index "EXTRACT(year FROM transaction_date), EXTRACT(month FROM transaction_date)", name: "idx_expenses_year_month", where: "(deleted_at IS NULL)", comment: "For monthly/yearly aggregations"
+    t.index ["amount", "transaction_date", "merchant_name"], name: "idx_expenses_manual_duplicate_check", unique: true, where: "((deleted_at IS NULL) AND (merchant_name IS NOT NULL) AND (email_account_id IS NULL))", comment: "Unique constraint for detecting duplicate manual expenses (email_account_id IS NULL)"
     t.index ["amount"], name: "idx_expenses_amount_range", using: :brin, comment: "BRIN index for amount range queries"
     t.index ["auto_categorized", "categorization_confidence"], name: "idx_expenses_auto_categorization", where: "((auto_categorized = true) AND (deleted_at IS NULL))", comment: "Index for tracking auto-categorization"
     t.index ["bank_name", "transaction_date"], name: "idx_expenses_bank_date", where: "(deleted_at IS NULL)"

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -193,13 +193,15 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     # PER-498: iPhone Shortcuts may retry the webhook on a flaky network. The
-    # DB's idx_expenses_manual_duplicate_check partial unique index raises
-    # RecordNotUnique on the second submission. The handler converts that to
-    # an idempotent 200 response returning the existing row.
+    # DB's partial unique indexes raise RecordNotUnique on the second submission.
+    # The handler converts that to an idempotent 200 response returning the
+    # actual existing row (scoped by email_account_id so we return the row the
+    # index actually collided on, not any row matching the tuple).
     context "when the same expense is submitted twice (idempotent retry)" do
-      it "returns the existing row with a 200 instead of creating a duplicate" do
+      it "returns the original row with a 200 instead of creating a duplicate" do
         post :add_expense, params: { expense: expense_params }
         expect(response).to have_http_status(:created)
+        first_id = JSON.parse(response.body).dig("expense", "id")
 
         expect {
           post :add_expense, params: { expense: expense_params }
@@ -209,6 +211,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
         json_response = JSON.parse(response.body)
         expect(json_response["status"]).to eq("success")
         expect(json_response["message"]).to match(/idempotent/i)
+        expect(json_response.dig("expense", "id")).to eq(first_id)
       end
     end
 

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -192,6 +192,26 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
       end
     end
 
+    # PER-498: iPhone Shortcuts may retry the webhook on a flaky network. The
+    # DB's idx_expenses_manual_duplicate_check partial unique index raises
+    # RecordNotUnique on the second submission. The handler converts that to
+    # an idempotent 200 response returning the existing row.
+    context "when the same expense is submitted twice (idempotent retry)" do
+      it "returns the existing row with a 200 instead of creating a duplicate" do
+        post :add_expense, params: { expense: expense_params }
+        expect(response).to have_http_status(:created)
+
+        expect {
+          post :add_expense, params: { expense: expense_params }
+        }.not_to change(Expense, :count)
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("success")
+        expect(json_response["message"]).to match(/idempotent/i)
+      end
+    end
+
     context "with invalid parameters" do
       it "returns error for missing amount" do
         invalid_params = expense_params.except(:amount)

--- a/spec/db/duplicate_expense_constraint_spec.rb
+++ b/spec/db/duplicate_expense_constraint_spec.rb
@@ -9,8 +9,10 @@ require "rails_helper"
 # correctly prevents duplicate active expenses while allowing:
 # - soft-deleted records
 # - NULL merchant_name (manual expenses without merchant)
-# - NULL email_account_id (manual expenses)
 # - different amounts or merchants
+#
+# PER-498 (B8): companion partial unique index idx_expenses_manual_duplicate_check
+# now also dedupes manual expenses (email_account_id IS NULL).
 #
 # Tagged :unit so the pre-commit hook includes it.
 
@@ -75,13 +77,6 @@ RSpec.describe "PER-277 Duplicate expense unique constraint", :unit do
       }.not_to raise_error
     end
 
-    it "allows inserting when email_account_id is NULL (manual expense)" do
-      insert_expense(email_account_id: nil)
-      expect {
-        insert_expense(email_account_id: nil)
-      }.not_to raise_error
-    end
-
     it "allows different amounts for same account/date/merchant" do
       insert_expense(amount: 50.00)
       expect {
@@ -93,6 +88,57 @@ RSpec.describe "PER-277 Duplicate expense unique constraint", :unit do
       insert_expense(merchant_name: "Walmart", merchant_normalized: "Walmart")
       expect {
         insert_expense(merchant_name: "Target", merchant_normalized: "Target")
+      }.not_to raise_error
+    end
+  end
+
+  # PER-498 (B8): manual-expense duplicate check — email_account_id IS NULL
+  describe "manual-expense partial index (PER-498)" do
+    it "has a unique partial index named idx_expenses_manual_duplicate_check" do
+      idx = connection.indexes(:expenses).find { |i| i.name == "idx_expenses_manual_duplicate_check" }
+      expect(idx).not_to be_nil
+      expect(idx.unique).to be true
+      expect(idx.columns).to eq(%w[amount transaction_date merchant_name])
+      expect(idx.where).to include("deleted_at IS NULL")
+      expect(idx.where).to include("merchant_name IS NOT NULL")
+      expect(idx.where).to include("email_account_id IS NULL")
+    end
+
+    it "prevents inserting duplicate manual expenses (email_account_id IS NULL)" do
+      insert_expense(email_account_id: nil)
+      expect {
+        insert_expense(email_account_id: nil)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "allows two manual rows with the same key if one is soft-deleted" do
+      insert_expense(email_account_id: nil, deleted_at: Time.current)
+      expect {
+        insert_expense(email_account_id: nil)
+      }.not_to raise_error
+    end
+
+    it "allows two manual rows when merchant_name is NULL (excluded from index)" do
+      insert_expense(email_account_id: nil, merchant_name: nil, merchant_normalized: nil)
+      expect {
+        insert_expense(email_account_id: nil, merchant_name: nil, merchant_normalized: nil)
+      }.not_to raise_error
+    end
+
+    it "allows a manual row to coexist with an email-account row at the same tuple" do
+      # Manual (email_account_id IS NULL) and email-linked (email_account_id = N)
+      # rows are disjoint in each partial index, so the same (amount, date,
+      # merchant) can exist in both.
+      insert_expense
+      expect {
+        insert_expense(email_account_id: nil)
+      }.not_to raise_error
+    end
+
+    it "allows different amounts for manual rows" do
+      insert_expense(email_account_id: nil, amount: 50.00)
+      expect {
+        insert_expense(email_account_id: nil, amount: 75.00)
       }.not_to raise_error
     end
   end


### PR DESCRIPTION
## Summary

Closes [PER-498](https://linear.app/personal-brand-esoto/issue/PER-498) — deploy-blocker **B8** and the **LAST** blocker under [epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490).

## Problem

Migration \`20260215144706_change_email_account_id_nullable_on_expenses\` made \`email_account_id\` nullable on expenses (manual entries via web form / iPhone Shortcuts). The existing partial unique index \`idx_expenses_duplicate_check\` has \`WHERE email_account_id IS NOT NULL\` — so manual expenses bypass deduplication entirely. Double-tap on the form or retried webhook call creates duplicates.

## Changes

**New migration** \`20260417030000_add_manual_expense_duplicate_check_index.rb\`:
\`\`\`ruby
add_index :expenses,
  [:amount, :transaction_date, :merchant_name],
  name: :idx_expenses_manual_duplicate_check,
  unique: true,
  where: "deleted_at IS NULL AND merchant_name IS NOT NULL AND email_account_id IS NULL",
  algorithm: :concurrently
\`\`\`
Uses \`disable_ddl_transaction!\` + \`algorithm: :concurrently\` so it won't lock writes during deploy.

**Controller rescues** so \`RecordNotUnique\` becomes user-friendly:
- \`ExpensesController#create\`: friendly error, render \`:new\` with 422 + i18n keys in \`en.yml\` / \`es.yml\`.
- \`Api::WebhooksController#add_expense\`: idempotent retry — look up the existing row and return it with a 200. iPhone Shortcuts retries flaky network calls; we don't want those to 500.

## Tests

- Flipped the pre-existing \`"allows inserting when email_account_id is NULL"\` assertion (which documented the bug) → now expects \`RecordNotUnique\`.
- New describe block for the new partial index: uniqueness, soft-delete escape, nil-merchant escape, manual-and-email-row coexistence at the same tuple, different-amount allowance.
- New webhook idempotent-retry spec.
- \`bundle exec rspec spec/db/duplicate_expense_constraint_spec.rb\` — 12 pass.
- \`bundle exec rspec spec/controllers/api/webhooks_controller_spec.rb\` — 92 pass.
- Full unit suite: 8599 examples pass (minus a pre-existing order-dependent flake in \`orchestrator_integration_spec.rb\` that passes in isolation, unrelated to this change).

## Deploy notes

- Migration is \`concurrently\` so no lock, but **existing orphan duplicates would prevent the CREATE INDEX from completing**. Before running \`kamal app exec "bin/rails db:migrate"\`, check with:
  \`\`\`sql
  SELECT amount, transaction_date, merchant_name, COUNT(*)
  FROM expenses
  WHERE deleted_at IS NULL AND merchant_name IS NOT NULL AND email_account_id IS NULL
  GROUP BY 1,2,3 HAVING COUNT(*) > 1;
  \`\`\`
  For a single-user app with limited manual entries, this should return 0 rows. If not, soft-delete the older duplicates before the migration.

## 🎉 End of epic PER-490

This is **B8 of 8 deploy-blockers**. After this merges, the epic is complete and the app is ready for Hetzner deploy.