### PR TITLE
fix(llm): version the cache key with prompt_version + model_used (PER-499)

### DIFF
--- a/app/models/llm_categorization_cache_entry.rb
+++ b/app/models/llm_categorization_cache_entry.rb
@@ -3,7 +3,11 @@ class LlmCategorizationCacheEntry < ApplicationRecord
 
   belongs_to :category
 
-  validates :merchant_normalized, presence: true, uniqueness: true
+  # PER-499: uniqueness now scoped by prompt_version + model_used so a prompt
+  # tweak or model bump doesn't silently serve stale cache. The DB-level
+  # index on (merchant_normalized, prompt_version, model_used) is the
+  # authoritative guard — this validation is best-effort.
+  validates :merchant_normalized, presence: true, uniqueness: { scope: %i[prompt_version model_used] }
 
   scope :active, -> { where(expires_at: nil).or(where(expires_at: Time.current..)) }
   scope :expired, -> { where.not(expires_at: nil).where(expires_at: ...Time.current) }

--- a/app/models/llm_categorization_cache_entry.rb
+++ b/app/models/llm_categorization_cache_entry.rb
@@ -12,6 +12,22 @@ class LlmCategorizationCacheEntry < ApplicationRecord
   scope :active, -> { where(expires_at: nil).or(where(expires_at: Time.current..)) }
   scope :expired, -> { where.not(expires_at: nil).where(expires_at: ...Time.current) }
 
+  # PER-499: single source of truth for the cache composite key. Any future
+  # key-field addition (region, locale, ...) happens here — callers in
+  # LlmStrategy don't need to change. Prevents the silent cache-poisoning
+  # bug where lookup and store drift out of sync.
+  def self.cache_key_for(merchant_normalized:)
+    {
+      merchant_normalized: merchant_normalized,
+      prompt_version: Services::Categorization::Llm::PromptBuilder::PROMPT_VERSION,
+      model_used: Services::Categorization::Llm::Client::MODEL
+    }
+  end
+
+  def self.lookup_for(merchant_normalized:)
+    find_by(cache_key_for(merchant_normalized: merchant_normalized))
+  end
+
   def expired?
     expires_at.present? && expires_at < Time.current
   end

--- a/app/services/categorization/llm/prompt_builder.rb
+++ b/app/services/categorization/llm/prompt_builder.rb
@@ -3,6 +3,17 @@
 module Services::Categorization
   module Llm
     class PromptBuilder
+      # PER-499: Prompt version — any change to the prompt text, system
+      # instruction, category list format, correction-note format, or web-
+      # search behaviour MUST bump this constant so that existing LLM cache
+      # rows are invalidated instead of silently serving stale classifications.
+      #
+      # Version log:
+      #   v1 — initial implementation
+      #   v2 — PR #417 added merchant enrichment + PR #419 added web search
+      #   v3 — placeholder for the next prompt change
+      PROMPT_VERSION = "v2"
+
       SYSTEM_INSTRUCTION = <<~INSTRUCTION.freeze
         You are a local business expert and expense categorizer.
         Given a bank transaction, search the internet to identify what type

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -95,8 +95,12 @@ module Services::Categorization
           return build_cached_result(cached, duration_ms(start_time))
         end
 
-        # Cache miss or expired — call LLM
-        call_llm_and_cache(expense, normalized, cached, start_time)
+        # Cache miss or expired — call LLM. The `cached` value (possibly an
+        # expired entry for the CURRENT prompt_version/model_used tuple) is
+        # not passed to call_llm_and_cache anymore; store_cache now uses
+        # find_or_create_by on the composite key so concurrent writes, stale
+        # expired entries, and fresh inserts all converge safely.
+        call_llm_and_cache(expense, normalized, start_time)
       rescue Llm::Client::Error => e
         @logger.error "[LlmStrategy] LLM client error: #{e.message}"
         CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
@@ -115,17 +119,13 @@ module Services::Categorization
       end
 
       def lookup_cache(normalized)
