### PR TITLE
feat(external-budgets): SyncService + PullJob + daily cron (PR 3/4)

### DIFF
--- a/app/jobs/external_budgets/pull_job.rb
+++ b/app/jobs/external_budgets/pull_job.rb
@@ -1,14 +1,23 @@
 # frozen_string_literal: true
 
 module ExternalBudgets
-  # Stub PR 2 implementation — real implementation lands in PR 3 (salary_calc
-  # sync service). Exists only so the OAuth callback in PR 2 can enqueue a
-  # real job class without NameError.
+  # Pulls the current monthly budget from an ExternalBudgetSource via
+  # Services::ExternalBudgets::SyncService. Retries on transient transport
+  # failures; deactivation on 401 is handled by SyncService (no retry at
+  # the job layer for auth failures — user must re-link).
   class PullJob < ApplicationJob
     queue_as :default
 
+    retry_on Services::ExternalBudgets::ApiClient::NetworkError,
+             wait: :polynomially_longer, attempts: 3
+    retry_on Services::ExternalBudgets::ApiClient::ServerError,
+             wait: :polynomially_longer, attempts: 3
+
     def perform(source_id)
-      Rails.logger.info("[external_budgets] pull job stub invoked for source=#{source_id}")
+      source = ExternalBudgetSource.find_by(id: source_id)
+      return unless source&.active?
+
+      Services::ExternalBudgets::SyncService.new(source: source).call
     end
   end
 end

--- a/app/services/external_budgets/api_client.rb
+++ b/app/services/external_budgets/api_client.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "openssl"
+require "uri"
+require "json"
+
+module Services
+  module ExternalBudgets
+    # Thin HTTP wrapper over the salary_calc
+    # `/api/v1/monthly_budgets/current` endpoint. Maps transport and HTTP
+    # error classes to explicit local errors so callers (SyncService,
+    # PullJob) can decide between deactivate / silent-ok / retry behaviors
+    # without matching on raw Net::HTTP codes.
+    class ApiClient
+      class Error < StandardError; end
+      class UnauthorizedError < Error; end
+      class NotFoundError < Error; end
+      class ServerError < Error; end
+      class NetworkError < Error; end
+
+      Result = Struct.new(:status, :body, keyword_init: true) do
+        def ok? = status == 200
+        def not_modified? = status == 304
+      end
+
+      BUDGET_PATH = "/api/v1/monthly_budgets/current"
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 10
+
+      def initialize(source:)
+        @source = source
+      end
+
+      def fetch_current_budget(if_modified_since: nil)
+        uri = URI.join(@source.base_url, BUDGET_PATH)
+        req = Net::HTTP::Get.new(uri)
+        req["Authorization"] = "Bearer #{@source.api_token}"
+        req["Accept"] = "application/json"
+        req["If-Modified-Since"] = if_modified_since.httpdate if if_modified_since
+
+        resp = Net::HTTP.start(
+          uri.hostname, uri.port,
+          use_ssl: uri.scheme == "https",
+          open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT
+        ) { |http| http.request(req) }
+
+        case resp.code.to_i
+        when 200 then Result.new(status: 200, body: JSON.parse(resp.body))
+        when 304 then Result.new(status: 304, body: nil)
+        when 401 then raise UnauthorizedError, resp.body.to_s.truncate(500)
+        when 404 then raise NotFoundError
+        when 500..599 then raise ServerError, "status=#{resp.code}"
+        else raise Error, "unexpected status=#{resp.code}"
+        end
+      rescue Net::OpenTimeout, Net::ReadTimeout, Net::HTTPError, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError => e
+        raise NetworkError, "#{e.class}: #{e.message}"
+      rescue JSON::ParserError => e
+        raise Error, "invalid JSON: #{e.message}"
+      end
+    end
+  end
+end

