### PR TITLE
config(tz): set application zone to Central America (Costa Rica)

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -23,7 +23,8 @@ module ApplicationCable
       # Get the main session data
       session_data = cookies.encrypted[:_expense_tracker_session]
       ip_address = request.remote_ip || request.ip
-      timestamp = Time.current.iso8601
+      # Security audit logs are emitted in UTC regardless of app time zone.
+      timestamp = Time.current.utc.iso8601
 
       # Extract session ID from cookies
       rails_session_id = extract_session_id(session_data)

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -234,7 +234,7 @@ class BudgetsController < ApplicationController
 
     start_date = Date.current - lookback_days.days
     average_spend = @email_account.expenses
-      .where(transaction_date: start_date..Date.current)
+      .where(transaction_date: start_date.beginning_of_day..Date.current.end_of_day)
       .average(:amount) || 0
 
     # Suggest 10% more than average to provide some buffer

--- a/app/controllers/bulk_categorization_actions_controller.rb
+++ b/app/controllers/bulk_categorization_actions_controller.rb
@@ -137,15 +137,16 @@ class BulkCategorizationActionsController < ApplicationController
     filters = auto_categorize_params
     scope = Expense.includes(:category, :email_account)
 
-    # Apply date filters using parameterized queries
+    # Apply date filters using parameterized queries. transaction_date is a
+    # timestamp column so bracket the day-aligned bound with beginning/end_of_day.
     if filters[:date_from].present?
       date_from = parse_date(filters[:date_from])
-      scope = scope.where("transaction_date >= ?", date_from) if date_from
+      scope = scope.where("transaction_date >= ?", date_from.beginning_of_day) if date_from
     end
 
     if filters[:date_to].present?
       date_to = parse_date(filters[:date_to])
-      scope = scope.where("transaction_date <= ?", date_to) if date_to
+      scope = scope.where("transaction_date <= ?", date_to.end_of_day) if date_to
     end
 
     # Use Arel for safe LIKE queries instead of string interpolation

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -710,10 +710,10 @@ class ExpensesController < ApplicationController
       scope = scope.where(transaction_date: date_range) if date_range
     elsif params[:date_from].present? && params[:date_to].present?
       # Handle explicit date range from dashboard
-      scope = scope.where(transaction_date: params[:date_from]..params[:date_to])
+      scope = scope.where(transaction_date: parse_date_param(params[:date_from]).beginning_of_day..parse_date_param(params[:date_to]).end_of_day)
     elsif date_range_present?
       # Handle traditional date range filters
-      scope = scope.where(transaction_date: params[:start_date]..params[:end_date])
+      scope = scope.where(transaction_date: parse_date_param(params[:start_date]).beginning_of_day..parse_date_param(params[:end_date]).end_of_day)
     end
 
     # Use left_joins instead of joins to maintain includes
@@ -724,6 +724,12 @@ class ExpensesController < ApplicationController
 
   def date_range_present?
     params[:start_date].present? && params[:end_date].present?
+  end
+
+  def parse_date_param(value)
+    value.is_a?(Date) ? value : Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    Date.current
   end
 
   def calculate_period_range(period)

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -727,16 +727,18 @@ class ExpensesController < ApplicationController
   end
 
   def calculate_period_range(period)
+    # transaction_date is a timestamp column, so boundaries must be Times
+    # (not Dates) to bracket the full day in the app's configured zone.
     today = Date.current
     case period
-    when "day"
-      today..today
+    when "day", "today"
+      today.beginning_of_day..today.end_of_day
     when "week"
-      today.beginning_of_week..today.end_of_week
+      today.beginning_of_week.beginning_of_day..today.end_of_week.end_of_day
     when "month"
-      today.beginning_of_month..today.end_of_month
+      today.beginning_of_month.beginning_of_day..today.end_of_month.end_of_day
     when "year"
-      today.beginning_of_year..today.end_of_year
+      today.beginning_of_year.beginning_of_day..today.end_of_year.end_of_day
     else
       nil
     end