-        # PER-499: scope lookup by prompt_version + model_used so a prompt
-        # change or model bump produces a miss instead of silently returning
-        # the stale classification.
-        LlmCategorizationCacheEntry.find_by(
-          merchant_normalized: normalized,
-          prompt_version: Llm::PromptBuilder::PROMPT_VERSION,
-          model_used: Llm::Client::MODEL
-        )
+        # PER-499: the model owns the composite cache key (merchant_normalized,
+        # prompt_version, model_used). A prompt or model bump produces a miss
+        # instead of silently returning a stale classification.
+        LlmCategorizationCacheEntry.lookup_for(merchant_normalized: normalized)
       end
 
-      def call_llm_and_cache(expense, normalized, existing_entry, start_time)
+      def call_llm_and_cache(expense, normalized, start_time)
         correction_history = Rails.cache.read("#{CORRECTION_KEY_PREFIX}:#{normalized}")
         prompt = Llm::PromptBuilder.new.build(expense: expense, correction_history: correction_history)
         api_result = call_with_rate_limit_handling(prompt)
@@ -143,7 +143,7 @@ module Services::Categorization
         total_tokens = api_result[:token_count][:input] + api_result[:token_count][:output]
 
         # Store or update cache
-        store_cache(normalized, parsed, api_result, total_tokens, existing_entry)
+        store_cache(normalized, parsed, api_result, total_tokens)
 
         # Feed Layer 2 so similarity strategy learns from LLM results
         feed_vector_updater(expense, parsed[:category])
@@ -201,16 +201,15 @@ module Services::Categorization
         end
       end
 
