### PR TITLE
feat(jobs): 30-day retention for Solid Queue failed executions (PER-503)

### DIFF
--- a/app/jobs/solid_queue_failed_execution_cleanup_job.rb
+++ b/app/jobs/solid_queue_failed_execution_cleanup_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Background job that purges SolidQueue::FailedExecution rows older than
+# RETENTION_DAYS to prevent unbounded growth of the queue.failed_executions
+# table (PER-503).
+#
+# Context: config/recurring.yml already clears Solid Queue *finished* jobs via
+# SolidQueue::Job.clear_finished_in_batches, but failed executions accumulate
+# forever. Over months of production, this bloats the queue database.
+#
+# Retention matches PER-496 (email parsing failures): 30 days. The constant
+# lives on this job (not on SolidQueue::FailedExecution) because we don't own
+# the gem's model.
+#
+# Scheduled daily at 4:15am via config/recurring.yml (offset from the 4:00am
+# PER-496 email-parsing cleanup to spread load).
+class SolidQueueFailedExecutionCleanupJob < ApplicationJob
+  RETENTION_DAYS = 30
+
+  queue_as :low
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform
+    Rails.logger.info "[SolidQueueFailedExecutionCleanup] Starting cleanup (retention=#{RETENTION_DAYS}d)..."
+
+    # delete_all (not destroy_all): SolidQueue::FailedExecution has no
+    # before/after_destroy callbacks we care about. Bulk SQL DELETE is fast
+    # and keeps the queue DB clean.
+    count = SolidQueue::FailedExecution
+              .where("created_at <= ?", RETENTION_DAYS.days.ago)
+              .delete_all
+
+    Rails.logger.info "[SolidQueueFailedExecutionCleanup] Cleanup complete: cleaned_up=#{count}"
+  rescue StandardError => e
+    Rails.logger.error "[SolidQueueFailedExecutionCleanup] Cleanup failed: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise
+  end
+end

--- a/app/jobs/solid_queue_failed_execution_cleanup_job.rb
+++ b/app/jobs/solid_queue_failed_execution_cleanup_job.rb
@@ -25,9 +25,17 @@ class SolidQueueFailedExecutionCleanupJob < ApplicationJob
 
     # delete_all (not destroy_all): SolidQueue::FailedExecution has no
     # before/after_destroy callbacks we care about. Bulk SQL DELETE is fast
-    # and keeps the queue DB clean.
+    # and keeps the queue DB clean. The `created_at: ..cutoff` beginless range
+    # emits `created_at <= $1` (inclusive) — matches the PER-496 pattern and
+    # is more idiomatic than a raw SQL fragment.
+    #
+    # Scaling note: at current volume (dozens to low hundreds of rows per
+    # month), a single DELETE is fine. If solid_queue_failed_executions ever
+    # grows past ~10k rows, switch to `find_each(batch_size: 1000)` or add
+    # a custom `db/queue_migrate/` index on created_at (the gem ships only
+    # an index on job_id).
     count = SolidQueue::FailedExecution
-              .where("created_at <= ?", RETENTION_DAYS.days.ago)
+              .where(created_at: ..RETENTION_DAYS.days.ago)
               .delete_all
 
     Rails.logger.info "[SolidQueueFailedExecutionCleanup] Cleanup complete: cleaned_up=#{count}"

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -83,6 +83,17 @@ default: &default
     schedule: every day at 4am
     description: "Purge email parsing failures older than 30 days (PER-496 retention)"
 
+  # Purge SolidQueue::FailedExecution rows older than 30 days. The existing
+  # clear_solid_queue_finished_jobs entry handles completed jobs, but failed
+  # executions grow unbounded without this. Offset to 4:15am to avoid
+  # colliding with the PER-496 cleanup above.
+  cleanup_solid_queue_failed_executions:
+    class: SolidQueueFailedExecutionCleanupJob
+    queue: low
+    priority: 10
+    schedule: every day at 4:15am
+    description: "Purge failed job executions older than 30 days (PER-503 retention)"
+
 development:
   <<: *default
   # In development, run metrics calculation more frequently for testing