--- a/app/jobs/broadcast_analytics_cleanup_job.rb
+++ b/app/jobs/broadcast_analytics_cleanup_job.rb
@@ -92,7 +92,8 @@ class BroadcastAnalyticsCleanupJob < ApplicationJob
     Rails.cache.write(
       "broadcast_analytics:cleanup:last_run",
       {
-        timestamp: Time.current.iso8601,
+        # Emit UTC so cache entries stay zone-stable regardless of app zone.
+        timestamp: Time.current.utc.iso8601,
         stats: stats
       },
       expires_in: 24.hours

--- a/app/jobs/failed_broadcast_recovery_job.rb
+++ b/app/jobs/failed_broadcast_recovery_job.rb
@@ -89,7 +89,8 @@ class FailedBroadcastRecoveryJob < ApplicationJob
     Rails.cache.write(
       "failed_broadcast_recovery:last_run",
       {
-        timestamp: Time.current.iso8601,
+        # Emit UTC so cache entries stay zone-stable regardless of app zone.
+        timestamp: Time.current.utc.iso8601,
         stats: stats
       },
       expires_in: 24.hours

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -76,11 +76,11 @@ class Budget < ApplicationRecord
     when :daily
       reference_date.beginning_of_day..reference_date.end_of_day
     when :weekly
-      reference_date.beginning_of_week..reference_date.end_of_week
+      reference_date.beginning_of_week.beginning_of_day..reference_date.end_of_week.end_of_day
     when :monthly
-      reference_date.beginning_of_month..reference_date.end_of_month
+      reference_date.beginning_of_month.beginning_of_day..reference_date.end_of_month.end_of_day
     when :yearly
-      reference_date.beginning_of_year..reference_date.end_of_year
+      reference_date.beginning_of_year.beginning_of_day..reference_date.end_of_year.end_of_day
     else
       raise "Invalid period: #{period}"
     end

--- a/app/models/concerns/expense_query_optimizer.rb
+++ b/app/models/concerns/expense_query_optimizer.rb
@@ -161,8 +161,10 @@ module ExpenseQueryOptimizer
 
     # Generate cursor for pagination
     def encode_cursor(expense)
+      # Serialize the cursor in UTC so tokens stay stable across app zones
+      # (and are directly comparable to stored timestamp values).
       Base64.strict_encode64({
-        date: expense.transaction_date.iso8601,
+        date: expense.transaction_date.utc.iso8601,
         id: expense.id
       }.to_json)
     end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -35,11 +35,27 @@ class Expense < ApplicationRecord
   # Scopes
   scope :recent, -> { order(transaction_date: :desc) }
   scope :by_status, ->(status) { where(status: status) }
-  scope :by_date_range, ->(start_date, end_date) { where(transaction_date: start_date..end_date) }
+  scope :by_date_range, ->(start_date, end_date) {
+    range_start = start_date&.to_date&.beginning_of_day
+    range_end   = end_date&.to_date&.end_of_day
+    if range_start && range_end
+      where(transaction_date: range_start..range_end)
+    elsif range_start
+      where("transaction_date >= ?", range_start)
+    elsif range_end
+      where("transaction_date <= ?", range_end)
+    else
+      all
+    end
+  }
   scope :by_amount_range, ->(min, max) { where(amount: min..max) }
   scope :uncategorized, -> { where(category: nil) }
-  scope :this_month, -> { where(transaction_date: Date.current.beginning_of_month..Date.current.end_of_month) }
-  scope :this_year, -> { where(transaction_date: Date.current.beginning_of_year..Date.current.end_of_year) }
+  scope :this_month, -> {
+    where(transaction_date: Date.current.beginning_of_month.beginning_of_day..Date.current.end_of_month.end_of_day)
+  }
+  scope :this_year, -> {
+    where(transaction_date: Date.current.beginning_of_year.beginning_of_day..Date.current.end_of_year.end_of_day)
+  }
 
   # Instance methods
   def formatted_amount

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -221,24 +221,25 @@ class Expense < ApplicationRecord
     if saved_change_to_amount? || saved_change_to_transaction_date? ||
        saved_change_to_category_id? || saved_change_to_status?
 
-      # Schedule metrics refresh with debouncing
+      # Schedule metrics refresh with debouncing. Metrics roll up by day, so
+      # pass a Date — comparisons stay zone-agnostic downstream.
       if saved_change_to_transaction_date? && transaction_date_before_last_save.present?
         # Transaction date actually changed (not creation) - refresh both old and new dates
         MetricsRefreshJob.enqueue_debounced(
           email_account_id,
-          affected_date: transaction_date_before_last_save,
+          affected_date: transaction_date_before_last_save.to_date,
           delay: 3.seconds
         )
         MetricsRefreshJob.enqueue_debounced(
           email_account_id,
-          affected_date: transaction_date,
+          affected_date: transaction_date.to_date,
           delay: 3.seconds
         )
       else
         # Creation or other field changes - refresh current transaction date
         MetricsRefreshJob.enqueue_debounced(
           email_account_id,
-          affected_date: transaction_date,
+          affected_date: transaction_date.to_date,
           delay: 3.seconds
         )
       end
@@ -255,7 +256,7 @@ class Expense < ApplicationRecord
     # Trigger metrics refresh for the deleted expense's date
     MetricsRefreshJob.enqueue_debounced(
       email_account_id,
-      affected_date: transaction_date,
+      affected_date: transaction_date.to_date,
       delay: 3.seconds
     )
   rescue StandardError => e

--- a/app/services/categorization/bulk_categorization_service.rb
+++ b/app/services/categorization/bulk_categorization_service.rb
@@ -429,7 +429,8 @@ module Services::Categorization
       end
 
       def group_by_date
-        expense_adapter.group_by { |e| e.transaction_date.beginning_of_month }
+        # Group by month as a Date so keys are zone-stable across app zones.
+        expense_adapter.group_by { |e| e.transaction_date.to_date.beginning_of_month }
                 .transform_values { |group| {
                   expenses: group,
                   count: group.count,

--- a/app/services/dashboard_expense_filter_service.rb
+++ b/app/services/dashboard_expense_filter_service.rb
@@ -333,20 +333,22 @@ class DashboardExpenseFilterService < ExpenseFilterService
   end
 
   def calculate_period_dates(period)
+    # transaction_date is a timestamp column, so boundaries must be Times
+    # (not Dates) to bracket the full day in the app's configured zone.
     today = Date.current
     case period.to_s
     when "today", "day"
-      { start: today, end: today }
+      { start: today.beginning_of_day, end: today.end_of_day }
     when "week"
-      { start: today.beginning_of_week, end: today.end_of_week }
+      { start: today.beginning_of_week.beginning_of_day, end: today.end_of_week.end_of_day }
     when "month"
-      { start: today.beginning_of_month, end: today.end_of_month }
+      { start: today.beginning_of_month.beginning_of_day, end: today.end_of_month.end_of_day }
     when "year"
-      { start: today.beginning_of_year, end: today.end_of_year }
+      { start: today.beginning_of_year.beginning_of_day, end: today.end_of_year.end_of_day }
     when "last_7_days"
-      { start: 7.days.ago.to_date, end: today }
+      { start: 7.days.ago.beginning_of_day, end: today.end_of_day }
     when "last_30_days"
-      { start: 30.days.ago.to_date, end: today }
+      { start: 30.days.ago.beginning_of_day, end: today.end_of_day }
     else
       {}
     end

--- a/app/services/expense_filter_service.rb
+++ b/app/services/expense_filter_service.rb
@@ -199,16 +199,17 @@ module Services
       return scope.where(transaction_date: date_range) if date_range
     end
 
-    # Handle dashboard date_from and date_to parameters
+    # Handle dashboard date_from and date_to parameters. transaction_date
+    # is a timestamp column, so bracket by beginning/end of day in app zone.
     if date_from.present? && date_to.present?
-      return scope.where(transaction_date: date_from.to_date..date_to.to_date)
+      return scope.where(transaction_date: date_from.to_date.beginning_of_day..date_to.to_date.end_of_day)
     end
 
     # Handle traditional start_date and end_date parameters
     return scope unless start_date.present? || end_date.present?
 
-    scope = scope.where("transaction_date >= ?", start_date.to_date) if start_date
-    scope = scope.where("transaction_date <= ?", end_date.to_date) if end_date
+    scope = scope.where("transaction_date >= ?", start_date.to_date.beginning_of_day) if start_date
+    scope = scope.where("transaction_date <= ?", end_date.to_date.end_of_day) if end_date
     scope
   end
 
@@ -248,16 +249,18 @@ module Services
   end
 
   def calculate_period_range(period)
+    # transaction_date is a timestamp column, so boundaries must be Times
+    # (not Dates) to bracket the full day in the app's configured zone.
     today = Date.current
     case period
-    when "day"
-      today..today
+    when "day", "today"
+      today.beginning_of_day..today.end_of_day
     when "week"
-      today.beginning_of_week..today.end_of_week
+      today.beginning_of_week.beginning_of_day..today.end_of_week.end_of_day
     when "month"
-      today.beginning_of_month..today.end_of_month
+      today.beginning_of_month.beginning_of_day..today.end_of_month.end_of_day
     when "year"
-      today.beginning_of_year..today.end_of_year
+      today.beginning_of_year.beginning_of_day..today.end_of_year.end_of_day
     else
       nil
     end
@@ -320,19 +323,20 @@ module Services
   end
 
   def parse_date_range(range)
+    today = Date.current
     case range.to_s
     when "today"
-      { start: Date.current, end: Date.current }
+      { start: today.beginning_of_day, end: today.end_of_day }
     when "week"
-      { start: Date.current.beginning_of_week, end: Date.current.end_of_week }
+      { start: today.beginning_of_week.beginning_of_day, end: today.end_of_week.end_of_day }
     when "month"
-      { start: Date.current.beginning_of_month, end: Date.current.end_of_month }
+      { start: today.beginning_of_month.beginning_of_day, end: today.end_of_month.end_of_day }
     when "year"
-      { start: Date.current.beginning_of_year, end: Date.current.end_of_year }
+      { start: today.beginning_of_year.beginning_of_day, end: today.end_of_year.end_of_day }
     when "last_30_days"
-      { start: 30.days.ago.to_date, end: Date.current }
+      { start: 30.days.ago.beginning_of_day, end: today.end_of_day }
     when "last_90_days"
-      { start: 90.days.ago.to_date, end: Date.current }
+      { start: 90.days.ago.beginning_of_day, end: today.end_of_day }
     else
       {}
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,8 @@ module ExpenseTracker
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    # Costa Rica (UTC-6, no DST). DB continues storing UTC; views/forms render in CR local time.
+    config.time_zone = "Central America"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Localization settings

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -330,7 +330,8 @@ RSpec.describe ApplicationCable::Connection, type: :channel, unit: true do
             def self.test_find_verified_session_logic(session_data, remote_ip, fallback_ip = nil)
               # This mimics the exact non-test environment logic from find_verified_session
               ip_address = remote_ip || fallback_ip
-              timestamp = Time.current.iso8601
+              # Mirrors production: security audit logs emit UTC regardless of app zone.
+              timestamp = Time.current.utc.iso8601
 
               rails_session_id = extract_session_id(session_data)
 

--- a/spec/controllers/bulk_categorization_actions_controller_unit_spec.rb
+++ b/spec/controllers/bulk_categorization_actions_controller_unit_spec.rb
@@ -225,8 +225,8 @@ RSpec.describe BulkCategorizationActionsController, type: :controller, unit: tru
       allow(Expense).to receive(:includes).with(:category, :email_account).and_return(scope)
       allow(scope).to receive(:where).with(category: nil).and_return(scope)
 
-      expect(scope).to receive(:where).with("transaction_date >= ?", Date.parse("2023-01-01")).ordered.and_return(scope)
-      expect(scope).to receive(:where).with("transaction_date <= ?", Date.parse("2023-12-31")).ordered.and_return(scope)
+      expect(scope).to receive(:where).with("transaction_date >= ?", Date.parse("2023-01-01").beginning_of_day).ordered.and_return(scope)
+      expect(scope).to receive(:where).with("transaction_date <= ?", Date.parse("2023-12-31").end_of_day).ordered.and_return(scope)
       expect(scope).to receive(:limit).with(1000).and_return(expenses)
 
       post :auto_categorize, params: {

--- a/spec/controllers/expenses_inline_actions_spec.rb
+++ b/spec/controllers/expenses_inline_actions_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ExpensesController, type: :controller, integration: true do
       post :duplicate, params: { id: expense.id }
       duplicated = Expense.order(created_at: :desc).first
 
-      expect(duplicated.transaction_date).to eq(Date.current)
+      expect(duplicated.transaction_date.to_date).to eq(Date.current)
       expect(duplicated.status).to eq("pending")
       expect(duplicated.ml_confidence).to be_nil
       expect(duplicated.ml_suggested_category_id).to be_nil

--- a/spec/jobs/broadcast_analytics_cleanup_job_spec.rb
+++ b/spec/jobs/broadcast_analytics_cleanup_job_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe BroadcastAnalyticsCleanupJob, type: :job, unit: true do
 
     before do
       allow(cache_mock).to receive(:write)
-      allow(Time).to receive(:current).and_return(Time.zone.parse('2025-08-30 12:00:00'))
+      allow(Time).to receive(:current).and_return(Time.utc(2025, 8, 30, 12, 0, 0).in_time_zone)
     end
 
     it 'writes cleanup metrics to cache' do

--- a/spec/jobs/failed_broadcast_recovery_job_spec.rb
+++ b/spec/jobs/failed_broadcast_recovery_job_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe FailedBroadcastRecoveryJob, type: :job, unit: true do
 
   describe '#record_recovery_metrics' do
     let(:stats) { { attempted: 5, successful: 3, failed: 1, skipped: 1 } }
-    let(:current_time) { Time.zone.parse('2025-08-30 15:30:00') }
+    let(:current_time) { Time.utc(2025, 8, 30, 15, 30, 0).in_time_zone }
 
     before do
       allow(Time).to receive(:current).and_return(current_time)

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current week\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_week)
-        expect(range.end).to eq(Date.current.end_of_week)
+        expect(range.begin).to eq(Date.current.beginning_of_week.beginning_of_day)
+        expect(range.end).to eq(Date.current.end_of_week.end_of_day)
       end
     end
 
@@ -118,8 +118,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current month\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_month)
-        expect(range.end).to eq(Date.current.end_of_month)
+        expect(range.begin).to eq(Date.current.beginning_of_month.beginning_of_day)
+        expect(range.end).to eq(Date.current.end_of_month.end_of_day)
       end
     end
 
@@ -128,8 +128,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current year\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_year)
-        expect(range.end).to eq(Date.current.end_of_year)
+        expect(range.begin).to eq(Date.current.beginning_of_year.beginning_of_day)
+        expect(range.end).to eq(Date.current.end_of_year.end_of_day)
       end
     end
   end

--- a/spec/models/budget_unit_spec.rb
+++ b/spec/models/budget_unit_spec.rb
@@ -255,9 +255,9 @@ RSpec.describe Budget, type: :model, unit: true do
       it "returns correct ranges for different periods" do
         expected_ranges = {
           daily: [ Date.new(2025, 1, 15).beginning_of_day, Date.new(2025, 1, 15).end_of_day ],
-          weekly: [ Date.new(2025, 1, 13), Date.new(2025, 1, 19) ], # Monday to Sunday
-          monthly: [ Date.new(2025, 1, 1), Date.new(2025, 1, 31) ],
-          yearly: [ Date.new(2025, 1, 1), Date.new(2025, 12, 31) ]
+          weekly: [ Date.new(2025, 1, 13).beginning_of_day, Date.new(2025, 1, 19).end_of_day ], # Monday to Sunday
+          monthly: [ Date.new(2025, 1, 1).beginning_of_day, Date.new(2025, 1, 31).end_of_day ],
+          yearly: [ Date.new(2025, 1, 1).beginning_of_day, Date.new(2025, 12, 31).end_of_day ]
         }
 
         expected_ranges.each do |period, (expected_start, expected_end)|

--- a/spec/models/concerns/expense_query_optimizer_unit_spec.rb
+++ b/spec/models/concerns/expense_query_optimizer_unit_spec.rb
@@ -424,7 +424,8 @@ RSpec.describe ExpenseQueryOptimizer, type: :model, unit: true do
 
       it "includes date and id in cursor" do
         expense.id = 456
-        expense.transaction_date = Date.new(2024, 6, 15)
+        # Pin the transaction instant in UTC so the assertion is zone-stable.
+        expense.transaction_date = Time.utc(2024, 6, 15, 0, 0, 0)
 
         cursor = Expense.encode_cursor(expense)
         decoded = JSON.parse(Base64.strict_decode64(cursor))

--- a/spec/models/expense_metrics_callback_spec.rb
+++ b/spec/models/expense_metrics_callback_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Expense metrics callbacks", type: :model, integration: true do
 
           expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
             email_account.id,
-            affected_date: expense.transaction_date,
+            affected_date: expense.transaction_date.to_date,
             delay: 3.seconds
           )
 
@@ -45,13 +45,13 @@ RSpec.describe "Expense metrics callbacks", type: :model, integration: true do
           # Should trigger for both old and new dates
           expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
             email_account.id,
-            affected_date: old_date,
+            affected_date: old_date.to_date,
             delay: 3.seconds
           ).ordered
 
           expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
             email_account.id,