-      def store_cache(normalized, parsed, api_result, total_tokens, _existing_entry)
-        # PER-499: the cache key is (merchant_normalized, prompt_version,
-        # model_used). Two concurrent writes for the same tuple race on the
-        # unique index — find_or_create_by! + update handles it, with a
-        # RecordNotUnique rescue for the narrow window between find and create.
-        key = {
-          merchant_normalized: normalized,
-          prompt_version: Llm::PromptBuilder::PROMPT_VERSION,
-          model_used: Llm::Client::MODEL
-        }
+      def store_cache(normalized, parsed, api_result, total_tokens)
+        # PER-499: the model owns the composite key. find_or_create_by! handles
+        # the happy path; a concurrent writer that lost the race between find
+        # and create raises RecordNotUnique, which we rescue and update the
+        # winner's row. If the row was deleted between insert attempt and
+        # rescue lookup (e.g. LlmCacheCleanupJob swept an expired entry),
+        # find_by + safe-navigation silently drops the cache write — the
+        # caller still has `parsed` and returns the categorization.
+        key = LlmCategorizationCacheEntry.cache_key_for(merchant_normalized: normalized)
         attrs = {
           category: parsed[:category],
           confidence: parsed[:confidence],
@@ -224,7 +223,7 @@ module Services::Categorization
         end
         entry.update!(attrs) unless entry.previously_new_record?
       rescue ActiveRecord::RecordNotUnique
-        LlmCategorizationCacheEntry.find_by!(**key).update!(attrs)
+        LlmCategorizationCacheEntry.find_by(**key)&.update!(attrs)
       end
 
       def feed_vector_updater(expense, category)

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -115,7 +115,14 @@ module Services::Categorization
       end
 
       def lookup_cache(normalized)
-        LlmCategorizationCacheEntry.find_by(merchant_normalized: normalized)
+        # PER-499: scope lookup by prompt_version + model_used so a prompt
+        # change or model bump produces a miss instead of silently returning
+        # the stale classification.
+        LlmCategorizationCacheEntry.find_by(
+          merchant_normalized: normalized,
+          prompt_version: Llm::PromptBuilder::PROMPT_VERSION,
+          model_used: Llm::Client::MODEL
+        )
       end
 
       def call_llm_and_cache(expense, normalized, existing_entry, start_time)
@@ -195,23 +202,29 @@ module Services::Categorization
       end
 
       def store_cache(normalized, parsed, api_result, total_tokens, _existing_entry)
+        # PER-499: the cache key is (merchant_normalized, prompt_version,
+        # model_used). Two concurrent writes for the same tuple race on the
+        # unique index — find_or_create_by! + update handles it, with a
+        # RecordNotUnique rescue for the narrow window between find and create.
+        key = {
+          merchant_normalized: normalized,
+          prompt_version: Llm::PromptBuilder::PROMPT_VERSION,
+          model_used: Llm::Client::MODEL
+        }
         attrs = {
           category: parsed[:category],
           confidence: parsed[:confidence],
-          model_used: Llm::Client::MODEL,
           token_count: total_tokens,
           cost: api_result[:cost],
           expires_at: CACHE_TTL.from_now
         }
 
-        # Use find_or_create + update to handle concurrent requests safely.
-        # Rescues RecordNotUnique from the unique index on merchant_normalized.
-        entry = LlmCategorizationCacheEntry.find_or_create_by!(merchant_normalized: normalized) do |e|
+        entry = LlmCategorizationCacheEntry.find_or_create_by!(**key) do |e|
           e.assign_attributes(attrs)
         end
         entry.update!(attrs) unless entry.previously_new_record?
       rescue ActiveRecord::RecordNotUnique
-        LlmCategorizationCacheEntry.find_by!(merchant_normalized: normalized).update!(attrs)
+        LlmCategorizationCacheEntry.find_by!(**key).update!(attrs)
       end
 
       def feed_vector_updater(expense, category)

--- a/db/migrate/20260417135500_add_prompt_version_to_llm_categorization_cache.rb
+++ b/db/migrate/20260417135500_add_prompt_version_to_llm_categorization_cache.rb
@@ -19,29 +19,38 @@ class AddPromptVersionToLlmCategorizationCache < ActiveRecord::Migration[8.1]
     # PROMPT_VERSION on insert (see LlmStrategy#store_cache).
     add_column :llm_categorization_cache, :prompt_version, :string, default: "v1", null: false
 
-    # Swap the unique index: drop (merchant_normalized), add the composite.
-    # `concurrently` on both so writes continue during deploy.
-    remove_index :llm_categorization_cache,
-                 name: :index_llm_cache_on_merchant_normalized,
-                 algorithm: :concurrently
-
+    # Swap the unique index: add the composite FIRST, then drop the old
+    # single-column one. Reverse of the naive order on purpose — between
+    # `remove` and `add` (both concurrent, minutes on a large table) there
+    # would otherwise be a window with no unique constraint on
+    # merchant_normalized, during which concurrent writes could insert
+    # duplicates and then cause the CREATE UNIQUE INDEX CONCURRENTLY to
+    # fail and leave an INVALID index behind. The brief both-indexes-live
+    # state is ~10 MB extra and has no correctness issue because every
+    # existing row has prompt_version="v1" + a single model_used, so the
+    # composite is functionally equivalent to the single-column index for
+    # legacy rows.
     add_index :llm_categorization_cache,
               %i[merchant_normalized prompt_version model_used],
               unique: true,
               name: :index_llm_cache_on_merchant_version_model,
               algorithm: :concurrently
+
+    remove_index :llm_categorization_cache,
+                 name: :index_llm_cache_on_merchant_normalized,
+                 algorithm: :concurrently
   end
 
   def down
-    remove_index :llm_categorization_cache,
-                 name: :index_llm_cache_on_merchant_version_model,
-                 algorithm: :concurrently
-
     add_index :llm_categorization_cache,
               :merchant_normalized,
               unique: true,
               name: :index_llm_cache_on_merchant_normalized,
               algorithm: :concurrently
+
+    remove_index :llm_categorization_cache,
+                 name: :index_llm_cache_on_merchant_version_model,
+                 algorithm: :concurrently
 
     remove_column :llm_categorization_cache, :prompt_version
   end

--- a/db/migrate/20260417135500_add_prompt_version_to_llm_categorization_cache.rb
+++ b/db/migrate/20260417135500_add_prompt_version_to_llm_categorization_cache.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# PER-499 (H1): add prompt_version to the LLM cache key so stale entries age
+# out when prompt logic or model version changes. The pre-existing unique
+# index on (merchant_normalized) meant a single prompt tweak could pin a
+# wrong classification in cache forever (refresh_ttl! on every hit extended
+# its life indefinitely).
+#
+# After this migration the cache key is (merchant_normalized, prompt_version,
+# model_used). Bumping PROMPT_VERSION in PromptBuilder makes every lookup
+# miss, a fresh LLM call populates a new row, and the old row ages out via
+# the existing expires_at / LlmCacheCleanupJob path.
+class AddPromptVersionToLlmCategorizationCache < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    # Default "v1" for existing rows — every row pre-dates this migration and
+    # was produced by the v1 prompt pipeline. New rows get the current
+    # PROMPT_VERSION on insert (see LlmStrategy#store_cache).
+    add_column :llm_categorization_cache, :prompt_version, :string, default: "v1", null: false
+
+    # Swap the unique index: drop (merchant_normalized), add the composite.
+    # `concurrently` on both so writes continue during deploy.
+    remove_index :llm_categorization_cache,
+                 name: :index_llm_cache_on_merchant_normalized,
+                 algorithm: :concurrently
+
+    add_index :llm_categorization_cache,
+              %i[merchant_normalized prompt_version model_used],
+              unique: true,
+              name: :index_llm_cache_on_merchant_version_model,
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :llm_categorization_cache,
+                 name: :index_llm_cache_on_merchant_version_model,
+                 algorithm: :concurrently
+
+    add_index :llm_categorization_cache,
+              :merchant_normalized,
+              unique: true,
+              name: :index_llm_cache_on_merchant_normalized,
+              algorithm: :concurrently
+
+    remove_column :llm_categorization_cache, :prompt_version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_135500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -398,11 +398,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_030000) do
     t.datetime "expires_at"
     t.string "merchant_normalized", null: false
     t.string "model_used", default: "claude-haiku-4-5"
