### PR TITLE
fix(llm): circuit-break auth failures + alert path (PER-500)

### DIFF
--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -25,6 +25,17 @@ module Services::Categorization
       BUDGET_UNITS_PER_USD = 10_000
       CORRECTION_KEY_PREFIX = "llm_correction"
 
+      # PER-500: auth-failure circuit breaker. A dropped API key, rotated
+      # credentials, or a config regression should NOT silently fail every
+      # categorization for hours — we saw exactly that on 2026-04-16. When
+      # the LLM client reports an auth or configuration error, we trip a
+      # short-lived cache flag so subsequent calls return no_match
+      # immediately (no 15s throttle, no wasted retry loop) and the error
+      # surfaces via the ErrorTrackingService. The flag auto-clears after
+      # AUTH_FAILURE_TTL so the system recovers as soon as creds are fixed.
+      AUTH_FAILURE_CACHE_KEY = "llm_auth_broken"
+      AUTH_FAILURE_TTL = 5.minutes
+
       # Rate limit handling.
       # Anthropic's default input tokens-per-minute limit is 50,000 for Haiku.
       # Each LLM call with web_search uses ~10,000 input tokens (tool results
@@ -78,6 +89,13 @@ module Services::Categorization
       def call(expense, _options = {})
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+        # PER-500: short-circuit when auth has recently broken. Saves the
+        # 15s throttle + retry cycle for every expense in the queue.
+        if auth_circuit_open?
+          @logger.warn "[LlmStrategy] circuit open (auth failure within last #{AUTH_FAILURE_TTL.inspect}) — skipping LLM"
+          return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
+        end
+
         normalized = normalize_merchant(expense)
         if normalized.blank?
           return CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
@@ -101,6 +119,9 @@ module Services::Categorization
         # find_or_create_by on the composite key so concurrent writes, stale
         # expired entries, and fresh inserts all converge safely.
         call_llm_and_cache(expense, normalized, start_time)
+      rescue Llm::Client::AuthenticationError, Llm::Client::ConfigurationError => e
+        trip_auth_circuit!(e)
+        CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
       rescue Llm::Client::Error => e
         @logger.error "[LlmStrategy] LLM client error: #{e.message}"
         CategorizationResult.no_match(processing_time_ms: duration_ms(start_time))
@@ -110,6 +131,29 @@ module Services::Categorization
 
       def client
         @client ||= Llm::Client.new
+      end
+
+      # PER-500: circuit-breaker helpers. Read and write the shared cache
+      # flag that tells every LlmStrategy instance across every Solid Queue
+      # worker that auth is currently broken.
+      def auth_circuit_open?
+        Rails.cache.read(AUTH_FAILURE_CACHE_KEY).present?
+      end
+
+      def trip_auth_circuit!(exception)
+        Rails.cache.write(AUTH_FAILURE_CACHE_KEY, true, expires_in: AUTH_FAILURE_TTL)
+        @logger.error(
+          "[LlmStrategy] LLM auth failed — circuit open for #{AUTH_FAILURE_TTL.inspect}: " \
+          "#{exception.class.name}: #{exception.message}"
+        )
+        Services::ErrorTrackingService.instance.track_exception(
+          exception,
+          strategy: "LlmStrategy",
+          reason: "auth_failure_circuit_breaker_tripped"
+        )
+      rescue StandardError => track_err
+        # Don't let a broken tracker mask the underlying auth failure.
+        @logger.warn "[LlmStrategy] ErrorTrackingService.track_exception failed: #{track_err.message}"
       end
 
       def normalize_merchant(expense)

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -137,7 +137,10 @@ module Services::Categorization
       # flag that tells every LlmStrategy instance across every Solid Queue
       # worker that auth is currently broken.
       def auth_circuit_open?
-        Rails.cache.read(AUTH_FAILURE_CACHE_KEY).present?
+        # `Rails.cache.exist?` is one round trip and doesn't materialize the
+        # payload — tighter than `read(...).present?` and signals intent (we
+        # only care that the flag is set, not its value).
+        Rails.cache.exist?(AUTH_FAILURE_CACHE_KEY)
       end
 
       def trip_auth_circuit!(exception)
@@ -152,8 +155,10 @@ module Services::Categorization
           reason: "auth_failure_circuit_breaker_tripped"
         )
       rescue StandardError => track_err
-        # Don't let a broken tracker mask the underlying auth failure.
-        @logger.warn "[LlmStrategy] ErrorTrackingService.track_exception failed: #{track_err.message}"
+        # Don't let a broken tracker mask the underlying auth failure. Log at
+        # :error (not :warn) — losing the alert signal IS the outage this PR
+        # exists to detect, so it must be visible in default log filters.
+        @logger.error "[LlmStrategy] ErrorTrackingService.track_exception failed: #{track_err.class.name}: #{track_err.message}"
       end
 
       def normalize_merchant(expense)

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
           parse: { category: category, confidence: 0.85, raw_response: category.i18n_key }))
     end
 
