### PR TITLE
feat(email): add before: date bound to fetch_new_emails

### DIFF
--- a/app/jobs/process_emails_job.rb
+++ b/app/jobs/process_emails_job.rb
@@ -25,7 +25,7 @@ class ProcessEmailsJob < ApplicationJob
     end
   end
 
-  def perform(email_account_id = nil, since: 1.week.ago, sync_session_id: nil)
+  def perform(email_account_id = nil, since: 1.week.ago, before: nil, sync_session_id: nil)
     @sync_session = sync_session_id ? SyncSession.find_by(id: sync_session_id) : nil
     @metrics_collector = Services::SyncMetricsCollector.new(@sync_session) if @sync_session
 
@@ -43,16 +43,16 @@ class ProcessEmailsJob < ApplicationJob
     if @metrics_collector
       @metrics_collector.track_operation(:sync_account, nil, { job_type: "batch" }) do
         if email_account_id
-          process_single_account(email_account_id, since)
+          process_single_account(email_account_id, since, before)
         else
-          process_all_accounts(since)
+          process_all_accounts(since, before)
         end
       end
     else
       if email_account_id
-        process_single_account(email_account_id, since)
+        process_single_account(email_account_id, since, before)
       else
-        process_all_accounts(since)
+        process_all_accounts(since, before)
       end
     end
 
@@ -78,7 +78,7 @@ class ProcessEmailsJob < ApplicationJob
 
   private
 
-  def process_single_account(email_account_id, since)
+  def process_single_account(email_account_id, since, before = nil)
     email_account = EmailAccount.find_by(id: email_account_id)
     session_account = find_or_create_session_account(email_account) if @sync_session
 
@@ -109,7 +109,7 @@ class ProcessEmailsJob < ApplicationJob
         sync_session_account: session_account,
         metrics_collector: @metrics_collector
       )
-      result = fetcher.fetch_new_emails(since: since)
+      result = fetcher.fetch_new_emails(since: since, before: before)
 
       if result.success?
         Rails.logger.info "Successfully processed emails for: #{email_account.email} - " \
@@ -135,7 +135,7 @@ class ProcessEmailsJob < ApplicationJob
     @sync_session.sync_session_accounts.find_or_create_by(email_account: email_account)
   end
 
-  def process_all_accounts(since)
+  def process_all_accounts(since, before = nil)
     email_accounts = EmailAccount.active
 
     Rails.logger.info "Processing emails for #{email_accounts.count} active accounts"
@@ -144,7 +144,7 @@ class ProcessEmailsJob < ApplicationJob
 
     email_accounts.find_each do |email_account|
       # Process each account in a separate job to isolate failures
-      job = ProcessEmailsJob.perform_later(email_account.id, since: since, sync_session_id: @sync_session&.id)
+      job = ProcessEmailsJob.perform_later(email_account.id, since: since, before: before, sync_session_id: @sync_session&.id)
 
       # Collect job IDs to batch-write after the loop (avoids per-row write-lock contention)
       if @sync_session && job.respond_to?(:provider_job_id) && job.provider_job_id.present?

--- a/app/services/email_processing/fetcher.rb
+++ b/app/services/email_processing/fetcher.rb
@@ -15,13 +15,13 @@ module Services::EmailProcessing
       @errors = []
     end
 
-    def fetch_new_emails(since: 1.week.ago)
+    def fetch_new_emails(since: 1.week.ago, before: nil)
       unless valid_account?
         return FetcherResponse.failure(errors: @errors)
       end
 
       begin