+    t.string "prompt_version", default: "v1", null: false
     t.integer "token_count"
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_llm_categorization_cache_on_category_id"
     t.index ["expires_at"], name: "index_llm_cache_on_expires_at"
-    t.index ["merchant_normalized"], name: "index_llm_cache_on_merchant_normalized", unique: true
+    t.index ["merchant_normalized", "prompt_version", "model_used"], name: "index_llm_cache_on_merchant_version_model", unique: true
   end
 
   create_table "merchant_aliases", force: :cascade do |t|

--- a/spec/db/index_audit_per126_spec.rb
+++ b/spec/db/index_audit_per126_spec.rb
@@ -454,11 +454,15 @@ RSpec.describe "PER-126 Index Audit", :unit do
       expect(composite.unique).to be true
     end
 
-    it "llm_categorization_cache has a unique index on merchant_normalized" do
+    # PER-499: the unique index was widened to
+    # (merchant_normalized, prompt_version, model_used) so prompt / model
+    # bumps invalidate old rows instead of silently serving stale results.
+    it "llm_categorization_cache has a composite unique index including prompt_version + model_used" do
       indexes = connection.indexes(:llm_categorization_cache)
-      merchant_idx = indexes.find { |i| i.name == "index_llm_cache_on_merchant_normalized" }
-      expect(merchant_idx).to be_present
-      expect(merchant_idx.unique).to be true
+      composite_idx = indexes.find { |i| i.name == "index_llm_cache_on_merchant_version_model" }
+      expect(composite_idx).to be_present
+      expect(composite_idx.unique).to be true
+      expect(composite_idx.columns).to eq(%w[merchant_normalized prompt_version model_used])
     end
   end
 

--- a/spec/factories/llm_categorization_cache_entries.rb
+++ b/spec/factories/llm_categorization_cache_entries.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
     category
     confidence { 0.85 }
     model_used { "claude-haiku-4-5" }
+    # Match the current PromptBuilder::PROMPT_VERSION so the strategy's cache
+    # lookup finds factory-built rows by default.
+    prompt_version { Services::Categorization::Llm::PromptBuilder::PROMPT_VERSION }
     expires_at { 90.days.from_now }
   end
 end

--- a/spec/models/llm_categorization_cache_entry_spec.rb
+++ b/spec/models/llm_categorization_cache_entry_spec.rb
@@ -16,10 +16,48 @@ RSpec.describe LlmCategorizationCacheEntry, type: :model, unit: true do
       expect(entry.errors[:category]).to be_present
     end
 