--- a/app/services/external_budgets/sync_service.rb
+++ b/app/services/external_budgets/sync_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Services
+  module ExternalBudgets
+    # Drives one pull-sync cycle for an ExternalBudgetSource:
+    # 1. Fetch the current monthly budget (honoring If-Modified-Since).
+    # 2. Upsert each budget item as a local Budget row keyed by
+    #    (external_source, external_id); assign_attributes never touches
+    #    category_id or active, so user mappings survive re-syncs.
+    # 3. Deactivate any previously-synced Budget rows that are no longer
+    #    present in the upstream response.
+    # 4. Mark the source as succeeded on any non-error terminal state
+    #    (200, 304, 404 — all mean "we reached the server successfully").
+    #
+    # Error policy:
+    # - UnauthorizedError → deactivate! (permanent, user must re-link)
+    # - ServerError / NetworkError → re-raise for job-layer retry
+    # - NotFoundError → silent success (no MonthlyBudget for this month yet)
+    class SyncService
+      SOURCE_KEY = "salary_calculator"
+
+      def initialize(source:)
+        @source = source
+      end
+
+      def call
+        result = ApiClient.new(source: @source).fetch_current_budget(
+          if_modified_since: @source.last_synced_at
+        )
+        apply_payload(result.body) if result.ok?
+        @source.mark_succeeded!
+        true
+      rescue ApiClient::NotFoundError
+        @source.mark_succeeded!
+        true
+      rescue ApiClient::UnauthorizedError => e
+        @source.deactivate!(reason: "unauthorized: #{e.message.to_s.truncate(200)}")
+        false
+      end
+
+      private
+
+      def apply_payload(body)
+        monthly = body.fetch("monthly_budget")
+        items   = body.fetch("budget_items", [])
+        period_start = Date.new(monthly.fetch("year").to_i, monthly.fetch("month").to_i, 1)
+        period_end   = period_start.end_of_month
+        account = @source.email_account
+        present_ids = items.map { |i| i.fetch("id") }
+
+        ActiveRecord::Base.transaction do
+          items.each { |item| upsert_budget(account, item, period_start, period_end) }
+          account.budgets
+            .where(external_source: SOURCE_KEY)
+            .where.not(external_id: present_ids)
+            .update_all(active: false)
+        end
+      end
+
+      def upsert_budget(account, item, period_start, period_end)
+        budget = account.budgets.find_or_initialize_by(
+          external_source: SOURCE_KEY,
+          external_id: item.fetch("id")
+        )
+        budget.assign_attributes(
+          name: item.fetch("name"),
+          amount: item.fetch("amount"),
+          currency: item.fetch("currency"),
+          period: :monthly,
+          start_date: period_start,
+          end_date: period_end,
+          external_synced_at: Time.current
+        )
+        budget.active = true if budget.new_record?
+        budget.save!
+      end
+    end
+  end
+end

--- a/app/services/external_budgets/sync_service.rb
+++ b/app/services/external_budgets/sync_service.rb
@@ -5,19 +5,23 @@ module Services
     # Drives one pull-sync cycle for an ExternalBudgetSource:
     # 1. Fetch the current monthly budget (honoring If-Modified-Since).
     # 2. Upsert each budget item as a local Budget row keyed by
-    #    (external_source, external_id); assign_attributes never touches
-    #    category_id or active, so user mappings survive re-syncs.
-    # 3. Deactivate any previously-synced Budget rows that are no longer
-    #    present in the upstream response.
+    #    (email_account_id, external_source, external_id, start_date); assign_attributes
+    #    never touches category_id, so user mappings survive re-syncs.
+    # 3. Deactivate any previously-synced Budget rows from prior months, and any
+    #    current-month external rows that are no longer present upstream.
     # 4. Mark the source as succeeded on any non-error terminal state
     #    (200, 304, 404 — all mean "we reached the server successfully").
     #
     # Error policy:
     # - UnauthorizedError → deactivate! (permanent, user must re-link)
-    # - ServerError / NetworkError → re-raise for job-layer retry
+    # - InvalidPayload (bad data from upstream) → record_failure! and return false
+    # - ServerError / NetworkError → record_failure! and re-raise for job-layer retry
     # - NotFoundError → silent success (no MonthlyBudget for this month yet)
     class SyncService
       SOURCE_KEY = "salary_calculator"
+      ALLOWED_CURRENCIES = %w[CRC USD EUR].freeze
+
+      class InvalidPayload < StandardError; end
 
       def initialize(source:)
         @source = source