-        result = search_and_process_emails(since)
+        result = search_and_process_emails(since, before)
         FetcherResponse.success(
           processed_emails_count: result[:processed_emails_count],
           total_emails_found: result[:total_emails_found],
@@ -57,14 +57,12 @@ module Services::EmailProcessing
       true
     end
 
-    def search_and_process_emails(since)
+    def search_and_process_emails(since, before = nil)
       imap_service.with_session do
-        # Build search criteria for emails since the specified date
-        search_criteria = build_search_criteria(since)
+        search_criteria = build_search_criteria(since, before)
 
-        # Track email fetch operation
         message_ids = if @metrics_collector
-          @metrics_collector.track_operation(:fetch_emails, @email_account, { since: since }) do
+          @metrics_collector.track_operation(:fetch_emails, @email_account, { since: since, before: before }) do
             imap_service.search_emails(search_criteria)
           end
         else
@@ -115,9 +113,10 @@ module Services::EmailProcessing
       end
     end
 
-    def build_search_criteria(since_date)
-      formatted_date = since_date.strftime("%d-%b-%Y")
-      [ "SINCE", formatted_date ]
+    def build_search_criteria(since_date, before_date = nil)
+      criteria = [ "SINCE", since_date.strftime("%d-%b-%Y") ]
+      criteria.concat([ "BEFORE", before_date.strftime("%d-%b-%Y") ]) if before_date
+      criteria
     end
 
     def add_error(message)

--- a/app/services/email_processing/fetcher.rb
+++ b/app/services/email_processing/fetcher.rb
@@ -15,6 +15,14 @@ module Services::EmailProcessing
       @errors = []
     end
 
+    # Fetches emails from the IMAP server within a date window.
+    #
+    # @param since [Date, Time] lower bound, INCLUSIVE (IMAP SINCE semantics).
+    # @param before [Date, Time, nil] upper bound, EXCLUSIVE (IMAP BEFORE semantics,
+    #   RFC 3501). For a full month, pass the first day of the NEXT month —
+    #   e.g. `since: Date.new(2026, 1, 1), before: Date.new(2026, 2, 1)` selects
+    #   exactly January 2026. `before: Date.new(2026, 1, 31)` would silently
+    #   drop Jan 31. Default `nil` disables the upper bound (sweep forward).
     def fetch_new_emails(since: 1.week.ago, before: nil)
       unless valid_account?
         return FetcherResponse.failure(errors: @errors)

--- a/spec/jobs/process_emails_job_spec.rb
+++ b/spec/jobs/process_emails_job_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe ProcessEmailsJob, type: :job, unit: true do
 
         expect { job.perform(email_account.id, sync_session_id: sync_session.id) }.not_to raise_error
       end
+
+      it "threads before: kwarg through to the fetcher", :unit do
+        before_date = Date.new(2026, 2, 1)
+        expect(mock_fetcher).to receive(:fetch_new_emails)
+          .with(since: anything, before: before_date)
+          .and_return(success_response)
+
+        described_class.new.perform(email_account.id, since: Date.new(2026, 1, 1), before: before_date)
+      end
+
+      it "defaults before: to nil when not provided", :unit do
+        expect(mock_fetcher).to receive(:fetch_new_emails)
+          .with(since: anything, before: nil)
+          .and_return(success_response)
+
+        described_class.new.perform(email_account.id)
+      end
     end
 
     context "without email account id" do
@@ -163,6 +180,21 @@ RSpec.describe ProcessEmailsJob, type: :job, unit: true do
       expect(described_class).to receive(:perform_later).once
 
       job.send(:process_all_accounts, 1.week.ago)
+    end
+
+    it "forwards before: kwarg to per-account perform_later calls", :unit do
+      before_date = Date.new(2026, 2, 1)
+      since_date = Date.new(2026, 1, 1)
+      active_relation = double("ActiveRecord::Relation")
+      allow(active_relation).to receive(:count).and_return(1)
+      allow(active_relation).to receive(:find_each).and_yield(email_account)
+      allow(EmailAccount).to receive(:active).and_return(active_relation)
+
+      expect(described_class).to receive(:perform_later)
+        .with(email_account.id, since: since_date, before: before_date, sync_session_id: nil)
+        .and_return(double(respond_to?: false, provider_job_id: nil))
+
+      job.send(:process_all_accounts, since_date, before_date)
     end
 
     context "batch job ID tracking (PER-369)", :unit do

--- a/spec/services/email_processing/fetcher_metrics_spec.rb
+++ b/spec/services/email_processing/fetcher_metrics_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'metrics integration', type: 
         expect(metrics_collector).to receive(:track_operation).with(
           :fetch_emails,
           email_account,
-          { since: since_date }
+          { since: since_date, before: nil }
         ).and_yield
 
         allow(mock_imap_service).to receive(:search_emails).and_return(message_ids)
@@ -171,7 +171,7 @@ RSpec.describe Services::EmailProcessing::Fetcher, 'metrics integration', type: 
         expect(metrics_collector).to receive(:track_operation).with(
           :fetch_emails,
           email_account,
-          { since: since_date }
+          { since: since_date, before: nil }
         ).and_yield
 
         allow(mock_imap_service).to receive(:search_emails).and_return([ 1, 2 ])

--- a/spec/services/email_processing/fetcher_spec.rb
+++ b/spec/services/email_processing/fetcher_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe Services::EmailProcessing::Fetcher, type: :service, integration: 
         fetcher.fetch_new_emails
       end
 
+      it 'adds BEFORE to search criteria when before: is passed' do
+        since_date = Date.new(2026, 1, 1)
+        before_date = Date.new(2026, 2, 1)
+        expected = [ 'SINCE', '01-Jan-2026', 'BEFORE', '01-Feb-2026' ]
+        expect(mock_imap_service).to receive(:search_emails).with(expected)
+
+        fetcher.fetch_new_emails(since: since_date, before: before_date)
+      end
+
+      it 'omits BEFORE when before: is nil (default)' do
+        since_date = Date.new(2026, 1, 1)
+        expect(mock_imap_service).to receive(:search_emails).with([ 'SINCE', '01-Jan-2026' ])
+
+        fetcher.fetch_new_emails(since: since_date)
+      end
+
       it 'handles empty message list' do
         allow(mock_imap_service).to receive(:search_emails).and_return([])
         allow(mock_email_processor).to receive(:process_emails).and_return({ processed_count: 0, total_count: 0 })


### PR DESCRIPTION
Enables month-by-month syncs. Before this, `since:` had no upper bound — IMAP SINCE pulls everything forward. `fetch_new_emails(since:, before:)` now adds IMAP BEFORE to stop at a month boundary.

## What changed
- `Services::EmailProcessing::Fetcher#fetch_new_emails` gains a `before: nil` kwarg
- `Services::EmailProcessing::Fetcher#build_search_criteria` appends BEFORE when provided
- `ProcessEmailsJob#perform` gains a `before: nil` kwarg
- `before` is threaded through `process_single_account` and `process_all_accounts`
- `metrics_collector.track_operation` now gets `before:` in its context hash
- Two new fetcher specs, two updated metric specs

## Backward compat
`before: nil` (default) preserves prior behavior — a call without the kwarg is equivalent to the old fetcher.

## Context
Discovered when 'sync January' swept 4 months. Now `ProcessEmailsJob.perform_later(id, since: Date.new(2026, 1, 1), before: Date.new(2026, 2, 1))` bounds the pull to exactly January.