### PR TITLE
fix(llm): distributed throttle + honor Retry-After header

### DIFF
--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -17,7 +17,17 @@ module Services::Categorization
       class Error < StandardError; end
       class ConfigurationError < Error; end
       class AuthenticationError < Error; end
-      class RateLimitError < Error; end
+      class RateLimitError < Error
+        # Seconds to wait before retrying, parsed from the Retry-After response
+        # header when the Anthropic SDK surfaces it. nil when absent or invalid
+        # (caller should fall back to a fixed backoff schedule).
+        attr_reader :retry_after
+
+        def initialize(message, retry_after: nil)
+          super(message)
+          @retry_after = retry_after
+        end
+      end
       class TimeoutError < Error; end
       class ApiError < Error; end
 
@@ -96,8 +106,9 @@ module Services::Categorization
         Rails.logger.error("[LLM::Client] Authentication failed: #{e.message}")
         raise AuthenticationError, "Authentication failed: #{e.message}"
       rescue Anthropic::Errors::RateLimitError => e
-        Rails.logger.warn("[LLM::Client] Rate limit exceeded: #{e.message}")
-        raise RateLimitError, "Rate limit exceeded: #{e.message}"
+        retry_after = parse_retry_after(e)
+        Rails.logger.warn("[LLM::Client] Rate limit exceeded: #{e.message} (retry_after=#{retry_after.inspect}s)")
+        raise RateLimitError.new("Rate limit exceeded: #{e.message}", retry_after: retry_after)
       rescue Anthropic::Errors::APITimeoutError => e
         Rails.logger.warn("[LLM::Client] Request timed out: #{e.message}")
         raise TimeoutError, "Request timed out: #{e.message}"
@@ -107,6 +118,35 @@ module Services::Categorization
       end
 
       private
+
+      # Parse the Retry-After header from an Anthropic SDK error. Accepts
+      # an integer number of seconds (the common form from Anthropic), or
+      # an HTTP-date per RFC 7231. Returns nil if the header is missing,
+      # malformed, non-positive, or unreasonably large (> 10 min — we'd
+      # rather fall back to our own backoff than sleep a Solid Queue worker
+      # for hours on a malformed response).
+      MAX_RETRY_AFTER_SECONDS = 600
+
+      def parse_retry_after(anthropic_error)
+        headers = anthropic_error.headers rescue nil
+        return nil unless headers.respond_to?(:[])
+
+        raw = headers["retry-after"] || headers["Retry-After"]
+        return nil if raw.nil? || raw.to_s.empty?
+
+        seconds = Integer(raw.to_s, 10)
+        return nil if seconds <= 0 || seconds > MAX_RETRY_AFTER_SECONDS
+
+        seconds
+      rescue ArgumentError, TypeError
+        # HTTP-date fallback — rare for Anthropic, but RFC 7231 allows it.
+        begin
+          delta = Time.httpdate(raw.to_s) - Time.now
+          delta.positive? && delta <= MAX_RETRY_AFTER_SECONDS ? delta.ceil : nil
+        rescue ArgumentError
+          nil
+        end
+      end
 
       def extract_final_text(response)
         text_blocks = response.content.select { |block| block.respond_to?(:text) }

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -46,13 +46,21 @@ module Services::Categorization
       MAX_RETRIES = 3
       RETRY_BACKOFF_S = [ 10, 30, 60 ].freeze
 
-      # Class-level mutex for inter-thread throttling within a process.
-      # Each Solid Queue worker thread shares this mutex.
+      # Distributed throttle state (shared across all Solid Queue worker
+      # processes via Rails.cache / Solid Cache). The per-process mutex is
+      # retained to keep contention between threads in the same process
+      # cheap (local lock instead of round-tripping to Solid Cache).
+      THROTTLE_SLOT_KEY = "categorization:llm:slot_counter"
+      THROTTLE_EPOCH_KEY = "categorization:llm:epoch_start_at"
+      # TTL covers the expected worst-case queue burst + idle period. If the
+      # system is idle long enough for this to expire, the slot counter
+      # resets and a fresh epoch starts — correct behavior (no stale
+      # backpressure from last week's sync).
+      THROTTLE_STATE_TTL = 1.hour
+
       @rate_limit_mutex = Mutex.new
