### PR TITLE
security(admin): replace no-op check_rate_limit with Rack::Attack throttle (PER-507)

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -8,19 +8,16 @@ module Admin
     skip_before_action :authenticate_user!
     include AdminAuthentication
 
-    # Rate limiting for admin actions
-    before_action :check_rate_limit
+    # Rate limiting is centralized in Rack::Attack (see config/initializers/
+    # rack_attack.rb for the admin/state-changing/ip throttle and the per-
+    # action rules for login, password reset, pattern test/import, CSV
+    # exports, and statistics). PER-507 removed a no-op request-level
+    # placeholder that added no protection.
 
     # Audit logging
     after_action :log_admin_activity
 
     private
-
-    def check_rate_limit
-      # Rate limiting is handled by Rack::Attack middleware
-      # This is a placeholder for request-specific rate limiting
-      true
-    end
 
     def log_admin_activity
       # Log all admin actions for audit trail

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -146,8 +146,11 @@ class Rack::Attack
   # test/import, CSV exports) still apply — Rack::Attack evaluates every
   # matching throttle, so the tightest one wins.
   throttle("admin/state-changing/ip", limit: 60, period: 1.minute) do |req|
-    if req.path.start_with?("/admin") &&
-       (req.post? || req.patch? || req.put? || req.delete?)
+    # Anchor the path check so this rule catches only the /admin namespace,
+    # not future routes like /admins or /admin_something that don't exist
+    # today but could be added later and silently fall under this rule.
+    admin_path = req.path == "/admin" || req.path.start_with?("/admin/")
+    if admin_path && (req.post? || req.patch? || req.put? || req.delete?)
       req.ip
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -136,6 +136,22 @@ class Rack::Attack
     end
   end
 
+  # PER-507: throttle state-changing admin requests. Previously, the generic
+  # req/ip rule (300/5min) was the only gate on /admin/* POST/PATCH/PUT/DELETE,
+  # which is too loose for write-side admin flows (categories, expenses edit,
+  # category fingerprint mutations). A no-op `check_rate_limit` placeholder on
+  # Admin::BaseController gave the false impression of an additional layer.
+  # This rule centralizes the limit in Rack::Attack. The specific subpaths
+  # already covered by tighter rules above (login, password reset, pattern
+  # test/import, CSV exports) still apply — Rack::Attack evaluates every
+  # matching throttle, so the tightest one wins.
+  throttle("admin/state-changing/ip", limit: 60, period: 1.minute) do |req|
+    if req.path.start_with?("/admin") &&
+       (req.post? || req.patch? || req.put? || req.delete?)
+      req.ip
+    end
+  end
+
   # === Track suspicious activity ===
 
   # Track 404s to identify scanners

--- a/spec/controllers/admin/base_controller_unit_spec.rb
+++ b/spec/controllers/admin/base_controller_unit_spec.rb
@@ -35,9 +35,12 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
       expect(described_class.included_modules.map(&:name)).to include("AdminAuthentication")
     end
 
-    it "has check_rate_limit as before_action" do
-      # Test that the method exists in the class (including private methods)
-      expect(described_class.private_instance_methods).to include(:check_rate_limit)
+    it "does NOT register a check_rate_limit method (PER-507 removed the no-op placeholder)" do
+      # Rate limiting is handled centrally by Rack::Attack (see
+      # config/initializers/rack_attack.rb — `admin/state-changing/ip`
+      # throttle). A controller-level placeholder that just `return true`
+      # provided no protection and was misleading.
+      expect(described_class.private_instance_methods).not_to include(:check_rate_limit)
     end
 
     it "has log_admin_activity as after_action" do
@@ -57,13 +60,6 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
   end
 
   describe "private methods", unit: true do
-    describe "#check_rate_limit" do
-      it "returns true by default" do
-        result = controller.send(:check_rate_limit)
-        expect(result).to be_truthy
-      end
-    end
-
     describe "#log_admin_activity" do
       before do
         allow(controller).to receive(:controller_name).and_return("test")
@@ -116,8 +112,12 @@ RSpec.describe Admin::BaseController, type: :controller, unit: true do
   end
 
   describe "security features", unit: true do
-    it "includes rate limiting functionality" do
-      expect(controller.respond_to?(:check_rate_limit, true)).to be_truthy
+    it "delegates rate limiting to Rack::Attack middleware (PER-507)" do
+      # Rate limiting is NOT a controller-level concern anymore. The
+      # admin/state-changing/ip throttle in config/initializers/rack_attack.rb
+      # is the single source of truth for per-IP limits on POST/PATCH/PUT/
+      # DELETE to /admin/*.
+      expect(controller.respond_to?(:check_rate_limit, true)).to be false
     end
 
     it "includes audit logging functionality" do

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -112,6 +112,43 @@ RSpec.describe "Rack::Attack throttle path matching", :unit do
     end
   end
 