+    # Guard against leaking the flag into neighboring specs in the same
+    # process — Rails.cache is shared state.
+    after { Rails.cache.delete(described_class::AUTH_FAILURE_CACHE_KEY) }
+
     it "defines AUTH_FAILURE_CACHE_KEY and AUTH_FAILURE_TTL" do
       expect(described_class::AUTH_FAILURE_CACHE_KEY).to be_a(String)
       expect(described_class::AUTH_FAILURE_TTL).to be_a(ActiveSupport::Duration)
@@ -102,6 +106,63 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
       it "trips the circuit breaker" do
         strategy.call(expense)
         expect(Rails.cache.read(described_class::AUTH_FAILURE_CACHE_KEY)).to be true
+      end
+
+      it "reports via Services::ErrorTrackingService (parity with AuthenticationError)" do
+        tracker = instance_double(Services::ErrorTrackingService, track_exception: nil)
+        allow(Services::ErrorTrackingService).to receive(:instance).and_return(tracker)
+
+        strategy.call(expense)
+
+        expect(tracker).to have_received(:track_exception).with(
+          instance_of(Services::Categorization::Llm::Client::ConfigurationError),
+          hash_including(strategy: "LlmStrategy")
+        )
+      end
+
+      it "returns no_match so the engine falls through to the next layer" do
+        result = strategy.call(expense)
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+    end
+
+    # Lock in the design decision: when the circuit is open, we DO NOT serve
+    # a stale cached classification — we return no_match so the outage
+    # signal propagates. A future refactor that moved the circuit check
+    # below `lookup_cache` (for "performance") would silently hide outages.
+    context "when the circuit is open AND a valid cache entry exists" do
+      before do
+        Rails.cache.write(described_class::AUTH_FAILURE_CACHE_KEY, true,
+                          expires_in: described_class::AUTH_FAILURE_TTL)
+        create(:llm_categorization_cache_entry,
+          merchant_normalized: normalized_merchant,
+          category: category,
+          expires_at: 30.days.from_now)
+      end
+
+      it "returns no_match (circuit wins over cache)" do
+        result = strategy.call(expense)
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+    end
+
+    # Lock in the auto-recovery contract: when AUTH_FAILURE_TTL expires the
+    # circuit closes on its own. Prevents a future typo that pinned the
+    # circuit open forever.
+    context "when the circuit has expired (auto-recovery)" do
+      before do
+        Rails.cache.write(described_class::AUTH_FAILURE_CACHE_KEY, true,
+                          expires_in: described_class::AUTH_FAILURE_TTL)
+        allow(mock_client).to receive(:categorize).and_return(api_response)
+      end
+
+      it "recovers and calls the LLM after the TTL elapses" do
+        travel_to(described_class::AUTH_FAILURE_TTL.from_now + 1.second) do
+          strategy.call(expense)
+          expect(mock_client).to have_received(:categorize)
+        end
       end
     end
 

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -17,6 +17,116 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
     end
   end
 