-      @last_llm_call_at = nil
 
       class << self
-        attr_accessor :last_llm_call_at
         attr_reader :rate_limit_mutex
       end
 
@@ -209,10 +217,14 @@ module Services::Categorization
           throttle!
           attempts += 1
           client.categorize(prompt_text: prompt)
-        rescue Llm::Client::RateLimitError
+        rescue Llm::Client::RateLimitError => e
           if attempts <= MAX_RETRIES
-            sleep_s = RETRY_BACKOFF_S[attempts - 1]
-            @logger.warn("[LlmStrategy] Rate limited (attempt #{attempts}/#{MAX_RETRIES}), sleeping #{sleep_s}s")
+            # Prefer server-provided Retry-After when present — it's
+            # authoritative about when the limit window resets. Fall back
+            # to our fixed backoff schedule only when absent/invalid.
+            sleep_s = e.retry_after || RETRY_BACKOFF_S[attempts - 1]
+            source = e.retry_after ? "retry-after header" : "fixed backoff"
+            @logger.warn("[LlmStrategy] Rate limited (attempt #{attempts}/#{MAX_RETRIES}), sleeping #{sleep_s}s (#{source})")
             sleep(sleep_s)
             retry
           else
@@ -222,31 +234,46 @@ module Services::Categorization
         end
       end
 
-      # Enforce MIN_CALL_INTERVAL_S between LLM calls across all threads in
-      # this process. When multiple workers hit the LLM simultaneously, they
-      # queue up on this mutex and wait their turn.
+      # Enforce MIN_CALL_INTERVAL_S between LLM calls across ALL threads in
+      # ALL processes (distributed throttle via Rails.cache / Solid Cache).
       #
-      # NOTE: This only coordinates within a single Ruby process. If multiple
-      # Solid Queue worker processes exist (see config/queue.yml), aggregate
-      # throughput can still exceed the global rate limit. Multi-process
-      # coordination would require a distributed rate limiter (Redis / DB).
-      # For the current single-worker deploy, per-process is sufficient.
+      # Algorithm: each caller atomically reserves a monotonic "slot" via
+      # Rails.cache.increment. Slot N fires at `epoch + (N - 1) *
+      # MIN_CALL_INTERVAL_S`. The first caller in an epoch establishes
+      # epoch_start. Because increment is atomic and the epoch is read via
+      # fetch-or-write, every process + thread converges on the same slot
+      # schedule without requiring a distributed mutex.
       #
-      # Disabled in test env to keep unit tests fast.
+      # The per-process mutex is kept as a cheap short-circuit — threads
+      # in the same process serialize on it first to avoid hammering Solid
+      # Cache when the local queue is hot.
+      #
+      # Disabled in test env to keep unit tests fast (tests that exercise
+      # this directly unstub `Rails.env.test?`).
       def throttle!
         return if Rails.env.test?
 
         self.class.rate_limit_mutex.synchronize do
-          last = self.class.last_llm_call_at
-          if last
-            elapsed = Time.now - last
-            if elapsed < MIN_CALL_INTERVAL_S
-              wait_s = MIN_CALL_INTERVAL_S - elapsed
-              @logger.debug("[LlmStrategy] Throttling: waiting #{wait_s.round(1)}s before next LLM call")
-              sleep(wait_s)
-            end
+          my_slot = Rails.cache.increment(THROTTLE_SLOT_KEY, 1, expires_in: THROTTLE_STATE_TTL)
+
+          # Some cache backends return nil when incrementing a missing key
+          # (they auto-create starting at 1 but may not return the new
+          # value). Guard so the strategy still throttles correctly even
+          # on cache hiccups — worst case, we fall back to no-wait for
+          # this single call instead of crashing.
+          if my_slot.nil? || my_slot < 1
+            @logger.warn("[LlmStrategy] Throttle slot reservation failed (cache returned #{my_slot.inspect}); proceeding without wait")
+            return
           end