+  describe "admin state-changing throttle (PER-507)" do
+    # PER-507: centralize admin rate-limiting in Rack::Attack, replacing the
+    # no-op `check_rate_limit` placeholder on Admin::BaseController. Read
+    # the initializer source + verify the throttle rule is present with the
+    # expected shape: limit 60/min/IP, POST/PATCH/PUT/DELETE to /admin/*.
+    let(:initializer_content) { File.read(Rails.root.join("config/initializers/rack_attack.rb")) }
+    let(:throttle_block) do
+      initializer_content[/throttle\("admin\/state-changing\/ip".*?end\s*end/m]
+    end
+
+    it "registers a throttle named 'admin/state-changing/ip'" do
+      expect(throttle_block).to be_present,
+        "expected a Rack::Attack throttle for admin state-changing requests"
+    end
+
+    it "limits to 60 requests per minute per IP" do
+      expect(throttle_block).to include("limit: 60")
+      expect(throttle_block).to include("period: 1.minute")
+    end
+
+    it "scopes to /admin paths only (not /api, not public)" do
+      expect(throttle_block).to include('req.path.start_with?("/admin")')
+    end
+
+    it "matches state-changing HTTP methods (POST, PATCH, PUT, DELETE) but not GET/HEAD" do
+      # Uses a negative method check so any future state-changing verb is
+      # covered automatically; GET/HEAD stays under the broader req/ip rule.
+      expect(throttle_block).to match(/req\.post\?|req\.patch\?|req\.put\?|req\.delete\?/)
+    end
+
+    it "documents PER-507 context in the initializer comments" do
+      # Comment lives just above the throttle block (not captured by the
+      # `throttle(...) do...end` regex) — assert anywhere in the file.
+      expect(initializer_content).to match(/PER-507/)
+    end
+  end
+
   describe "cache store configuration" do
     it "uses Rails.cache unconditionally without Redis branching" do
       initializer_path = Rails.root.join("config/initializers/rack_attack.rb")

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -132,14 +132,20 @@ RSpec.describe "Rack::Attack throttle path matching", :unit do
       expect(throttle_block).to include("period: 1.minute")
     end
 
-    it "scopes to /admin paths only (not /api, not public)" do
-      expect(throttle_block).to include('req.path.start_with?("/admin")')
+    it "scopes to /admin paths with a path anchor (not /admins or /admin_foo)" do
+      # Check both forms: exact /admin OR /admin/ prefix.
+      expect(throttle_block).to include('req.path == "/admin"')
+      expect(throttle_block).to include('req.path.start_with?("/admin/")')
     end
 
-    it "matches state-changing HTTP methods (POST, PATCH, PUT, DELETE) but not GET/HEAD" do
-      # Uses a negative method check so any future state-changing verb is
-      # covered automatically; GET/HEAD stays under the broader req/ip rule.
-      expect(throttle_block).to match(/req\.post\?|req\.patch\?|req\.put\?|req\.delete\?/)
+    it "matches every state-changing HTTP method (POST, PATCH, PUT, DELETE)" do
+      # Assert each verb individually — a single regex alternation would
+      # silently pass if someone refactored to just `req.post?`, losing
+      # coverage for the other three verbs.
+      expect(throttle_block).to include("req.post?")
+      expect(throttle_block).to include("req.patch?")
+      expect(throttle_block).to include("req.put?")
+      expect(throttle_block).to include("req.delete?")
     end
 
     it "documents PER-507 context in the initializer comments" do


### PR DESCRIPTION
## Summary

Closes [PER-507](https://linear.app/personal-brand-esoto/issue/PER-507) (H9 — production readiness campaign, **final H-series ticket**).

`Admin::BaseController#check_rate_limit` was a no-op placeholder that simply returned `true`:

```ruby
def check_rate_limit
  # Rate limiting is handled by Rack::Attack middleware
  # This is a placeholder for request-specific rate limiting
  true
end
```

It provided zero protection and gave false confidence that a second rate-limiting layer existed. The only actual gate on state-changing admin paths (POST/PATCH/PUT/DELETE to `/admin/*`) was the generic `req/ip: 300/5min` rule — too loose for admin write flows (category / expense / user / pattern mutations).

**Option A** chosen per the ticket's recommendation: centralize in Rack::Attack rather than per-action in-controller throttling. Simpler, consistent with existing rules, no new request state.

## Changes

1. **`config/initializers/rack_attack.rb`** — new `admin/state-changing/ip` throttle: 60 req/min/IP for POST/PATCH/PUT/DELETE to `/admin/*`. GET/HEAD stays under the broader `req/ip` rule. Tighter per-action throttles above (login, password reset, pattern test/import, CSV exports, statistics) continue to apply — Rack::Attack evaluates every matching throttle and the tightest wins.

2. **`app/controllers/admin/base_controller.rb`** — remove the no-op `check_rate_limit` method and its `before_action`. Replaced with a comment pointing operators at the Rack::Attack initializer.

3. **Specs** — `rack_attack_spec.rb` gets 5 new assertions verifying throttle config shape (name, limit, period, path scope, method scope, PER-507 breadcrumb); `admin/base_controller_unit_spec.rb` flips the "has check_rate_limit" / "includes rate limiting functionality" assertions to prove the method is GONE + rate limiting is delegated.

## Test plan

- [x] `bundle exec rspec spec/initializers/rack_attack_spec.rb spec/controllers/admin/base_controller_unit_spec.rb` — 36 examples, 0 failures
- [x] `bundle exec rspec spec/controllers/admin/` — 250 examples, 0 failures (broader regression sweep)
- [x] Pre-commit hook: full unit suite green
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec brakeman` — 0 new warnings

## Out of scope

- Audit of `check_rate_limit_for_testing` / `check_rate_limit_for_import` in `Admin::PatternsController` — those are separate per-action throttles covered by existing Rack::Attack rules above; untouched by this PR
- Per-user (vs per-IP) throttling — would require auth-layer integration; not in ticket scope
- `app/controllers/concerns/rate_limiting.rb` and `app/services/sync_session_validator.rb` — unrelated `check_rate_limit!` methods in different namespaces, not the admin placeholder

## Campaign status (PER-490)

This ticket completes the H-series (H1-H9). Of the 17 tickets identified by the pre-Hetzner production-readiness review:
- **B1-B8 (deploy-blockers):** 8 of 8 shipped
- **H1-H9 (high-priority):** 8 of 9 shipped, 1 deferred (PER-505 needs post-deploy `pg_stat_user_indexes` data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)