--- a/spec/jobs/solid_queue_failed_execution_cleanup_job_spec.rb
+++ b/spec/jobs/solid_queue_failed_execution_cleanup_job_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolidQueueFailedExecutionCleanupJob, type: :job, unit: true do
+  let(:job) { described_class.new }
+
+  before do
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  # Helper: create a real SolidQueue::FailedExecution anchored to a backing
+  # job. FailedExecution belongs_to :job with class_name "SolidQueue::Job", and
+  # the gem validates the presence of the job + error payload. We bypass
+  # created_at auto-set with update_columns so boundary scenarios are
+  # deterministic.
+  def create_failed_execution(created_at:)
+    solid_job = SolidQueue::Job.create!(
+      queue_name: "default",
+      class_name: "DummyJob",
+      arguments: [].to_json,
+      active_job_id: SecureRandom.uuid
+    )
+    SolidQueue::FailedExecution.create!(
+      job: solid_job,
+      error: { "exception_class" => "RuntimeError", "message" => "boom" }
+    ).tap do |fe|
+      fe.update_columns(created_at: created_at)
+    end
+  end
+
+  describe "retention policy" do
+    # Threshold lives on the JOB (not the gem's FailedExecution model, which
+    # we don't own). PER-503 retention matches PER-496 (30 days).
+    it "uses SolidQueueFailedExecutionCleanupJob::RETENTION_DAYS (30)" do
+      expect(described_class::RETENTION_DAYS).to eq(30)
+    end
+  end
+
+  describe "#perform" do
+    it "runs without error when no failed executions exist" do
+      SolidQueue::FailedExecution.delete_all
+      expect { job.perform }.not_to raise_error
+    end
+
+    it "logs a completion line with the cleaned-up count" do
+      SolidQueue::FailedExecution.delete_all
+      expect(Rails.logger).to receive(:info).with(/Cleanup complete: cleaned_up=0/)
+      job.perform
+    end
+
+    context "with a mix of stale, boundary, and recent failed executions" do
+      around do |example|
+        travel_to(Time.zone.local(2026, 4, 17, 4, 15, 0)) { example.run }
+      end
+
+      before { SolidQueue::FailedExecution.delete_all }
+
+      let!(:stale) { create_failed_execution(created_at: 31.days.ago) }
+      let!(:exact_cutoff) do
+        # Inclusive cutoff: exactly RETENTION_DAYS ago IS expired.
+        create_failed_execution(created_at: described_class::RETENTION_DAYS.days.ago)
+      end
+      let!(:just_newer) do
+        create_failed_execution(created_at: described_class::RETENTION_DAYS.days.ago + 1.second)
+      end
+      let!(:recent) { create_failed_execution(created_at: 29.days.ago) }
+
+      it "deletes stale and exact-cutoff rows (inclusive boundary)" do
+        expect { job.perform }.to change(SolidQueue::FailedExecution, :count).by(-2)
+      end
+
+      it "preserves rows newer than the cutoff (including the 1-second-younger row)" do
+        job.perform
+        expect(SolidQueue::FailedExecution.exists?(recent.id)).to be true
+        expect(SolidQueue::FailedExecution.exists?(just_newer.id)).to be true
+      end
+
+      it "removes the stale and exact-cutoff rows" do
+        job.perform
+        expect(SolidQueue::FailedExecution.exists?(stale.id)).to be false
+        expect(SolidQueue::FailedExecution.exists?(exact_cutoff.id)).to be false
+      end
+
+      it "logs the completion line with the cleaned-up count" do
+        expect(Rails.logger).to receive(:info).with(/Cleanup complete: cleaned_up=2/)
+        job.perform
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "is queued on the low-priority queue" do
+      expect(described_class.new.queue_name).to eq("low")
+    end
+  end
+end

