### PR TITLE
test: remove dead cache-lock tests from metrics calc job specs (PER-532)

### DIFF
--- a/spec/integration/metrics_background_job_integration_spec.rb
+++ b/spec/integration/metrics_background_job_integration_spec.rb
@@ -57,17 +57,12 @@ RSpec.describe "Metrics Background Job Integration", type: :integration do
       expect(cached_data[:metrics][:total_amount]).to eq(150.0)
     end
 
-    it "prevents concurrent job execution" do
-      # First job acquires lock
-      lock_key = "metrics_calculation:#{email_account.id}"
-      Rails.cache.write(lock_key, Time.current.to_s, expires_in: 5.minutes)
-
-      # Second job should skip
-      expect(Rails.logger).to receive(:info).with(/skipped - another job is already processing/)
-
-      job = MetricsCalculationJob.new
-      job.perform(email_account_id: email_account.id)
-    end
+    # Removed "prevents concurrent job execution" — it asserted a cache-based lock
+    # ("metrics_calculation:<id>" + "skipped - another job is already processing") that
+    # no longer exists. MetricsCalculationJob now relies on Active Job / Solid Queue's
+    # `limits_concurrency`, which is enforced at dispatch — not observable via direct
+    # `job.perform`. Configuration-level assertions live in the unit spec
+    # (spec/jobs/metrics_calculation_job_spec.rb:133–156). Closes PER-532.
 
     it "uses longer cache expiration for background-calculated metrics" do
       # Calculate metrics via background job
@@ -118,18 +113,9 @@ RSpec.describe "Metrics Background Job Integration", type: :integration do
   end
 
   describe "Error recovery" do
-    it "releases lock on error" do
-      lock_key = "metrics_calculation:#{email_account.id}"
-
-      # Force an error
-      allow_any_instance_of(Services::ExtendedCacheMetricsCalculator).to receive(:calculate).and_raise(StandardError, "Test error")
-
-      job = MetricsCalculationJob.new
-      expect { job.perform(email_account_id: email_account.id, period: :month) }.to raise_error(StandardError)
-
-      # Lock should be released
-      expect(Rails.cache.read(lock_key)).to be_nil
-    end
+    # Removed "releases lock on error" — asserted `Rails.cache.read("metrics_calculation:<id>")`
+    # was nil after a raise. The key is never written by the job (cache-lock was removed in
+    # the Solid Queue refactor), so the assertion passed vacuously. Closes PER-532.
 
     it "tracks failure metrics" do
       # Force an error

--- a/spec/jobs/metrics_calculation_job_enhanced_spec.rb
+++ b/spec/jobs/metrics_calculation_job_enhanced_spec.rb
@@ -15,43 +15,13 @@ RSpec.describe "MetricsCalculationJob Enhanced Features", type: :job, integratio
     Rails.cache.clear
   end
 
-  describe 'concurrency control', integration: true do
-    # QUARANTINED: Flaky test — the job proceeds to normal execution instead
-    # of logging "skipped - another job is already processing", even though
-    # the lock key is pre-seeded. Reproduces on main at commit 692b505.
-    # Ticket: PER-532 (lock-check diverged from test expectation)
-    # Quarantined on: 2026-04-16
-    # Prior failures: observed Apr 11 (session 66d0eb9b) and Apr 16.
-    xit 'prevents concurrent execution for same account' do
-      lock_key = "metrics_calculation:#{email_account.id}"
-      Rails.cache.write(lock_key, Time.current.to_s, expires_in: 5.minutes)
-
-      expect(Rails.logger).to receive(:info).with(/skipped - another job is already processing/)
-      expect_any_instance_of(Services::ExtendedCacheMetricsCalculator).not_to receive(:calculate)
-
-      job.perform(email_account_id: email_account.id, period: :month)
-    end
-
-    it 'acquires and releases lock properly' do
-      lock_key = "metrics_calculation:#{email_account.id}"
-
-      job.perform(email_account_id: email_account.id, period: :month, reference_date: current_date)
-
-      # Lock should be released after execution
-      expect(Rails.cache.read(lock_key)).to be_nil
-    end
-
-    it 'releases lock even on error' do
-      lock_key = "metrics_calculation:#{email_account.id}"
-
-      allow_any_instance_of(Services::ExtendedCacheMetricsCalculator).to receive(:calculate).and_raise(StandardError, "Test error")
-
-      expect { job.perform(email_account_id: email_account.id, period: :month) }.to raise_error(StandardError)
-
-      # Lock should be released
-      expect(Rails.cache.read(lock_key)).to be_nil
-    end
-  end
+  # Concurrency control is enforced by Active Job / Solid Queue's `limits_concurrency`
+  # directive (see app/jobs/metrics_calculation_job.rb:17–19), NOT by a cache-based lock.
+  # The cache-lock tests that previously lived here tested behavior that was deliberately
+  # removed during the Solid Queue refactor. The correct tests — asserting
+  # `concurrency_limit`, `concurrency_key`, and that no cache-lock write happens —
+  # are in spec/jobs/metrics_calculation_job_spec.rb (lines 133–156 and 936–955).
+  # Closes PER-532.
 
   describe 'performance monitoring', integration: true do
     it 'tracks job metrics on success' do