-            affected_date: new_date,
+            affected_date: new_date.to_date,
             delay: 3.seconds
           ).ordered
 
@@ -64,7 +64,7 @@ RSpec.describe "Expense metrics callbacks", type: :model, integration: true do
 
           expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
             email_account.id,
-            affected_date: expense.transaction_date,
+            affected_date: expense.transaction_date.to_date,
             delay: 3.seconds
           )
 
@@ -76,7 +76,7 @@ RSpec.describe "Expense metrics callbacks", type: :model, integration: true do
 
           expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
             email_account.id,
-            affected_date: expense.transaction_date,
+            affected_date: expense.transaction_date.to_date,
             delay: 3.seconds
           )
 
@@ -112,7 +112,7 @@ RSpec.describe "Expense metrics callbacks", type: :model, integration: true do
 
         expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
           email_account.id,
-          affected_date: expense.transaction_date,
+          affected_date: expense.transaction_date.to_date,
           delay: 3.seconds
         )
 

--- a/spec/models/expense_unit_spec.rb
+++ b/spec/models/expense_unit_spec.rb
@@ -621,7 +621,7 @@ RSpec.describe Expense, type: :model, unit: true do
 
         expect(MetricsRefreshJob).to receive(:enqueue_debounced).with(
           expense.email_account_id,
-          hash_including(affected_date: expense.transaction_date)
+          hash_including(affected_date: expense.transaction_date.to_date)
         )
 
         expense.send(:trigger_metrics_refresh)