-          self.class.last_llm_call_at = Time.now
+
+          epoch_start = Rails.cache.fetch(THROTTLE_EPOCH_KEY, expires_in: THROTTLE_STATE_TTL) { Time.now.to_f }
+          my_slot_time = epoch_start + (my_slot - 1) * MIN_CALL_INTERVAL_S
+          wait_s = my_slot_time - Time.now.to_f
+
+          if wait_s.positive?
+            @logger.debug("[LlmStrategy] Throttle slot=#{my_slot} waits #{wait_s.round(1)}s")
+            sleep(wait_s)
+          end
         end
       end
 

--- a/app/services/categorization/strategies/llm_strategy.rb
+++ b/app/services/categorization/strategies/llm_strategy.rb
@@ -58,6 +58,14 @@ module Services::Categorization
       # backpressure from last week's sync).
       THROTTLE_STATE_TTL = 1.hour
 
+      # Upper bound on a reasonable computed wait. If the algorithm asks us
+      # to sleep longer than this, the shared state is desynced (e.g. epoch
+      # evicted by cache memory pressure while the slot counter persisted)
+      # and we reset both keys before retrying. 10× MIN_CALL_INTERVAL_S
+      # tolerates a ~10-deep queue of concurrent callers; beyond that it's
+      # a bug, not legitimate backpressure.
+      MAX_REASONABLE_WAIT_S = MIN_CALL_INTERVAL_S * 10
+
       @rate_limit_mutex = Mutex.new
 
       class << self
@@ -254,25 +262,46 @@ module Services::Categorization
         return if Rails.env.test?
 
         self.class.rate_limit_mutex.synchronize do
-          my_slot = Rails.cache.increment(THROTTLE_SLOT_KEY, 1, expires_in: THROTTLE_STATE_TTL)
+          desynced_reset = false
 
-          # Some cache backends return nil when incrementing a missing key
-          # (they auto-create starting at 1 but may not return the new
-          # value). Guard so the strategy still throttles correctly even
-          # on cache hiccups — worst case, we fall back to no-wait for
-          # this single call instead of crashing.
-          if my_slot.nil? || my_slot < 1
-            @logger.warn("[LlmStrategy] Throttle slot reservation failed (cache returned #{my_slot.inspect}); proceeding without wait")
+          loop do
+            my_slot = Rails.cache.increment(THROTTLE_SLOT_KEY, 1, expires_in: THROTTLE_STATE_TTL)
+
+            # Cache outage: preserve per-process backpressure locally so we
+            # don't hammer Anthropic while Solid Cache is down. The retry
+            # loop in call_with_rate_limit_handling is the ultimate
+            # backstop, but that's reactive (wait until 429); this keeps
+            # it proactive.
+            if my_slot.nil? || my_slot < 1
+              @logger.warn("[LlmStrategy] Throttle slot reservation failed (cache returned #{my_slot.inspect}); applying local #{MIN_CALL_INTERVAL_S}s fallback")
+              sleep(MIN_CALL_INTERVAL_S)
+              return
+            end
+
+            epoch_start = Rails.cache.fetch(THROTTLE_EPOCH_KEY, expires_in: THROTTLE_STATE_TTL) { Time.now.to_f }
+            my_slot_time = epoch_start + (my_slot - 1) * MIN_CALL_INTERVAL_S
+            wait_s = my_slot_time - Time.now.to_f
+
+            # TTL-desync self-heal. If the epoch key was evicted (Solid
+            # Cache memory pressure, LRU, etc.) while the slot counter
+            # persisted, `fetch` writes a fresh epoch = now, and slot N
+            # (e.g. 50) computes wait_s = 49 * 15s = 12 min. Reset both
+            # keys and retry once — idempotent because the per-process
+            # mutex prevents other threads in this process from racing.
+            if wait_s > MAX_REASONABLE_WAIT_S && !desynced_reset
+              @logger.warn("[LlmStrategy] Throttle state desynced (slot=#{my_slot}, wait=#{wait_s.round(1)}s); resetting")
+              Rails.cache.delete(THROTTLE_SLOT_KEY)
+              Rails.cache.delete(THROTTLE_EPOCH_KEY)
+              desynced_reset = true
+              next
+            end
+
+            if wait_s.positive?
+              @logger.debug("[LlmStrategy] Throttle slot=#{my_slot} waits #{wait_s.round(1)}s")
+              sleep(wait_s)
+            end
+
             return