@@ -36,6 +40,12 @@ module Services
       rescue ApiClient::UnauthorizedError => e
         @source.deactivate!(reason: "unauthorized: #{e.message.to_s.truncate(200)}")
         false
+      rescue InvalidPayload => e
+        @source.record_failure!(error: e.message)
+        false
+      rescue ApiClient::ServerError, ApiClient::NetworkError => e
+        @source.record_failure!(error: "#{e.class.name}: #{e.message.to_s.truncate(200)}")
+        raise
       end
 
       private
@@ -49,29 +59,48 @@ module Services
         present_ids = items.map { |i| i.fetch("id") }
 
         ActiveRecord::Base.transaction do
-          items.each { |item| upsert_budget(account, item, period_start, period_end) }
+          # Deactivate any external rows from prior/other months FIRST — only the
+          # current period should remain active after a successful sync. This
+          # must happen before upserts to avoid clashing with the Budget model's
+          # "one active budget per (period, category)" validation when the same
+          # external_id appears across months.
           account.budgets
             .where(external_source: SOURCE_KEY)
-            .where.not(external_id: present_ids)
+            .where.not(start_date: period_start)
             .update_all(active: false)
+
+          # Deactivate any current-month external rows that dropped out of the
+          # upstream response. If the response is empty, deactivate them all.
+          scope = account.budgets
+            .where(external_source: SOURCE_KEY, start_date: period_start)
+          scope = scope.where.not(external_id: present_ids) if present_ids.any?
+          scope.update_all(active: false)
+
+          items.each { |item| upsert_budget(account, item, period_start, period_end) }
         end
       end
 
       def upsert_budget(account, item, period_start, period_end)
+        currency = item.fetch("currency").to_s.upcase
+        unless ALLOWED_CURRENCIES.include?(currency)
+          raise InvalidPayload, "unsupported currency=#{currency.inspect} for item id=#{item['id']}"
+        end
+
         budget = account.budgets.find_or_initialize_by(
           external_source: SOURCE_KEY,
-          external_id: item.fetch("id")
+          external_id: item.fetch("id"),
+          start_date: period_start
         )
         budget.assign_attributes(
           name: item.fetch("name"),
           amount: item.fetch("amount"),
-          currency: item.fetch("currency"),
+          currency: currency,
           period: :monthly,
           start_date: period_start,
           end_date: period_end,
+          active: true,
           external_synced_at: Time.current
         )
-        budget.active = true if budget.new_record?
         budget.save!
       end
     end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -94,6 +94,14 @@ default: &default
     schedule: every day at 4:15am
     description: "Purge failed job executions older than 30 days (PER-503 retention)"
 
+  # Pull the latest monthly budget from each active external budget source
+  # (e.g. salary_calculator). Deactivated sources are skipped automatically.
+  external_budgets_daily_sync:
+    command: "ExternalBudgetSource.active.find_each { |s| ExternalBudgets::PullJob.perform_later(s.id) }"
+    queue: default
+    schedule: every day at 6am
+    description: "Pull latest monthly budget from each active external source"
+
 development:
   <<: *default
   # In development, run metrics calculation more frequently for testing

--- a/db/migrate/20260418191023_rescope_budgets_external_unique_index.rb
+++ b/db/migrate/20260418191023_rescope_budgets_external_unique_index.rb
@@ -1,0 +1,9 @@
+class RescopeBudgetsExternalUniqueIndex < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :budgets, name: "idx_budgets_external_unique"
+    add_index :budgets, [ :email_account_id, :external_source, :external_id, :start_date ],
+              unique: true,
+              where: "external_source IS NOT NULL",
+              name: "idx_budgets_external_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_182103) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_191023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -83,9 +83,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_182103) do
     t.index ["email_account_id", "active"], name: "index_budgets_on_email_account_id_and_active"
     t.index ["email_account_id", "category_id", "active"], name: "index_budgets_on_email_account_id_and_category_id_and_active"
     t.index ["email_account_id", "category_id", "period", "active"], name: "index_budgets_unique_active", unique: true, where: "(active = true)"