--- a/spec/jobs/solid_queue_failed_execution_cleanup_job_spec.rb
+++ b/spec/jobs/solid_queue_failed_execution_cleanup_job_spec.rb
@@ -94,5 +94,34 @@ RSpec.describe SolidQueueFailedExecutionCleanupJob, type: :job, unit: true do
     it "is queued on the low-priority queue" do
       expect(described_class.new.queue_name).to eq("low")
     end
+
+    it "retries on StandardError up to 3 attempts with polynomial backoff" do
+      # retry_on contract — if a transient queue-DB error happens, the job
+      # must be retried rather than silently failing the cleanup. This
+      # assertion guards the retry_on declaration from being accidentally
+      # removed or narrowed to a specific error class.
+      retry_jitters = described_class.retry_jitter
+      rescue_handlers = described_class.rescue_handlers
+
+      standard_error_entry = rescue_handlers.find do |class_name, _handler|
+        class_name == "StandardError"
+      end
+      expect(standard_error_entry).not_to be_nil,
+        "expected retry_on StandardError (3x polynomial) — rescue_handlers=#{rescue_handlers.inspect}"
+    end
+  end
+
+  describe "error handling" do
+    it "logs the failure and re-raises so retry_on can fire" do
+      # The rescue branch MUST re-raise — ActiveJob's retry_on only sees
+      # exceptions that propagate out of perform. A silent rescue would
+      # mask the error and defeat the 3-attempt polynomial-backoff policy.
+      boom = StandardError.new("queue db offline")
+      allow(SolidQueue::FailedExecution).to receive(:where).and_raise(boom)
+      expect(Rails.logger).to receive(:error).with(/Cleanup failed: queue db offline/)
+      expect(Rails.logger).to receive(:error) # backtrace line
+
+      expect { job.perform }.to raise_error(StandardError, "queue db offline")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Closes [PER-503](https://linear.app/personal-brand-esoto/issue/PER-503) (H5 — production readiness campaign).

`config/recurring.yml` already schedules `clear_solid_queue_finished_jobs` to trim completed jobs every 6 hours. **Failed executions** were unbounded. Over months of production this bloats the queue database.

Adds `SolidQueueFailedExecutionCleanupJob` — mirror of the PER-496 `EmailParsingFailureCleanupJob` pattern:

- `RETENTION_DAYS = 30` (matches PER-496)
- `queue_as :low` + `retry_on StandardError` polynomially 3x (inherited `ApplicationJob` pattern)
- Bulk DELETE: `SolidQueue::FailedExecution.where("created_at <= ?", cutoff).delete_all` — gem model has no `.expired` scope, filter lives on the job
- Scheduled daily at **4:15am** — offset from PER-496's 4:00am to spread load

## Why this matters (pre-Hetzner deploy)

Round 1 DB/jobs review (`round1-jobs.md` #6, `round1-db.md` #6) flagged unbounded growth of `solid_queue_failed_executions` as a deploy risk. Not a correctness bug — just a slow database bloat that compounds across months.

## Test plan

- [x] 8 new unit tests covering:
  - Retention constant value
  - No-op behavior on empty table
  - Log line emits `cleaned_up=N`
  - Boundary scenarios via `travel_to` + `update_columns`: stale (31d → deleted), exact cutoff (30d → deleted, inclusive), just-newer (30d+1s → preserved), recent (29d → preserved)
  - Queue name is `low`
- [x] `bundle exec rspec spec/jobs/` — 823 examples, 0 failures, 1 pending (PER-532 xit, expected)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec brakeman` — 0 new warnings
- [x] YAML parses cleanly with aliases enabled (`Psych.load` with `aliases: true`)

## Out of scope

- Configurable retention via env var — hardcoded 30d matches the PER-496 precedent and the FINAL production-readiness report's recommendation
- Batch-size tuning / rate limiting — current traffic doesn't require it; single DELETE is fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)