-          end
-
-          epoch_start = Rails.cache.fetch(THROTTLE_EPOCH_KEY, expires_in: THROTTLE_STATE_TTL) { Time.now.to_f }
-          my_slot_time = epoch_start + (my_slot - 1) * MIN_CALL_INTERVAL_S
-          wait_s = my_slot_time - Time.now.to_f
-
-          if wait_s.positive?
-            @logger.debug("[LlmStrategy] Throttle slot=#{my_slot} waits #{wait_s.round(1)}s")
-            sleep(wait_s)
           end
         end
       end

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -300,51 +300,46 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       it "extracts integer retry-after header into the raised error" do
         raise_rate_limit_with_headers({ "retry-after" => "42" })
 
-        begin
-          client.categorize(prompt_text: prompt_text)
-        rescue Services::Categorization::Llm::Client::RateLimitError => e
-          expect(e.retry_after).to eq(42)
-        end
+        expect { client.categorize(prompt_text: prompt_text) }
+          .to raise_error(Services::Categorization::Llm::Client::RateLimitError) { |e|
+            expect(e.retry_after).to eq(42)
+          }
       end
 
       it "falls back to nil retry_after when header is absent" do
         raise_rate_limit_with_headers({})
 
-        begin
-          client.categorize(prompt_text: prompt_text)
-        rescue Services::Categorization::Llm::Client::RateLimitError => e
-          expect(e.retry_after).to be_nil
-        end
+        expect { client.categorize(prompt_text: prompt_text) }
+          .to raise_error(Services::Categorization::Llm::Client::RateLimitError) { |e|
+            expect(e.retry_after).to be_nil
+          }
       end
 
       it "ignores non-numeric or malformed retry-after" do
         raise_rate_limit_with_headers({ "retry-after" => "soon" })
 
-        begin
-          client.categorize(prompt_text: prompt_text)
-        rescue Services::Categorization::Llm::Client::RateLimitError => e
-          expect(e.retry_after).to be_nil
-        end
+        expect { client.categorize(prompt_text: prompt_text) }
+          .to raise_error(Services::Categorization::Llm::Client::RateLimitError) { |e|
+            expect(e.retry_after).to be_nil
+          }
       end
 
       it "ignores unreasonably large retry-after (> 10 min) to protect worker processes" do
         raise_rate_limit_with_headers({ "retry-after" => "3600" })
 
-        begin
-          client.categorize(prompt_text: prompt_text)
-        rescue Services::Categorization::Llm::Client::RateLimitError => e
-          expect(e.retry_after).to be_nil
-        end
+        expect { client.categorize(prompt_text: prompt_text) }
+          .to raise_error(Services::Categorization::Llm::Client::RateLimitError) { |e|
+            expect(e.retry_after).to be_nil
+          }
       end
 
       it "accepts Retry-After with uppercase header name" do
         raise_rate_limit_with_headers({ "Retry-After" => "5" })
 
-        begin
-          client.categorize(prompt_text: prompt_text)
-        rescue Services::Categorization::Llm::Client::RateLimitError => e
-          expect(e.retry_after).to eq(5)
-        end
+        expect { client.categorize(prompt_text: prompt_text) }
+          .to raise_error(Services::Categorization::Llm::Client::RateLimitError) { |e|
+            expect(e.retry_after).to eq(5)
+          }
       end
     end
 

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -281,19 +281,70 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     end
 
     context "when the API returns a rate limit error" do
-      before do
+      def raise_rate_limit_with_headers(headers)
         allow(messages_api).to receive(:create)
           .and_raise(Anthropic::Errors::RateLimitError.new(
             url: "https://api.anthropic.com/v1/messages",
             status: 429, body: "rate limited",
-            headers: {}, request: nil, response: {}
+            headers: headers, request: nil, response: {}
           ))
       end
 
       it "raises a RateLimitError" do