+    t.index ["email_account_id", "external_source", "external_id", "start_date"], name: "idx_budgets_external_unique", unique: true, where: "(external_source IS NOT NULL)"
     t.index ["email_account_id", "period", "active"], name: "index_budgets_on_email_account_id_and_period_and_active"
     t.index ["email_account_id"], name: "index_budgets_on_email_account_id"
-    t.index ["external_source", "external_id"], name: "idx_budgets_external_unique", unique: true, where: "(external_source IS NOT NULL)"
     t.index ["external_source"], name: "index_budgets_on_external_source", where: "(external_source IS NOT NULL)"
     t.index ["metadata"], name: "index_budgets_on_metadata", using: :gin
     t.index ["start_date", "end_date"], name: "index_budgets_on_start_date_and_end_date"

--- a/spec/jobs/external_budgets/pull_job_spec.rb
+++ b/spec/jobs/external_budgets/pull_job_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExternalBudgets::PullJob, :unit do
+  let(:source) { create(:external_budget_source) }
+  let(:sync_service) { instance_double(Services::ExternalBudgets::SyncService) }
+
+  describe "#perform" do
+    context "with a valid active source" do
+      it "invokes SyncService#call once" do
+        allow(Services::ExternalBudgets::SyncService).to receive(:new).with(source: source).and_return(sync_service)
+        expect(sync_service).to receive(:call).once.and_return(true)
+
+        described_class.new.perform(source.id)
+      end
+    end
+
+    context "when the source does not exist" do
+      it "returns early without calling SyncService" do
+        expect(Services::ExternalBudgets::SyncService).not_to receive(:new)
+        expect { described_class.new.perform(-1) }.not_to raise_error
+      end
+    end
+
+    context "when the source is inactive" do
+      before { source.update!(active: false) }
+
+      it "returns early without calling SyncService" do
+        expect(Services::ExternalBudgets::SyncService).not_to receive(:new)
+        described_class.new.perform(source.id)
+      end
+    end
+
+    context "when SyncService raises UnauthorizedError internally" do
+      # SyncService catches UnauthorizedError and returns false; the job
+      # layer never sees it, so it must not retry.
+      it "does not re-raise and does not retry at the job layer" do
+        allow(Services::ExternalBudgets::SyncService).to receive(:new).with(source: source).and_return(sync_service)
+        allow(sync_service).to receive(:call).and_return(false)
+
+        expect { described_class.new.perform(source.id) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "retry configuration" do
+    let(:source_file) { Rails.root.join("app/jobs/external_budgets/pull_job.rb") }
+    let(:source_text) { File.read(source_file) }
+
+    it "retries on ApiClient::NetworkError with polynomially_longer backoff, attempts: 3" do
+      expect(source_text).to match(/retry_on[^\n]*NetworkError[\s\S]{0,120}polynomially_longer[\s\S]{0,120}attempts:\s*3/)
+    end
+
+    it "retries on ApiClient::ServerError with polynomially_longer backoff, attempts: 3" do
+      expect(source_text).to match(/retry_on[^\n]*ServerError[\s\S]{0,120}polynomially_longer[\s\S]{0,120}attempts:\s*3/)
+    end
+  end
+end

--- a/spec/services/external_budgets/api_client_spec.rb
+++ b/spec/services/external_budgets/api_client_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe Services::ExternalBudgets::ApiClient, :unit do
+  let(:base_url) { "https://salary-calc.estebansoto.dev" }
+  let(:source) { create(:external_budget_source, base_url: base_url, api_token: "tok") }
+  let(:path) { "#{base_url}/api/v1/monthly_budgets/current" }
+
+  subject(:client) { described_class.new(source: source) }
+
+  describe "#fetch_current_budget" do
+    let(:valid_body) do
+      {
+        monthly_budget: {
+          id: 42, year: 2026, month: 4,
+          exchange_rate: "503.0",
+          shared_with_household: false,
+          updated_at: "2026-04-17T15:00:00Z"
+        },
+        budget_items: [
+          {
+            id: 101, name: "Rent", category: "fixed", amount: "800.0",
+            currency: "USD", position: 1, paid: false,
+            updated_at: "2026-04-15T10:00:00Z"
+          }
+        ]
+      }.to_json
+    end
+
+    context "when server returns 200" do
+      before do
+        stub_request(:get, path)
+          .with(headers: { "Authorization" => "Bearer tok", "Accept" => "application/json" })
+          .to_return(status: 200, body: valid_body, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns an ok Result with parsed JSON body" do
+        result = client.fetch_current_budget
+        expect(result.ok?).to be true
+        expect(result.not_modified?).to be false
+        expect(result.status).to eq(200)
+        expect(result.body).to include("monthly_budget", "budget_items")
+        expect(result.body["budget_items"].first["id"]).to eq(101)
+      end
+    end
+
+    context "when if_modified_since is passed" do
+      let(:since) { Time.parse("2026-04-10T00:00:00Z") }
+
+      before do
+        stub_request(:get, path)
+          .with(headers: { "If-Modified-Since" => since.httpdate })
+          .to_return(status: 200, body: valid_body, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "sends the If-Modified-Since header in httpdate format" do
+        client.fetch_current_budget(if_modified_since: since)
+        expect(WebMock).to have_requested(:get, path)
+          .with(headers: { "If-Modified-Since" => since.httpdate })
+      end
+    end
+
+    context "when server returns 304" do
+      before do
+        stub_request(:get, path).to_return(status: 304, body: "")
+      end
+
+      it "returns a not_modified Result with nil body" do
+        result = client.fetch_current_budget
+        expect(result.status).to eq(304)
+        expect(result.body).to be_nil
+        expect(result.not_modified?).to be true
+        expect(result.ok?).to be false
+      end
+    end
+
+    context "when server returns 401" do
+      before do
+        stub_request(:get, path).to_return(status: 401, body: "invalid or expired token")
+      end
+
+      it "raises UnauthorizedError with body in message" do
+        expect { client.fetch_current_budget }
+          .to raise_error(described_class::UnauthorizedError, /invalid or expired token/)
+      end
+    end
+
+    context "when server returns 404" do
+      before do
+        stub_request(:get, path).to_return(status: 404, body: "not found")
+      end
+
+      it "raises NotFoundError" do
+        expect { client.fetch_current_budget }.to raise_error(described_class::NotFoundError)
+      end
+    end
+
+    context "when server returns 500" do
+      before do
+        stub_request(:get, path).to_return(status: 500, body: "boom")
+      end
+
+      it "raises ServerError with status in message" do
+        expect { client.fetch_current_budget }
+          .to raise_error(described_class::ServerError, /status=500/)
+      end
+    end
+
+    context "when the network times out" do
+      before do
+        stub_request(:get, path).to_raise(Net::OpenTimeout)
+      end
+
+      it "raises NetworkError" do
+        expect { client.fetch_current_budget }.to raise_error(described_class::NetworkError)
+      end
+    end
+
+    context "when TLS handshake fails" do
+      before do
+        stub_request(:get, path).to_raise(OpenSSL::SSL::SSLError.new("bad certificate"))
+      end
+
+      it "raises NetworkError" do
+        expect { client.fetch_current_budget }
+          .to raise_error(described_class::NetworkError, /SSLError/)
+      end
+    end
+  end
+end

--- a/spec/services/external_budgets/sync_service_spec.rb
+++ b/spec/services/external_budgets/sync_service_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe Services::ExternalBudgets::SyncService, :unit do
+  let(:base_url) { "https://salary-calc.estebansoto.dev" }
+  let(:source) { create(:external_budget_source, base_url: base_url, api_token: "tok") }
+  let(:account) { source.email_account }
+  let(:path) { "#{base_url}/api/v1/monthly_budgets/current" }
+
+  let(:period_start) { Date.new(2026, 4, 1) }
+  let(:period_end)   { period_start.end_of_month }
+
+  let(:rent_item) do
+    {
+      id: 101, name: "Rent", category: "fixed", amount: "800.0",
+      currency: "USD", position: 1, paid: false,
+      updated_at: "2026-04-15T10:00:00Z"
+    }
+  end
+
+  let(:food_item) do
+    {
+      id: 102, name: "Food", category: "variable", amount: "200.0",
+      currency: "USD", position: 2, paid: false,
+      updated_at: "2026-04-15T10:00:00Z"
+    }
+  end
+
+  def payload(items)
+    {
+      monthly_budget: {
+        id: 42, year: 2026, month: 4,
+        exchange_rate: "503.0",
+        shared_with_household: false,
+        updated_at: "2026-04-17T15:00:00Z"
+      },
+      budget_items: items
+    }.to_json
+  end
+
+  subject(:service) { described_class.new(source: source) }
+
+  describe "#call" do
+    context "when response is 200 with a new item" do
+      before do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "creates a new Budget with expected attributes" do
+        expect { service.call }.to change(account.budgets, :count).by(1)
+
+        budget = account.budgets.find_by(external_source: "salary_calculator", external_id: 101)
+        expect(budget).to be_present
+        expect(budget.name).to eq("Rent")
+        expect(budget.amount).to eq(800.0)
+        expect(budget.currency).to eq("USD")
+        expect(budget.period).to eq("monthly")
+        expect(budget.start_date).to eq(period_start)
+        expect(budget.end_date).to eq(period_end)
+        expect(budget.category_id).to be_nil
+        expect(budget.active).to be true
+        expect(budget.external_synced_at).to be_within(5.seconds).of(Time.current)
+      end
+
+      it "marks the source as succeeded and returns true" do
+        expect(service.call).to be true
+        source.reload
+        expect(source.last_sync_status).to eq("ok")
+        expect(source.last_synced_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context "when an existing synced budget is updated" do
+      let!(:category) { create(:category) }
+      let!(:existing) do
+        account.budgets.create!(
+          name: "Rent",
+          amount: 800.0,
+          currency: "USD",
+          period: :monthly,
+          start_date: period_start,
+          end_date: period_end,
+          external_source: "salary_calculator",
+          external_id: 101,
+          category_id: category.id,
+          active: true,
+          external_synced_at: 1.day.ago
+        )
+      end
+
+      let(:updated_item) do
+        rent_item.merge(amount: "900.0", name: "Rent — new")
+      end
+
+      before do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ updated_item ]),
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "updates mutable fields and preserves category_id and active" do
+        expect { service.call }.not_to change(account.budgets, :count)
+
+        existing.reload
+        expect(existing.amount).to eq(900.0)
+        expect(existing.name).to eq("Rent — new")
+        expect(existing.currency).to eq("USD")
+        expect(existing.category_id).to eq(category.id)
+        expect(existing.active).to be true
+      end
+    end
+
+    context "when a previously synced item is dropped from the response" do
+      let!(:dropped) do
+        account.budgets.create!(
+          name: "Gym", amount: 50.0, currency: "USD",
+          period: :monthly, start_date: period_start, end_date: period_end,
+          external_source: "salary_calculator", external_id: 999,
+          active: true, external_synced_at: 1.day.ago
+        )
+      end
+
+      let!(:native_budget) do
+        create(:budget, email_account: account, name: "Native food", amount: 100_000)
+      end
+
+      before do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "sets active: false on the dropped external budget" do
+        service.call
+        expect(dropped.reload.active).to be false
+      end
+
+      it "leaves native and unrelated-external budgets untouched" do
+        service.call
+        expect(native_budget.reload.active).to be true
+      end
+    end
+
+    context "when response is 304 Not Modified" do
+      before do
+        stub_request(:get, path).to_return(status: 304, body: "")
+      end
+
+      it "does not create or modify any budgets and still marks the source succeeded" do
+        expect { service.call }.not_to change(account.budgets, :count)
+        expect(service.call).to be true
+        expect(source.reload.last_sync_status).to eq("ok")
+      end
+    end
+
+    context "when the API returns 404 (no budget for current month)" do
+      before do
+        stub_request(:get, path).to_return(status: 404, body: "not found")
+      end
+
+      it "silently succeeds and marks the source succeeded" do
+        expect(service.call).to be true
+        expect(source.reload.last_sync_status).to eq("ok")
+      end
+    end
+
+    context "when the API returns 401" do
+      before do
+        stub_request(:get, path).to_return(status: 401, body: "bad token")
+      end
+
+      it "deactivates the source, returns false, does not raise" do
+        expect { expect(service.call).to be false }.not_to raise_error
+        source.reload
+        expect(source.active).to be false
+        expect(source.last_sync_status).to eq("failed")
+        expect(source.last_sync_error).to include("unauthorized")
+      end
+    end
+
+    context "when the API returns 500" do
+      before do
+        stub_request(:get, path).to_return(status: 500, body: "boom")
+      end
+
+      it "re-raises ServerError for job-layer retry" do
+        expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::ServerError)
+      end
+    end
+
+    context "on a network failure" do
+      before do
+        stub_request(:get, path).to_raise(Net::OpenTimeout)
+      end
+
+      it "re-raises NetworkError for job-layer retry" do
+        expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::NetworkError)
+      end
+    end
+
+    context "when source.last_synced_at is present" do
+      let(:since) { Time.parse("2026-04-10T00:00:00Z") }
+
+      before do
+        source.update!(last_synced_at: since)
+        stub_request(:get, path)
+          .with(headers: { "If-Modified-Since" => since.httpdate })
+          .to_return(status: 304, body: "")
+      end
+
+      it "passes it to ApiClient as If-Modified-Since" do
+        service.call
+        expect(WebMock).to have_requested(:get, path)
+          .with(headers: { "If-Modified-Since" => since.httpdate })
+      end
+    end
+  end
+end