-    it "enforces uniqueness of merchant_normalized" do
-      LlmCategorizationCacheEntry.create!(merchant_normalized: "uber eats", category: category, expires_at: 90.days.from_now)
-      duplicate = LlmCategorizationCacheEntry.new(merchant_normalized: "uber eats", category: category)
+    it "enforces uniqueness of (merchant_normalized, prompt_version, model_used)" do
+      LlmCategorizationCacheEntry.create!(
+        merchant_normalized: "uber eats",
+        prompt_version: "v2",
+        model_used: "claude-haiku-4-5",
+        category: category,
+        expires_at: 90.days.from_now
+      )
+      duplicate = LlmCategorizationCacheEntry.new(
+        merchant_normalized: "uber eats",
+        prompt_version: "v2",
+        model_used: "claude-haiku-4-5",
+        category: category
+      )
       expect(duplicate).not_to be_valid
+    end
+
+    # PER-499: bumping either prompt_version or model_used must allow a new
+    # row for the same merchant, so a prompt/model change produces fresh
+    # classifications instead of overwriting the old one.
+    it "allows the same merchant with a different prompt_version" do
+      LlmCategorizationCacheEntry.create!(
+        merchant_normalized: "uber eats", prompt_version: "v1",
+        model_used: "claude-haiku-4-5", category: category, expires_at: 90.days.from_now
+      )
+      newer = LlmCategorizationCacheEntry.new(
+        merchant_normalized: "uber eats", prompt_version: "v2",
+        model_used: "claude-haiku-4-5", category: category
+      )
+      expect(newer).to be_valid
+    end
+
+    it "allows the same merchant with a different model_used" do
+      LlmCategorizationCacheEntry.create!(
+        merchant_normalized: "uber eats", prompt_version: "v2",
+        model_used: "claude-haiku-4-5", category: category, expires_at: 90.days.from_now
+      )
+      newer = LlmCategorizationCacheEntry.new(
+        merchant_normalized: "uber eats", prompt_version: "v2",
+        model_used: "claude-sonnet-4-5", category: category
+      )
+      expect(newer).to be_valid
     end
   end
 

--- a/spec/services/categorization/llm/prompt_builder_spec.rb
+++ b/spec/services/categorization/llm/prompt_builder_spec.rb
@@ -5,6 +5,20 @@ require "rails_helper"
 RSpec.describe Services::Categorization::Llm::PromptBuilder, :unit do
   subject(:builder) { described_class.new }
 
+  # PER-499 canary: if this assertion fails, the SYSTEM_INSTRUCTION text was
+  # changed. Bump PromptBuilder::PROMPT_VERSION to invalidate stale cache
+  # rows and update the hash below. The whole point is that you must NOT
+  # silently modify the prompt without bumping the version — a stale cache
+  # serving outdated classifications is the bug this test catches in CI.
+  describe "prompt-version discipline canary" do
+    it "refuses to let SYSTEM_INSTRUCTION drift without a PROMPT_VERSION bump" do
+      current_hash = Digest::SHA1.hexdigest(described_class::SYSTEM_INSTRUCTION)
+      expected_hash = "d4f4fbc9d8fbf8e66282b2de2939469378e25b24"
+      expect(current_hash).to eq(expected_hash),
+        "SYSTEM_INSTRUCTION changed! Bump PROMPT_VERSION and update the hash in this spec."
+    end
+  end
+
   let(:expense) do
     build(:expense, merchant_name: "McDonald's", description: "Compra en restaurante",
                     amount: 5500.0, currency: "crc", bank_name: "BAC",

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -330,6 +330,56 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
       end
     end
 
+    # PER-499: prompt_version and model_used are part of the cache key.
+    # A row written under an older prompt/model must NOT be served after a
+    # bump — the strategy should treat it as a miss and call the LLM.
+    context "when cache entry exists but has a stale prompt_version" do
+      let!(:stale_entry) do
+        create(:llm_categorization_cache_entry,
+          merchant_normalized: normalized_merchant,
+          category: category,
+          prompt_version: "v0-historical",
+          model_used: "claude-haiku-4-5",
+          expires_at: 30.days.from_now)
+      end
+      let(:prompt_text) { "categorize" }
+      let(:api_response) do
+        { response_text: category.i18n_key,
+          token_count: { input: 80, output: 5 },
+          cost: 0.0003 }
+      end
+
+      before do
+        allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+        allow(mock_client).to receive(:categorize).with(prompt_text: prompt_text).and_return(api_response)
+        allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+          .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+            parse: { category: category, confidence: 0.85, raw_response: category.i18n_key }))
+      end
+
+      it "treats the stale-version entry as a cache miss and calls the LLM" do
+        strategy.call(expense)
+        expect(mock_client).to have_received(:categorize)
+      end
+
+      it "creates a new cache row at the current PROMPT_VERSION" do
+        expect { strategy.call(expense) }.to change(LlmCategorizationCacheEntry, :count).by(1)
+
+        fresh_entry = LlmCategorizationCacheEntry.find_by(
+          merchant_normalized: normalized_merchant,
+          prompt_version: Services::Categorization::Llm::PromptBuilder::PROMPT_VERSION,
+          model_used: "claude-haiku-4-5"
+        )
+        expect(fresh_entry).to be_present
+      end
+
+      it "leaves the stale entry in place so it can age out naturally" do
+        strategy.call(expense)
+        expect(LlmCategorizationCacheEntry.exists?(stale_entry.id)).to be true
+      end
+    end
+
     context "when cache miss with correction context in Rails.cache" do
       let(:prompt_text) { "categorize this merchant" }
       let(:correction_history) { { old: "groceries", new: "restaurants" } }