--- a/spec/models/user_category_preference_unit_spec.rb
+++ b/spec/models/user_category_preference_unit_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
       let!(:category) { create(:category) }
       let(:expense) { build(:expense,
         merchant_name: "Test Store",
-        transaction_date: Time.utc(2024, 1, 15, 14, 30), # Monday afternoon UTC
+        transaction_date: Time.zone.local(2024, 1, 15, 14, 30), # Monday afternoon UTC
         amount: 75.00
       ) }
 
@@ -228,7 +228,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         before { allow(described_class).to receive(:learn_preference) }
 
         it "classifies morning (6-11)" do
-          expense.transaction_date = Time.utc(2024, 1, 1, 8, 0)
+          expense.transaction_date = Time.zone.local(2024, 1, 1, 8, 0)
 
           expect(UserCategoryPreference).to receive(:learn_preference).with(
             email_account: email_account,
@@ -245,7 +245,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         end
 
         it "classifies afternoon (12-16)" do
-          expense.transaction_date = Time.utc(2024, 1, 1, 14, 0)
+          expense.transaction_date = Time.zone.local(2024, 1, 1, 14, 0)
 
           expect(UserCategoryPreference).to receive(:learn_preference).with(
             email_account: email_account,
@@ -262,7 +262,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         end
 
         it "classifies evening (17-20)" do
-          expense.transaction_date = Time.utc(2024, 1, 1, 19, 0)
+          expense.transaction_date = Time.zone.local(2024, 1, 1, 19, 0)
 
           expect(UserCategoryPreference).to receive(:learn_preference).with(
             email_account: email_account,
@@ -279,7 +279,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         end
 
         it "classifies night (21-5)" do
-          expense.transaction_date = Time.utc(2024, 1, 1, 23, 0)
+          expense.transaction_date = Time.zone.local(2024, 1, 1, 23, 0)
 
           expect(UserCategoryPreference).to receive(:learn_preference).with(
             email_account: email_account,
@@ -359,7 +359,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
       it "creates all context preferences in database" do
         expense = build(:expense,
           merchant_name: "Integration Store",
-          transaction_date: Time.utc(2024, 1, 15, 14, 30), # Monday afternoon UTC
+          transaction_date: Time.zone.local(2024, 1, 15, 14, 30), # Monday afternoon UTC
           amount: 150.00
         )
 
@@ -414,7 +414,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
       let(:expense) do
         build(:expense,
           merchant_name: "Test Store",
-          transaction_date: Time.utc(2024, 1, 15, 14, 30), # Monday afternoon UTC
+          transaction_date: Time.zone.local(2024, 1, 15, 14, 30), # Monday afternoon UTC
           amount: 75.00
         )
       end
@@ -763,13 +763,13 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         it "classifies all days of the week correctly" do
           # Using dates from January 1-7, 2024 (Monday-Sunday)
           days_mapping = {
-            "monday" => Time.utc(2024, 1, 1),    # Monday
-            "tuesday" => Time.utc(2024, 1, 2),   # Tuesday
-            "wednesday" => Time.utc(2024, 1, 3), # Wednesday
-            "thursday" => Time.utc(2024, 1, 4),  # Thursday
-            "friday" => Time.utc(2024, 1, 5),    # Friday
-            "saturday" => Time.utc(2024, 1, 6),  # Saturday
-            "sunday" => Time.utc(2024, 1, 7)     # Sunday
+            "monday" => Time.zone.local(2024, 1, 1),    # Monday
+            "tuesday" => Time.zone.local(2024, 1, 2),   # Tuesday
+            "wednesday" => Time.zone.local(2024, 1, 3), # Wednesday
+            "thursday" => Time.zone.local(2024, 1, 4),  # Thursday
+            "friday" => Time.zone.local(2024, 1, 5),    # Friday
+            "saturday" => Time.zone.local(2024, 1, 6),  # Saturday
+            "sunday" => Time.zone.local(2024, 1, 7)     # Sunday
           }
 
           days_mapping.each do |expected_day, date|
@@ -781,7 +781,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
 
       context "with different date types" do
         it "works with Time objects" do
-          time = Time.utc(2024, 1, 1, 14, 30)  # Monday afternoon
+          time = Time.zone.local(2024, 1, 1, 14, 30)  # Monday afternoon
           expect(UserCategoryPreference.send(:classify_day_of_week, time)).to eq("monday")
         end
 
@@ -798,7 +798,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
 
       context "with timezone considerations" do
         it "handles different timezone objects consistently" do
-          utc_time = Time.utc(2024, 1, 1, 23, 0)        # Monday 23:00 UTC
+          utc_time = Time.zone.local(2024, 1, 1, 23, 0)        # Monday 23:00 UTC
           local_time = Time.local(2024, 1, 1, 23, 0)     # Monday 23:00 local
 
           expect(UserCategoryPreference.send(:classify_day_of_week, utc_time)).to eq("monday")
@@ -808,13 +808,13 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
 
       context "with edge cases" do
         it "handles leap year dates" do
-          leap_day = Time.utc(2024, 2, 29)  # 2024 is a leap year, Feb 29 is Thursday
+          leap_day = Time.zone.local(2024, 2, 29)  # 2024 is a leap year, Feb 29 is Thursday
           expect(UserCategoryPreference.send(:classify_day_of_week, leap_day)).to eq("thursday")
         end
 
         it "handles year boundaries" do
-          new_years_eve = Time.utc(2023, 12, 31)  # Sunday
-          new_years_day = Time.utc(2024, 1, 1)    # Monday
+          new_years_eve = Time.zone.local(2023, 12, 31)  # Sunday
+          new_years_day = Time.zone.local(2024, 1, 1)    # Monday
 
           expect(UserCategoryPreference.send(:classify_day_of_week, new_years_eve)).to eq("sunday")
           expect(UserCategoryPreference.send(:classify_day_of_week, new_years_day)).to eq("monday")
@@ -884,7 +884,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
         it "executes complete learn_from_categorization flow with real database" do
           expense = build(:expense,
             merchant_name: "Coverage Store",
-            transaction_date: Time.utc(2024, 1, 15, 19, 30), # Monday evening
+            transaction_date: Time.zone.local(2024, 1, 15, 19, 30), # Monday evening
             amount: 350.00 # large amount
           )
 
@@ -925,7 +925,7 @@ RSpec.describe UserCategoryPreference, type: :model, unit: true do
 
           expense = build(:expense,
             merchant_name: "Match Store",
-            transaction_date: Time.utc(2024, 1, 15, 22, 0), # Monday night
+            transaction_date: Time.zone.local(2024, 1, 15, 22, 0), # Monday night
             amount: 600.00 # very_large
           )
 

--- a/spec/requests/expenses_inline_actions_spec.rb
+++ b/spec/requests/expenses_inline_actions_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Expenses Inline Actions API", type: :request do
       # New expense should have pending status
       new_expense = Expense.find(json["expense"]["id"])
       expect(new_expense.status).to eq("pending")
-      expect(new_expense.transaction_date).to eq(Date.current)
+      expect(new_expense.transaction_date.to_date).to eq(Date.current)
     end
 
     it "resets ML fields on duplicate" do

--- a/spec/services/dashboard_expense_filter_service_spec.rb
+++ b/spec/services/dashboard_expense_filter_service_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
     it "handles period-based filtering" do
       service = described_class.new(base_params.merge(period: "week"))
 
-      expect(service.start_date).to eq(Date.current.beginning_of_week)
-      expect(service.end_date).to eq(Date.current.end_of_week)
+      # Period bounds are Times so range queries on the timestamp
+      # transaction_date column bracket the full day in the app zone.
+      expect(service.start_date).to eq(Date.current.beginning_of_week.beginning_of_day)
+      expect(service.end_date).to eq(Date.current.end_of_week.end_of_day)
     end
   end
 
@@ -306,7 +308,7 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
         let(:params) { base_params.merge(period: "today") }
 
         it "returns only today's expenses" do
-          expect(result.expenses.map(&:transaction_date).uniq).to eq([ Date.current ])
+          expect(result.expenses.map { |e| e.transaction_date.to_date }.uniq).to eq([ Date.current ])
         end
       end
 


### PR DESCRIPTION
## Summary
- Set `config.time_zone = \"Central America\"` so UI timestamps render in CR (UTC-6). DB storage stays UTC — only presentation shifts.
- Fix cascading tz-sensitivity exposed by the change: date-range filters on the `transaction_date` timestamp column now use `beginning_of_day..end_of_day` boundaries (previously bare `Date..Date` ranges compared as UTC midnight and dropped rows stored at CR midnight).
- Metrics refresh callback passes a `Date` (not a `Time`); cursor pagination and analytics/recovery job cache timestamps are pinned to UTC; security audit log timestamp also UTC. Specs updated to mirror.

## Why this matters
User reported the UI showed a sync triggered at 8am CR as \"2pm\" because Rails defaulted to UTC. CR doesn't observe DST so \"Central America\" (TZInfo `America/Guatemala`) is a stable UTC-6 anchor.

## Test plan
- [x] `bundle exec rspec --tag unit` — 8694 examples, 0 failures
- [x] `bundle exec rubocop app/ spec/ config/application.rb` — clean
- [x] `bundle exec brakeman` — no new warnings
- [ ] After deploy: verify a fresh sync's timestamp in `/sync_sessions` and the sync-session trigger logs render in CR local (`-0600`)