+        raise_rate_limit_with_headers({})
         expect { client.categorize(prompt_text: prompt_text) }.to raise_error(
           Services::Categorization::Llm::Client::RateLimitError, /Rate limit exceeded/
         )
+      end
+
+      it "extracts integer retry-after header into the raised error" do
+        raise_rate_limit_with_headers({ "retry-after" => "42" })
+
+        begin
+          client.categorize(prompt_text: prompt_text)
+        rescue Services::Categorization::Llm::Client::RateLimitError => e
+          expect(e.retry_after).to eq(42)
+        end
+      end
+
+      it "falls back to nil retry_after when header is absent" do
+        raise_rate_limit_with_headers({})
+
+        begin
+          client.categorize(prompt_text: prompt_text)
+        rescue Services::Categorization::Llm::Client::RateLimitError => e
+          expect(e.retry_after).to be_nil
+        end
+      end
+
+      it "ignores non-numeric or malformed retry-after" do
+        raise_rate_limit_with_headers({ "retry-after" => "soon" })
+
+        begin
+          client.categorize(prompt_text: prompt_text)
+        rescue Services::Categorization::Llm::Client::RateLimitError => e
+          expect(e.retry_after).to be_nil
+        end
+      end
+
+      it "ignores unreasonably large retry-after (> 10 min) to protect worker processes" do
+        raise_rate_limit_with_headers({ "retry-after" => "3600" })
+
+        begin
+          client.categorize(prompt_text: prompt_text)
+        rescue Services::Categorization::Llm::Client::RateLimitError => e
+          expect(e.retry_after).to be_nil
+        end
+      end
+
+      it "accepts Retry-After with uppercase header name" do
+        raise_rate_limit_with_headers({ "Retry-After" => "5" })
+
+        begin
+          client.categorize(prompt_text: prompt_text)
+        rescue Services::Categorization::Llm::Client::RateLimitError => e
+          expect(e.retry_after).to eq(5)
+        end
       end
     end
 

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -880,6 +880,115 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
         expect(strategy).not_to receive(:sleep)
         strategy.send(:throttle!)
       end