### PR DESCRIPTION
## Summary

Closes [PER-499](https://linear.app/personal-brand-esoto/issue/PER-499) — high-priority **H1** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

Before this PR the LLM cache key was just \`merchant_normalized\`. A prompt tweak ([#417](https://github.com/esoto/expense_tracker/pull/417) enrichment, [#419](https://github.com/esoto/expense_tracker/pull/419) web-search) or model bump did **not** invalidate existing entries — and \`refresh_ttl!\` on every hit extended TTL indefinitely, so stale classifications could pin a merchant to a wrong category forever.

## Changes

**Migration** \`20260417135500_add_prompt_version_to_llm_categorization_cache.rb\`
- Adds \`prompt_version\` string column, default \`"v1"\` for legacy rows
- Drops the unique index on \`(merchant_normalized)\`, adds \`idx_llm_cache_on_merchant_version_model\` on \`(merchant_normalized, prompt_version, model_used)\`
- \`disable_ddl_transaction!\` + \`algorithm: :concurrently\` → zero-downtime deploy

**\`PromptBuilder::PROMPT_VERSION = "v2"\`**
Reflects current prompt (post #417 + #419). Version log in the comment. Bumping it invalidates every row in one read; next lookup misses, LLM repopulates, old row ages out via \`LlmCacheCleanupJob\`.

**\`LlmStrategy#lookup_cache\` + \`#store_cache\`**
Both now use the full composite key. \`find_or_create_by!\` + \`RecordNotUnique\` rescue continue to handle the concurrent-write race.

**Model**
\`LlmCategorizationCacheEntry\` validates uniqueness scoped by \`(prompt_version, model_used)\`.

**Specs**
- Model: 3 new uniqueness scopes (same merchant + different prompt_version allowed; different model_used allowed)
- Strategy: new context proving a stale-version row is treated as cache miss → fresh row created at current PROMPT_VERSION → old row preserved
- Factory: \`prompt_version\` defaults to \`PromptBuilder::PROMPT_VERSION\` so existing tests continue to hit
- Index-audit spec: updated to check the new composite index

## Test plan

- [x] \`bundle exec rspec spec/models/llm_categorization_cache_entry_spec.rb spec/services/categorization/strategies/llm_strategy_spec.rb\` — 67 pass
- [x] \`bundle exec rspec spec/services/categorization/ --tag unit\` — 1262 pass, 1 pending
- [x] \`bundle exec rspec spec/db/index_audit_per126_spec.rb\` — 79 pass
- [x] \`bundle exec rubocop\` on changed files — clean
- [ ] Post-deploy: confirm \`SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_llm_cache_on_merchant_version_model'::regclass\` returns \`true\`

## Deploy notes

- The migration uses \`CREATE/DROP INDEX CONCURRENTLY\` — safe to run during traffic.
- After deploy: every cached row is at \`prompt_version = "v1"\`, but production code will request \`"v2"\`. Every first lookup misses, LLM calls populate \`"v2"\` rows, \`"v1"\` rows age out via the existing daily \`LlmCacheCleanupJob\`. Expect a one-time LLM cost bump equal to the active-merchant count.