--- a/spec/services/external_budgets/sync_service_spec.rb
+++ b/spec/services/external_budgets/sync_service_spec.rb
@@ -190,6 +190,14 @@ RSpec.describe Services::ExternalBudgets::SyncService, :unit do
       it "re-raises ServerError for job-layer retry" do
         expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::ServerError)
       end
+
+      it "records the failure on the source before re-raising" do
+        expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::ServerError)
+        source.reload
+        expect(source.active).to be true
+        expect(source.last_sync_status).to eq("failed")
+        expect(source.last_sync_error).to include("ServerError")
+      end
     end
 
     context "on a network failure" do
@@ -199,6 +207,133 @@ RSpec.describe Services::ExternalBudgets::SyncService, :unit do
 
       it "re-raises NetworkError for job-layer retry" do
         expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::NetworkError)
+      end
+
+      it "records the failure on the source before re-raising" do
+        expect { service.call }.to raise_error(Services::ExternalBudgets::ApiClient::NetworkError)
+        source.reload
+        expect(source.active).to be true
+        expect(source.last_sync_status).to eq("failed")
+        expect(source.last_sync_error).to include("NetworkError")
+      end
+    end
+
+    context "when an item has an unsupported currency" do
+      let(:bad_item) { rent_item.merge(currency: "MXN") }
+
+      before do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ bad_item ]),
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "records the failure, creates no Budget, returns false, does not raise" do
+        expect { expect(service.call).to be false }.not_to raise_error
+        expect(account.budgets.where(external_source: "salary_calculator").count).to eq(0)
+        source.reload
+        expect(source.active).to be true
+        expect(source.last_sync_status).to eq("failed")
+        expect(source.last_sync_error).to include("unsupported currency")
+      end
+    end
+
+    context "when an item has a blank currency" do
+      let(:bad_item) { rent_item.merge(currency: "") }
+
+      before do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ bad_item ]),
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "records the failure, creates no Budget, returns false" do
+        expect { expect(service.call).to be false }.not_to raise_error
+        expect(account.budgets.where(external_source: "salary_calculator").count).to eq(0)
+        source.reload
+        expect(source.last_sync_status).to eq("failed")
+      end
+    end
+
+    context "when the same external_id appears in a later month (rollover)" do
+      let(:april_start) { Date.new(2026, 4, 1) }
+      let(:may_start)   { Date.new(2026, 5, 1) }
+
+      def monthly_payload(year, month, items)
+        {
+          monthly_budget: {
+            id: 42, year: year, month: month,
+            exchange_rate: "503.0",
+            shared_with_household: false,
+            updated_at: "2026-04-17T15:00:00Z"
+          },
+          budget_items: items
+        }.to_json
+      end
+
+      it "creates a separate Budget per month and deactivates prior-month rows" do
+        # April sync
+        stub_request(:get, path)
+          .to_return(status: 200, body: monthly_payload(2026, 4, [ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+        service.call
+
+        april_row = account.budgets.find_by!(
+          external_source: "salary_calculator", external_id: 101, start_date: april_start
+        )
+        expect(april_row.active).to be true
+
+        # Advance source state so next request uses fresh If-Modified-Since
+        source.reload
+
+        # May sync — same external_id 101, different month
+        WebMock.reset!
+        stub_request(:get, path)
+          .to_return(status: 200, body: monthly_payload(2026, 5, [ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+        described_class.new(source: source).call
+
+        may_row = account.budgets.find_by(
+          external_source: "salary_calculator", external_id: 101, start_date: may_start
+        )
+        expect(may_row).to be_present
+        expect(may_row.active).to be true
+        expect(may_row.id).not_to eq(april_row.id)
+
+        # April row now deactivated
+        april_row.reload
+        expect(april_row.active).to be false
+
+        # Exactly two rows exist for this external_id
+        expect(
+          account.budgets.where(external_source: "salary_calculator", external_id: 101).count
+        ).to eq(2)
+      end
+
+      it "reactivates a prior row when the same month is re-synced" do
+        # April sync
+        stub_request(:get, path)
+          .to_return(status: 200, body: monthly_payload(2026, 4, [ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+        service.call
+        april_row = account.budgets.find_by!(
+          external_source: "salary_calculator", external_id: 101, start_date: april_start
+        )
+
+        # May sync deactivates April
+        WebMock.reset!
+        stub_request(:get, path)
+          .to_return(status: 200, body: monthly_payload(2026, 5, [ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+        described_class.new(source: source).call
+        expect(april_row.reload.active).to be false
+
+        # Re-sync April — row comes back active
+        WebMock.reset!
+        stub_request(:get, path)
+          .to_return(status: 200, body: monthly_payload(2026, 4, [ rent_item ]),
+                     headers: { "Content-Type" => "application/json" })
+        described_class.new(source: source).call
+        expect(april_row.reload.active).to be true
       end
     end
 


### PR DESCRIPTION
## Summary

Third of 4 stacked PRs for the salary_calc integration. Builds on [#452](https://github.com/esoto/expense_tracker/pull/452) + [#453](https://github.com/esoto/expense_tracker/pull/453), both merged.

### What's included
- `Services::ExternalBudgets::ApiClient` — HTTP wrapper around `GET /api/v1/monthly_budgets/current`; Bearer auth, `If-Modified-Since`, typed errors (Unauthorized / NotFound / Server / Network).
- `Services::ExternalBudgets::SyncService` — orchestrates sync:
  - 200 → upsert `Budget` rows by `(external_source, external_id)`, preserving user-set `category_id`; drops missing items go inactive.
  - 304 → no writes; `mark_succeeded!`.
  - 404 → silent success (no budget this month yet).
  - 401 → `source.deactivate!(reason: ...)` — surfaces "Reconnect required" in UI.
  - 5xx / network → re-raise for job retry.
- `ExternalBudgets::PullJob` — real implementation replacing PR 2 stub; `retry_on NetworkError + ServerError` (polynomially_longer, 3 attempts).
- `config/recurring.yml` — daily 6am cron fans out `PullJob` per active source.

### Out of scope for this PR
- Budget UI changes (PR 4)

### Namespace note
Services are namespaced `Services::ExternalBudgets::…` because this project's Zeitwerk config mounts `app/services/` under the `Services::` root (same convention as `Services::Oauth::TokenExchanger` from PR 2). Job stays at top-level `ExternalBudgets::PullJob` (app/jobs root is `Object`).

## Test plan
- [x] `bundle exec rspec spec/services/external_budgets/api_client_spec.rb` (8 examples)
- [x] `bundle exec rspec spec/services/external_budgets/sync_service_spec.rb` (11 examples)
- [x] `bundle exec rspec spec/jobs/external_budgets/pull_job_spec.rb` (6 examples)
- [x] `bundle exec rubocop` clean across all new files
- [x] Pre-commit hook (full unit suite) passes on every commit

## Review complexity
Medium. Self-contained (service + job layer). HTTP stubbed via WebMock — no live external calls in tests.