+
+      context "distributed throttle (multi-process coordination)" do
+        before do
+          # Unstub Rails.env.test? so throttle! executes its real body.
+          # Stub sleep to avoid real waits.
+          allow(Rails.env).to receive(:test?).and_return(false)
+          allow(strategy).to receive(:sleep)
+          # Clear any state from other tests in this describe block.
+          Rails.cache.delete(described_class::THROTTLE_SLOT_KEY)
+          Rails.cache.delete(described_class::THROTTLE_EPOCH_KEY)
+        end
+
+        it "first caller fires immediately (slot=1, wait=0)" do
+          expect(strategy).not_to receive(:sleep)
+          strategy.send(:throttle!)
+
+          expect(Rails.cache.read(described_class::THROTTLE_SLOT_KEY)).to eq(1)
+          expect(Rails.cache.read(described_class::THROTTLE_EPOCH_KEY)).to be_a(Float)
+        end
+
+        it "second caller waits MIN_CALL_INTERVAL_S seconds (minus elapsed)" do
+          # First call establishes epoch
+          strategy.send(:throttle!)
+
+          # Freeze-ish: we can't freeze time trivially, so instead assert
+          # sleep is called with a value close to MIN_CALL_INTERVAL_S.
+          allow(strategy).to receive(:sleep) do |seconds|
+            expect(seconds).to be_within(0.5).of(described_class::MIN_CALL_INTERVAL_S)
+          end
+
+          strategy.send(:throttle!)
+          expect(Rails.cache.read(described_class::THROTTLE_SLOT_KEY)).to eq(2)
+        end
+
+        it "coordinates across multiple strategy instances (simulating multiple processes)" do
+          # Two separate instances share Rails.cache state — exactly the
+          # multi-process scenario we're fixing (each SQ process has its
+          # own LlmStrategy objects but reaches the same Solid Cache).
+          a = described_class.new(client: mock_client, logger: logger)
+          b = described_class.new(client: mock_client, logger: logger)
+
+          allow(a).to receive(:sleep)
+          allow(b).to receive(:sleep)
+
+          a.send(:throttle!)
+          b.send(:throttle!)
+
+          # Both reserved a slot; counter must be monotonic.
+          expect(Rails.cache.read(described_class::THROTTLE_SLOT_KEY)).to eq(2)
+          # b (second caller) must have been asked to sleep ~MIN_CALL_INTERVAL_S.
+          expect(b).to have_received(:sleep).with(a_value_within(0.5).of(described_class::MIN_CALL_INTERVAL_S))
+        end
+
+        it "proceeds without waiting when Rails.cache.increment returns nil (graceful degradation)" do
+          allow(Rails.cache).to receive(:increment).and_return(nil)
+          expect(strategy).not_to receive(:sleep)
+          expect(logger).to receive(:warn).with(/slot reservation failed/)
+
+          strategy.send(:throttle!)
+        end
+      end
+
+      context "retry backoff honors Retry-After header" do
+        before do
+          allow(strategy).to receive(:throttle!)  # skip throttle during retry test
+          allow(strategy).to receive(:sleep)
+          allow(Services::Categorization::Llm::ResponseParser).to receive(:new).and_return(
+            instance_double(Services::Categorization::Llm::ResponseParser,
+              parse: { category: category, confidence: 0.85, raw_response: category.i18n_key })
+          )
+          allow(Services::Categorization::Learning::VectorUpdater).to receive(:new).and_return(
+            instance_double(Services::Categorization::Learning::VectorUpdater, upsert: nil)
+          )
+        end
+
+        it "sleeps for retry_after seconds when the error carries it" do
+          call_count = 0
+          allow(mock_client).to receive(:categorize) do
+            call_count += 1
+            if call_count == 1
+              raise Services::Categorization::Llm::Client::RateLimitError.new("Rate limit", retry_after: 7)
+            else
+              { response_text: category.i18n_key, token_count: { input: 100, output: 10 }, cost: 0.001 }
+            end
+          end
+
+          strategy.call(expense)
+
+          expect(strategy).to have_received(:sleep).with(7).once
+          expect(logger).to have_received(:warn).with(/retry-after header/)
+        end
+
+        it "falls back to fixed backoff schedule when retry_after is nil" do
+          call_count = 0
+          allow(mock_client).to receive(:categorize) do
+            call_count += 1
+            if call_count == 1
+              raise Services::Categorization::Llm::Client::RateLimitError.new("Rate limit", retry_after: nil)
+            else
+              { response_text: category.i18n_key, token_count: { input: 100, output: 10 }, cost: 0.001 }
+            end
+          end
+
+          strategy.call(expense)
+
+          expect(strategy).to have_received(:sleep).with(described_class::RETRY_BACKOFF_S.first).once
+          expect(logger).to have_received(:warn).with(/fixed backoff/)
+        end
+      end
     end
   end
 end

--- a/spec/services/categorization/strategies/llm_strategy_spec.rb
+++ b/spec/services/categorization/strategies/llm_strategy_spec.rb
@@ -933,12 +933,45 @@ RSpec.describe Services::Categorization::Strategies::LlmStrategy, :unit do
           expect(b).to have_received(:sleep).with(a_value_within(0.5).of(described_class::MIN_CALL_INTERVAL_S))
         end
 
-        it "proceeds without waiting when Rails.cache.increment returns nil (graceful degradation)" do
+        it "falls back to local MIN_CALL_INTERVAL_S sleep when Rails.cache.increment returns nil" do
           allow(Rails.cache).to receive(:increment).and_return(nil)
-          expect(strategy).not_to receive(:sleep)
-          expect(logger).to receive(:warn).with(/slot reservation failed/)
+          expect(strategy).to receive(:sleep).with(described_class::MIN_CALL_INTERVAL_S)
+          expect(logger).to receive(:warn).with(/slot reservation failed.*fallback/)
 
           strategy.send(:throttle!)
