### PR TITLE
security(js): harden Stimulus innerHTML sites against latent XSS (PER-501)

### DIFF
--- a/app/javascript/controllers/bulk_actions_controller.js
+++ b/app/javascript/controllers/bulk_actions_controller.js
@@ -197,13 +197,18 @@ export default class extends Controller {
     
     const color = colors[type] || colors.info
     
+    // PER-501: build the notification via DOM APIs so `message` can't
+    // introduce XSS — the caller may pass server-supplied text containing
+    // merchant names, descriptions, or backend error strings.
     const notification = document.createElement('div')
     notification.className = `fixed top-4 right-4 z-50 p-4 bg-${color}-50 border border-${color}-200 rounded-lg shadow-lg`
-    notification.innerHTML = `
-      <div class="flex items-center">
-        <span class="text-${color}-700">${message}</span>
-      </div>
-    `
+    const row = document.createElement('div')
+    row.className = 'flex items-center'
+    const msgSpan = document.createElement('span')
+    msgSpan.className = `text-${color}-700`
+    msgSpan.textContent = message
+    row.appendChild(msgSpan)
+    notification.appendChild(row)
     
     document.body.appendChild(notification)
     

--- a/app/javascript/controllers/bulk_operations_controller.js
+++ b/app/javascript/controllers/bulk_operations_controller.js
@@ -470,9 +470,11 @@ export default class extends Controller {
   showError(message) {
     if (this.hasErrorContainerTarget) {
       this.errorContainerTarget.classList.remove('hidden')
-      
+
       if (this.hasErrorListTarget) {
-        this.errorListTarget.innerHTML = `<li>${message}</li>`
+        // PER-501: server error text may contain merchant names or other
+        // untrusted content — use textContent to neutralize HTML.
+        this.errorListTarget.replaceChildren(this.#errorListItem(message))
       }
     }
   }
@@ -482,9 +484,11 @@ export default class extends Controller {
    */
   showDetailedErrors(errors) {
     if (this.hasErrorListTarget) {
-      this.errorListTarget.innerHTML = errors
-        .map(error => `<li>${error}</li>`)
-        .join('')
+      // PER-501: errors come from the bulk-op backend response and may
+      // include user-input fragments. Build <li>s with textContent so a
+      // rogue string like "<script>..." renders as text, not markup.
+      const items = errors.map(error => this.#errorListItem(error))
+      this.errorListTarget.replaceChildren(...items)
     }
   }
 
@@ -497,13 +501,34 @@ export default class extends Controller {
       this.errorContainerTarget.classList.remove('hidden')
 
       if (this.hasErrorListTarget) {
-        this.errorListTarget.innerHTML = `
-          <li class="font-semibold">${message}</li>
-          ${failures.slice(0, 5).map(f => `<li class="ml-4">• ${t('bulk_operations.partial_errors.expense_item', { id: f.id, error: f.error })}</li>`).join('')}
-          ${failures.length > 5 ? `<li class="ml-4 text-slate-500">${t('bulk_operations.partial_errors.more_items', { count: failures.length - 5 })}</li>` : ''}
-        `
+        // PER-501: f.id is numeric and f.error is a backend string. i18n
+        // output itself is safe, but we build each <li> with textContent
+        // so the interpolated content can't escape.
+        const header = this.#errorListItem(message, 'font-semibold')
+        const detail = failures.slice(0, 5).map(f => (
+          this.#errorListItem(
+            `• ${t('bulk_operations.partial_errors.expense_item', { id: f.id, error: f.error })}`,
+            'ml-4'
+          )
+        ))
+        const nodes = [header, ...detail]
+        if (failures.length > 5) {
+          nodes.push(this.#errorListItem(
+            t('bulk_operations.partial_errors.more_items', { count: failures.length - 5 }),
+            'ml-4 text-slate-500'
+          ))
+        }
+        this.errorListTarget.replaceChildren(...nodes)
       }
     }
+  }
+
+  // PER-501 helper: single <li> node with textContent-safe content + optional classes.
+  #errorListItem(text, className = '') {
+    const li = document.createElement('li')
+    if (className) li.className = className
+    li.textContent = text
+    return li
   }
 
   /**

--- a/app/javascript/controllers/category_confidence_controller.js
+++ b/app/javascript/controllers/category_confidence_controller.js
@@ -72,37 +72,51 @@ export default class extends Controller {
     // Add content
     const content = document.createElement("div")
     content.classList.add("relative")
-    content.innerHTML = this.getTooltipContent()
+    // PER-501: build tooltip via DOM APIs. The `explanationValue` is read
+    // from a data attribute populated by the server — never interpolate it
+    // into innerHTML.
+    content.appendChild(this.buildTooltipFragment())
     tooltip.appendChild(content)
-    
+
     document.body.appendChild(tooltip)
     this.tooltipTarget = tooltip
   }
 
-  getTooltipContent() {
-    let content = `<div class="font-semibold mb-1">${t("categories.confidence.display", { percentage: this.percentageValue })}</div>`
+  // PER-501: returns a DocumentFragment so the caller can appendChild
+  // without ever seeing raw HTML strings.
+  buildTooltipFragment() {
+    const frag = document.createDocumentFragment()
+
+    const header = document.createElement("div")
+    header.className = "font-semibold mb-1"
+    header.textContent = t("categories.confidence.display", { percentage: this.percentageValue })
+    frag.appendChild(header)
 
     if (this.explanationValue) {
-      content += `<div class="text-slate-300">${this.explanationValue}</div>`
+      const explanation = document.createElement("div")
+      explanation.className = "text-slate-300"
+      explanation.textContent = this.explanationValue
+      frag.appendChild(explanation)
     }
 
     const levelKey = this.levelValue // high, medium, low, very_low
     const levelText = t(`categories.confidence.${levelKey}`)
 
     if (levelText !== `categories.confidence.${levelKey}`) {
-      content += `<div class="mt-1 pt-1 border-t border-slate-600 text-slate-400">
-                    ${levelText}
-                  </div>`
+      const levelDiv = document.createElement("div")
+      levelDiv.className = "mt-1 pt-1 border-t border-slate-600 text-slate-400"
+      levelDiv.textContent = levelText
+      frag.appendChild(levelDiv)
     }
 
-    // Add keyboard shortcut hint
     if (this.levelValue === "low" || this.levelValue === "very_low") {
-      content += `<div class="mt-1 text-slate-500">
-                    ${t("categories.confidence.shortcut_hint")}
-                  </div>`
+      const hint = document.createElement("div")
+      hint.className = "mt-1 text-slate-500"
+      hint.textContent = t("categories.confidence.shortcut_hint")
+      frag.appendChild(hint)
     }
 
-    return content
+    return frag
   }
 
   // Show correction interface

--- a/app/javascript/controllers/category_confidence_controller.js
+++ b/app/javascript/controllers/category_confidence_controller.js
@@ -379,28 +379,44 @@ export default class extends Controller {
       "fixed", "bottom-4", "right-4", "p-3", "rounded-lg",
       "shadow-lg", "z-50", "transition-all", "duration-300"
     )
-    
+
+    // PER-501: build the notification via DOM APIs. Today all callers pass
+    // static t() keys, but the signature accepts any string — a future caller
+    // passing a server error would open XSS. Same pattern as
+    // bulk_actions_controller.js#showNotification.
+    const iconPath = (type === "success")
+      ? "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+      : "M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+
     if (type === "success") {
       notification.classList.add("bg-emerald-50", "text-emerald-800", "border", "border-emerald-200")
-      notification.innerHTML = `
-        <div class="flex items-center gap-2">
-          <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-          </svg>
-          <span>${message}</span>
-        </div>
-      `
     } else {
       notification.classList.add("bg-rose-50", "text-rose-800", "border", "border-rose-200")
-      notification.innerHTML = `
-        <div class="flex items-center gap-2">
-          <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-          </svg>
-          <span>${message}</span>
-        </div>
-      `
     }
+
+    const row = document.createElement("div")
+    row.className = "flex items-center gap-2"
+
+    const svgNS = "http://www.w3.org/2000/svg"
+    const svg = document.createElementNS(svgNS, "svg")
+    svg.setAttribute("aria-hidden", "true")
+    svg.setAttribute("class", "w-5 h-5")
+    svg.setAttribute("fill", "none")
+    svg.setAttribute("stroke", "currentColor")
+    svg.setAttribute("viewBox", "0 0 24 24")
+    const path = document.createElementNS(svgNS, "path")
+    path.setAttribute("stroke-linecap", "round")
+    path.setAttribute("stroke-linejoin", "round")
+    path.setAttribute("stroke-width", "2")
+    path.setAttribute("d", iconPath)
+    svg.appendChild(path)
+
+    const span = document.createElement("span")
+    span.textContent = message
+
+    row.appendChild(svg)
+    row.appendChild(span)
+    notification.appendChild(row)
     
     document.body.appendChild(notification)
     

--- a/app/javascript/controllers/dashboard_virtual_scroll_controller.js
+++ b/app/javascript/controllers/dashboard_virtual_scroll_controller.js
@@ -451,9 +451,13 @@ export default class extends Controller {
       const expandedDetails = node.querySelector('.expense-expanded-details')
       expandedDetails.classList.remove('hidden')
       if (expense.description) {
-        expandedDetails.innerHTML = `
-          <p class="text-xs text-slate-600 line-clamp-2">${expense.description}</p>
-        `
+        // PER-501: expense.description originates from bank emails / user
+        // input — never interpolate into innerHTML. Build the <p> via DOM
+        // APIs so a description containing HTML renders as plain text.
+        const p = document.createElement('p')
+        p.className = 'text-xs text-slate-600 line-clamp-2'
+        p.textContent = expense.description
+        expandedDetails.replaceChildren(p)
       }
     }
     

--- a/app/javascript/controllers/dashboard_virtual_scroll_controller.js
+++ b/app/javascript/controllers/dashboard_virtual_scroll_controller.js
@@ -452,12 +452,16 @@ export default class extends Controller {
       expandedDetails.classList.remove('hidden')
       if (expense.description) {
         // PER-501: expense.description originates from bank emails / user
-        // input — never interpolate into innerHTML. Build the <p> via DOM
-        // APIs so a description containing HTML renders as plain text.
+        // input AND is NOT sanitized server-side — the frontend textContent
+        // assignment is the primary XSS guard, not defense-in-depth.
         const p = document.createElement('p')
         p.className = 'text-xs text-slate-600 line-clamp-2'
         p.textContent = expense.description
         expandedDetails.replaceChildren(p)
+      } else {
+        // PER-501: if this node was previously recycled from an expense that
+        // had a description, the old <p> would persist. Clear explicitly.
+        expandedDetails.replaceChildren()
       }
     }
     
@@ -489,11 +493,13 @@ export default class extends Controller {
     node.querySelector('.expense-amount').textContent = ''
     node.querySelector('.expense-date').textContent = ''
     
-    // Hide expanded details
-    node.querySelector('.expense-expanded-details').classList.add('hidden')
-    
+    // Hide expanded details + clear any leftover children (PER-501).
+    const expandedDetails = node.querySelector('.expense-expanded-details')
+    expandedDetails.classList.add('hidden')
+    expandedDetails.replaceChildren()
+
     // Clear inline actions
-    node.querySelector('.inline-quick-actions').innerHTML = ''
+    node.querySelector('.inline-quick-actions').replaceChildren()
   }
   
   // Clean up items outside the render range


### PR DESCRIPTION
## Summary

Closes [PER-501](https://linear.app/personal-brand-esoto/issue/PER-501) — high-priority **H3** from the production-readiness review ([epic PER-490](https://linear.app/personal-brand-esoto/issue/PER-490)).

Six Stimulus controllers assemble HTML via template-literal \`innerHTML\`. No current callsite exploits it, but any change that echoes an untrusted server field (merchant name, description, backend error message) into one of these templates becomes live XSS.

## Changes

Converted every site that **interpolates user-derived strings** to safe DOM construction (\`createElement\` + \`textContent\` + \`replaceChildren\`):

| File | Before | Risk |
|---|---|---|
| \`bulk_actions_controller.js\`:showNotification | \`innerHTML = \\\`...<span>\${message}</span>...\`\` | message from any server response |
| \`bulk_operations_controller.js\`:showError | \`innerHTML = \\\`<li>\${message}</li>\`\` | backend error strings |
| \`bulk_operations_controller.js\`:showDetailedErrors | \`errors.map(e => \\\`<li>\${e}</li>\`).join('')\` | backend error array |
| \`bulk_operations_controller.js\`:showPartialErrors | loop with \`f.error\` interpolation | bulk-op failure payload |
| \`dashboard_virtual_scroll_controller.js\`:454 | \`innerHTML = \\\`<p>\${expense.description}</p>\`\` | expense.description comes from bank emails — the most directly exploitable path |
| \`category_confidence_controller.js\`:getTooltipContent | template string with \`\${this.explanationValue}\` | refactored to \`buildTooltipFragment\` returning a \`DocumentFragment\` |

\`bulk_operations_controller\` got a private \`#errorListItem(text, className)\` helper so the three call sites share one DOM builder.

## What I did NOT touch

The remaining ticket-listed \`innerHTML\` sites (\`bulk_actions:115\`, \`virtual_scroll:380/763/961\`, \`pattern_chart:478\`, \`category_confidence:141\`, \`accessibility_manager:241\`) only interpolate \`t()\` output (i18n bundle, author-controlled) or static enum/number values. Those templates stay — rewriting them adds noise without closing a real hole.

## Test plan

- [x] \`node --check\` passed on all 4 modified files
- [x] \`bundle exec brakeman\` — no warnings
- [x] Manual audit of each interpolation source (see risk table above)
- [ ] System-test smoke on dashboard + bulk operations (covered by existing \`spec/system/bulk_operations_spec.rb\`, \`spec/system/virtual_scrolling_spec.rb\`)

## Out of scope (follow-up)

The pre-work surfaced **~41 other \`innerHTML\` sites across 18 controllers** beyond the 6 the ticket scoped. Will file a follow-up audit ticket to sweep those.