### PR TITLE
fix(boot): remove Rails.cache warm-up — crashes db:prepare

### DIFF
--- a/config/initializers/performance_optimizations.rb
+++ b/config/initializers/performance_optimizations.rb
@@ -122,22 +122,9 @@ if defined?(GetProcessMem)
   end
 end
 
-# Preload frequently accessed data.
-#
-# The warm-up is optional — the app works correctly without it (first
-# request just pays the DB round-trip). If the DB is unreachable at boot
-# (e.g. `assets:precompile` has no DB, or a rolling deploy boots the web
-# container before PG is ready), we log and move on rather than crash
-# boot. Letting the DB exception propagate to the outer rescue keeps the
-# skip observable — no silent swallowing.
-Rails.application.config.after_initialize do
-  next unless Rails.env.production?
-  next unless defined?(Category) && defined?(CategorizationPattern)
-
-  Rails.cache.fetch("categories:all", expires_in: 1.hour) { Category.all.to_a }
-  Rails.cache.fetch("patterns:active", expires_in: 10.minutes) { CategorizationPattern.active.to_a }
-rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, PG::ConnectionBad => e
-  Rails.logger.warn "Cache warm-up skipped (DB not reachable): #{e.class}: #{e.message}"
-end
+# Removed: Rails.cache.fetch warm-up for Category.all + CategorizationPattern.active.
+# Solid Cache's `solid_cache_entries` table doesn't exist until db:prepare
+# runs, and db:prepare boots the Rails env first — so a boot-time cache
+# fetch crashed db:prepare itself. First request naturally warms the cache.
 
 Rails.logger.info "Performance optimizations loaded successfully"

--- a/spec/initializers/production_boot_smoke_spec.rb
+++ b/spec/initializers/production_boot_smoke_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe "production-boot safety of config/initializers", :unit do
       expect(source).not_to match(/SolidQueue::RecurringJob\.create/)
     end
 
-    it "guards cache warm-up with a DB-connectivity check for build-time safety" do
-      # The cache-warmup after_initialize must no-op during
-      # assets:precompile (no DB). Any of: connection_pool check,
-      # rescue on ConnectionNotEstablished, or equivalent is acceptable.
-      expect(source).to match(/connection_pool\.active_connection\?|ConnectionNotEstablished|connected\?/)
+    it "does not call Rails.cache at boot" do
+      # solid_cache_entries does not exist until db:prepare runs, and
+      # db:prepare boots the env first — so a boot-time cache call
+      # crashes db:prepare itself.
+      expect(source).not_to match(/^\s*Rails\.cache\.(fetch|read|write|exist\?)/)
     end
   end
 end


### PR DESCRIPTION
Third boot-time bug surfaced during first Hetzner deploy. After PR #443, kamal deploy reached db:prepare and died with `PG::UndefinedTable: solid_cache_entries does not exist`.

The cache warm-up in performance_optimizations.rb called Rails.cache.fetch during after_initialize. Solid Cache routes to expense_tracker_production_cache, which is created by db:prepare — but db:prepare boots the env first, so the call hit a missing table.

Removed. First request warms the cache naturally; warm-up was never actually needed and had never run (no prior production deploy).

## Verification
- `RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile` — EXIT=0
- Initializer specs updated (regression guard: no Rails.cache.\* at boot)
- Pre-commit hook green (unit + rubocop + brakeman + best-practices)