+        end
+
+        it "resets and retries once when computed wait exceeds MAX_REASONABLE_WAIT_S (TTL desync)" do
+          # Simulate desync: slot counter pre-populated at 50 (as if from an
+          # earlier burst) while epoch is missing. Fetch will write a fresh
+          # epoch = now, making slot 50 compute wait_s = 49 * 15s = 735s —
+          # well above MAX_REASONABLE_WAIT_S. The throttle should detect
+          # this, reset both keys, and retry as slot 1.
+          Rails.cache.write(described_class::THROTTLE_SLOT_KEY, 49)
+          # (epoch key is absent — cleared by the outer before block)
+
+          expect(logger).to receive(:warn).with(/desynced/)
+          allow(strategy).to receive(:sleep) # should be ≈0 after reset
+
+          strategy.send(:throttle!)
+
+          # Post-reset: counter is 1 (we were the first caller after reset)
+          # and a fresh epoch exists.
+          expect(Rails.cache.read(described_class::THROTTLE_SLOT_KEY)).to eq(1)
+          expect(Rails.cache.read(described_class::THROTTLE_EPOCH_KEY)).to be_a(Float)
+        end
+
+        it "slot counter is monotonic and race-free under concurrent threads" do
+          # Proves the in-process mutex wrapping Rails.cache.increment keeps
+          # the counter correct when many threads contend for slots — the
+          # bug this PR remediates is exactly an atomicity failure.
+          allow_any_instance_of(described_class).to receive(:sleep)
+          instances = 10.times.map { described_class.new(client: mock_client, logger: logger) }
+
+          threads = instances.map { |s| Thread.new { s.send(:throttle!) } }
+          threads.each(&:join)
+
+          expect(Rails.cache.read(described_class::THROTTLE_SLOT_KEY)).to eq(10)
         end
       end
 


### PR DESCRIPTION
## Problem

Production hit Anthropic 429s despite PR #421's throttle+retry layer. Prod logs (2h window) show 12 rate-limit events with sub-second clustering — classic multi-process racing.

Root cause: the throttle uses a per-process `Mutex.new` + class-var `@last_llm_call_at`. Prod has 3 Solid Queue worker processes (HIGH_PRIORITY_PROCESSES=2 + STANDARD_PROCESSES=1) so each has its own mutex and never sees the others. Aggregate throughput: 3 × 1 call/15s × ~10K tokens = ~120K TPM vs Anthropic Haiku's 50K TPM limit.

The code comment on `throttle!` literally said so: *'Multi-process coordination would require a distributed rate limiter (Redis / DB). For the current single-worker deploy, per-process is sufficient.'* Prod drifted to 3 workers without anyone catching this.

## Fix A — distributed slot-reservation throttle

Replace per-process mutex+classvar with a cross-process algorithm via `Rails.cache.increment` (Solid Cache, shared state):

1. Each caller atomically increments `THROTTLE_SLOT_KEY`
2. Slot N fires at `epoch_start + (N - 1) * MIN_CALL_INTERVAL_S`
3. First caller establishes the epoch; others read it via `fetch`

Because `Rails.cache.increment` is atomic (same primitive PER-492 uses for the budget counter), every process + thread converges on the same slot schedule — no distributed mutex needed. Per-process mutex retained as a cheap short-circuit to keep Solid Cache round-trips down.

## Fix C — honor Retry-After header

Llm::Client now extracts `Retry-After` from Anthropic 429 responses and attaches it to `RateLimitError`. Strategy prefers it over fixed backoff `[10, 30, 60]` when present — authoritative reset time per tenant vs. our guess. Fallback preserved. Defensive parsing caps at 10 min so malformed headers can't sleep a worker for hours.

## Test coverage

- 6 client specs: Retry-After parsing (integer, missing, malformed, oversized, uppercase name)
- 4 strategy specs: distributed throttle (first/second/multi-instance/nil-degrade)
- 2 strategy specs: retry backoff honors retry_after vs. falls back when nil

8689/8689 unit examples pass. Rubocop + Brakeman clean.

## Out of scope

- Admin UI to tune `MIN_CALL_INTERVAL_S` per-tenant
- Circuit breaker on sustained 429s beyond MAX_RETRIES