+  # PER-500: auth / configuration failures trip a short-lived circuit breaker
+  # so the strategy stops burning 15s throttle cycles against a known-broken
+  # credential. The break auto-recovers after AUTH_FAILURE_TTL.
+  describe "#call auth-failure circuit breaker", :unit do
+    let(:prompt_text) { "categorize" }
+    let(:api_response) do
+      { response_text: category.i18n_key,
+        token_count: { input: 80, output: 5 },
+        cost: 0.0003 }
+    end
+
+    before do
+      Rails.cache.delete(described_class::AUTH_FAILURE_CACHE_KEY)
+      allow(Services::Categorization::Llm::PromptBuilder).to receive(:new)
+        .and_return(instance_double(Services::Categorization::Llm::PromptBuilder, build: prompt_text))
+      allow(Services::Categorization::Llm::ResponseParser).to receive(:new)
+        .and_return(instance_double(Services::Categorization::Llm::ResponseParser,
+          parse: { category: category, confidence: 0.85, raw_response: category.i18n_key }))
+    end
+
+    it "defines AUTH_FAILURE_CACHE_KEY and AUTH_FAILURE_TTL" do
+      expect(described_class::AUTH_FAILURE_CACHE_KEY).to be_a(String)
+      expect(described_class::AUTH_FAILURE_TTL).to be_a(ActiveSupport::Duration)
+    end
+
+    context "when the circuit is already open (auth flag set in cache)" do
+      before do
+        Rails.cache.write(described_class::AUTH_FAILURE_CACHE_KEY, true,
+                          expires_in: described_class::AUTH_FAILURE_TTL)
+      end
+
+      it "returns no_match without touching the LLM client" do
+        allow(mock_client).to receive(:categorize)
+        result = strategy.call(expense)
+
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+        expect(mock_client).not_to have_received(:categorize)
+      end
+
+      it "logs that the circuit is open with a short explanation" do
+        strategy.call(expense)
+        expect(logger).to have_received(:warn).with(/circuit open|auth failure/i)
+      end
+    end
+
+    context "when the LLM client raises AuthenticationError" do
+      before do
+        allow(mock_client).to receive(:categorize)
+          .and_raise(Services::Categorization::Llm::Client::AuthenticationError.new("bad api key"))
+      end
+
+      it "trips the circuit breaker by writing the cache flag" do
+        strategy.call(expense)
+        expect(Rails.cache.read(described_class::AUTH_FAILURE_CACHE_KEY)).to be true
+      end
+
+      it "reports the exception via Services::ErrorTrackingService" do
+        tracker = instance_double(Services::ErrorTrackingService, track_exception: nil)
+        allow(Services::ErrorTrackingService).to receive(:instance).and_return(tracker)
+
+        strategy.call(expense)
+
+        expect(tracker).to have_received(:track_exception).with(
+          instance_of(Services::Categorization::Llm::Client::AuthenticationError),
+          hash_including(strategy: "LlmStrategy")
+        )
+      end
+
+      it "returns no_match so the engine falls through to the next layer" do
+        result = strategy.call(expense)
+        expect(result).not_to be_successful
+        expect(result.method).to eq("no_match")
+      end
+    end
+
+    context "when the LLM client raises ConfigurationError" do
+      before do
+        allow(mock_client).to receive(:categorize)
+          .and_raise(Services::Categorization::Llm::Client::ConfigurationError.new("missing api key"))
+      end
+
+      it "trips the circuit breaker" do
+        strategy.call(expense)
+        expect(Rails.cache.read(described_class::AUTH_FAILURE_CACHE_KEY)).to be true
+      end
+    end
+
+    # Non-auth errors (rate limits, timeouts, server 500s) must NOT trip the
+    # circuit — those are transient and have their own retry layer. Tripping
+    # the circuit on a flaky network would lock out categorization for 5min
+    # every time Anthropic has a bad minute.
+    context "when the LLM client raises a non-auth Llm::Client::Error" do
+      before do
+        allow(mock_client).to receive(:categorize)
+          .and_raise(Services::Categorization::Llm::Client::ApiError.new("500 upstream"))
+      end
+
+      it "does NOT trip the circuit breaker" do
+        strategy.call(expense)
+        expect(Rails.cache.read(described_class::AUTH_FAILURE_CACHE_KEY)).to be_nil
+      end
+
+      it "returns no_match" do
+        result = strategy.call(expense)
+        expect(result).not_to be_successful
+      end
+    end
+  end
+
   describe "BaseStrategy interface" do
     it "inherits from BaseStrategy" do
       expect(described_class.superclass).to eq(Services::Categorization::Strategies::BaseStrategy)


### PR DESCRIPTION
## Summary

Closes [PER-500](https://linear.app/personal-brand-esoto/issue/PER-500) — high-priority **H2** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

On 2026-04-16 the Anthropic API key dropped from credentials and every email categorization silently returned \`no_match\` for hours. The existing catch-all rescue at the bottom of \`LlmStrategy#call\` logged each failure but the system kept burning a 15s throttle cycle per expense with no way to distinguish "transient 500" from "credentials are irrecoverably wrong."

## Changes

**\`LlmStrategy\`** — auth-failure circuit breaker:
- \`AUTH_FAILURE_CACHE_KEY = "llm_auth_broken"\`, \`AUTH_FAILURE_TTL = 5.minutes\`
- \`#call\` short-circuits to \`no_match\` when the flag is set (no client init, no throttle, no retry)
- New \`rescue Llm::Client::AuthenticationError, Llm::Client::ConfigurationError\` → \`#trip_auth_circuit!\` sets the flag + reports to \`Services::ErrorTrackingService.instance.track_exception\`
- \`ErrorTrackingService\` failure is caught separately so a broken tracker can't mask the underlying auth failure

Non-auth \`Llm::Client::Error\` (rate limits, timeouts, 5xx) deliberately do **not** trip the circuit — those are transient and already handled by the rate-limit retry loop.

## Test plan

- [x] \`bundle exec rspec spec/services/categorization/strategies/llm_strategy_spec.rb\` — 62 pass (9 new circuit-breaker tests)
- [x] Covers: flag-set short-circuit, \`AuthenticationError\` trips + tracks, \`ConfigurationError\` trips, \`ApiError\` does NOT trip, constants defined, logger called on trip
- [x] \`bundle exec rspec spec/services/categorization/ --tag unit\` — 1272 pass, 1 pending
- [x] \`bundle exec rubocop\` on changed files — clean

## Deploy notes

Depends on the Services::ErrorTrackingService wiring — if no APM is configured (O1 / PER-526 not yet shipped), the service logs locally. The circuit breaker still works — it just surfaces via Rails.logger until an error tracker is wired up.