### PR DESCRIPTION
## Summary

- Delete 5 stale tests that asserted a cache-based lock (`"metrics_calculation:<id>"` + `"skipped - another job is already processing"`) that was removed when `MetricsCalculationJob` switched to Active Job / Solid Queue's `limits_concurrency` directive.
- Replace with breadcrumb comments pointing at the canonical concurrency tests in `spec/jobs/metrics_calculation_job_spec.rb` (lines 133–156 and 936–955).
- Closes [PER-532](https://linear.app/personal-brand-esoto/issue/PER-532) — supersedes the xit-quarantine landed in [PER-494](https://linear.app/personal-brand-esoto/issue/PER-494) (PR #427).

## Why these tests were dead

`app/jobs/metrics_calculation_job.rb:17–19` uses:

```ruby
limits_concurrency to: 1,
  key: ->(args = {}) { args[:email_account_id] || "all_accounts" },
  duration: LOCK_DURATION
```

Three consequences:

1. **The log string doesn't exist in this job.** `"skipped - another job is already processing"` now lives only in `MetricsRefreshJob:22` — a different job that still uses a cache-lock. The enhanced spec was likely copy-pasted and never updated.
2. **The cache key is never written by the job.** `Rails.cache.read("metrics_calculation:<id>")` is always `nil`, so the "releases lock" sibling tests passed **vacuously** — they asserted `nil == nil` after the job ran.
3. **`limits_concurrency` is enforced at dispatch.** Direct `job.perform(...)` bypasses Active Job / Solid Queue entirely. You cannot test the concurrency guarantee this way even in principle.

`metrics_calculation_job_spec.rb:937` already documents this: *"concurrency is managed by Solid Queue"* — and one test there explicitly asserts the job does NOT do a cache-lock write. That's the right place for this.

## Tests removed

| File | Line | Status on main |
|------|------|----|
| `spec/jobs/metrics_calculation_job_enhanced_spec.rb` | 19 | Was `xit`-quarantined in PER-494 |
| `spec/jobs/metrics_calculation_job_enhanced_spec.rb` | 29 | Passed vacuously |
| `spec/jobs/metrics_calculation_job_enhanced_spec.rb` | 38 | Passed vacuously |
| `spec/integration/metrics_background_job_integration_spec.rb` | 60 | Failed same way, not yet quarantined |
| `spec/integration/metrics_background_job_integration_spec.rb` | 121 | Passed vacuously |

## Out-of-scope (pre-existing) failures

While validating, I found 3 other failures in `metrics_background_job_integration_spec.rb` (lines 13, 32, 67) caused by the factory creating duplicate expenses that trip `idx_expenses_duplicate_check`. Confirmed present on `origin/main` before my changes — they're a separate ticket, not introduced here.

## Test plan

- [x] `bundle exec rspec spec/jobs/metrics_calculation_job_enhanced_spec.rb` — 7 examples, 0 failures
- [x] `bundle exec rspec spec/jobs/metrics_calculation_job_spec.rb` — 83 examples, 0 failures (canonical tests still green)
- [x] Pre-commit hook passed (unit tests + RuboCop + Brakeman)
- [ ] CI green on push