### PR TITLE
feat(budgets): salary_calc UI — badge, unmapped banner, empty-state CTA (PR 4/4)

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -17,6 +17,10 @@ class BudgetsController < ApplicationController
 
     # Calculate overall budget health
     @overall_health = calculate_overall_budget_health
+
+    # Whether an active external budget source (e.g., salary_calculator) is linked.
+    # Drives the empty-state CTA and sync-in-progress messaging.
+    @has_external_source = @email_account.external_budget_source&.active? || false
   end
 
   # GET /budgets/1

--- a/app/views/budgets/_card.html.erb
+++ b/app/views/budgets/_card.html.erb
@@ -1,0 +1,61 @@
+<%# Renders a single budget as a card. Expects a `budget` local. %>
+<div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+  <div class="flex items-start justify-between gap-2 mb-2">
+    <h3 class="font-semibold text-slate-900"><%= budget.name %></h3>
+    <% if budget.external? %>
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-50 text-teal-700 border border-teal-200 whitespace-nowrap">
+        <%= t("budgets.external_badge") %>
+      </span>
+    <% end %>
+  </div>
+  <p class="text-sm text-slate-600 mb-4">
+    <%= budget.category&.display_name || t("budgets.show.general") %>
+  </p>
+
+  <% if budget.unmapped? %>
+    <div class="bg-amber-50 border border-amber-200 rounded-md p-3 mb-4">
+      <p class="text-sm text-amber-800"><%= t("budgets.unmapped_banner") %></p>
+      <%= form_with(model: budget, local: true, class: "flex items-center gap-2 mt-2") do |f| %>
+        <%= f.select :category_id,
+              options_from_collection_for_select(budget.email_account.categories.distinct, :id, :display_name),
+              { include_blank: t("budgets.pick_category") },
+              class: "rounded border-slate-300 text-sm" %>
+        <%= f.submit t("budgets.save_category"),
+              class: "bg-teal-700 hover:bg-teal-800 text-white px-3 py-1.5 rounded text-sm" %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="space-y-2">
+    <div class="flex justify-between text-sm">
+      <span class="text-slate-500">Monto:</span>
+      <span class="font-medium"><%= budget.formatted_amount %></span>
+    </div>
+
+    <div class="flex justify-between text-sm">
+      <span class="text-slate-500">Usado:</span>
+      <span class="font-medium <%= budget.status_color %>">
+        <%= budget.usage_percentage %>%
+      </span>
+    </div>
+
+    <div class="flex justify-between text-sm">
+      <span class="text-slate-500">Estado:</span>
+      <span class="<%= budget.active? ? 'text-emerald-600' : 'text-slate-400' %>">
+        <%= budget.active? ? 'Activo' : 'Inactivo' %>
+      </span>
+    </div>
+  </div>
+
+  <div class="mt-4 flex gap-2">
+    <%= link_to "Ver", budget_path(budget),
+        class: "text-teal-700 hover:text-teal-800 text-sm font-medium" %>
+    <%= link_to "Editar", edit_budget_path(budget),
+        class: "text-teal-700 hover:text-teal-800 text-sm font-medium" %>
+    <% if budget.active? %>
+      <%= button_to "Desactivar", deactivate_budget_path(budget),
+          method: :post,
+          class: "text-amber-600 hover:text-amber-700 text-sm font-medium" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/budgets/_external_source_empty_state.html.erb
+++ b/app/views/budgets/_external_source_empty_state.html.erb
@@ -1,0 +1,15 @@
+<%# Empty-state CTA shown on the budgets index when the user has no budgets
+    AND has not linked an active external budget source. Offers a one-click
+    action to start the salary_calc OAuth flow. %>
+<div class="bg-slate-50 border border-slate-200 rounded-xl p-10 text-center">
+  <h2 class="text-xl font-semibold text-slate-900 mb-2">
+    <%= t("budgets.empty_state.heading") %>
+  </h2>
+  <p class="text-slate-600 mb-6 max-w-md mx-auto">
+    <%= t("budgets.empty_state.body") %>
+  </p>
+  <%= button_to t("budgets.empty_state.cta"),
+        connect_external_source_path,
+        method: :post,
+        class: "bg-teal-700 hover:bg-teal-800 text-white font-medium px-5 py-2.5 rounded-lg shadow-sm transition-colors" %>
+</div>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -16,54 +16,16 @@
 
         <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <% budgets.each do |budget| %>
-            <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-              <h3 class="font-semibold text-slate-900 mb-2"><%= budget.name %></h3>
-              <p class="text-sm text-slate-600 mb-4">
-                <%= budget.category&.display_name || "General" %>
-              </p>
-
-              <div class="space-y-2">
-                <div class="flex justify-between text-sm">
-                  <span class="text-slate-500">Monto:</span>
-                  <span class="font-medium"><%= budget.formatted_amount %></span>
-                </div>
-
-                <div class="flex justify-between text-sm">
-                  <span class="text-slate-500">Usado:</span>
-                  <span class="font-medium <%= budget.status_color %>">
-                    <%= budget.usage_percentage %>%
-                  </span>
-                </div>
-
-                <div class="flex justify-between text-sm">
-                  <span class="text-slate-500">Estado:</span>
-                  <span class="<%= budget.active? ? 'text-emerald-600' : 'text-slate-400' %>">
-                    <%= budget.active? ? 'Activo' : 'Inactivo' %>
-                  </span>
-                </div>
-              </div>
-
-              <div class="mt-4 flex gap-2">
-                <%= link_to "Ver", budget_path(budget),
-                    class: "text-teal-700 hover:text-teal-800 text-sm font-medium" %>
-                <%= link_to "Editar", edit_budget_path(budget),
-                    class: "text-teal-700 hover:text-teal-800 text-sm font-medium" %>
-                <% if budget.active? %>
-                  <%= button_to "Desactivar", deactivate_budget_path(budget),
-                      method: :post,
-                      class: "text-amber-600 hover:text-amber-700 text-sm font-medium" %>
-                <% end %>
-              </div>
-            </div>
+            <%= render "budgets/card", budget: budget %>
           <% end %>
         </div>
       </div>
     <% end %>
-  <% else %>
+  <% elsif @has_external_source %>
     <div class="bg-slate-50 rounded-lg p-8 text-center">
-      <p class="text-slate-600 mb-4">No tienes presupuestos configurados.</p>
-      <%= link_to t("budgets.index.create_first"), new_budget_path,
-          class: "text-teal-700 hover:text-teal-800 font-medium" %>
+      <p class="text-slate-600"><%= t("budgets.empty_state.sync_in_progress") %></p>
     </div>
+  <% else %>
+    <%= render "budgets/external_source_empty_state" %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -686,6 +686,15 @@ en:
 
   # Budgets
   budgets:
+    external_badge: "from salary_calc"
+    unmapped_banner: "Pick a category to start tracking spend"
+    pick_category: "Choose a category..."
+    save_category: "Save"
+    empty_state:
+      heading: "Connect salary_calc"
+      body: "Pull in your monthly budget to see planned vs actual spend."
+      cta: "Connect salary_calc"
+      sync_in_progress: "No budgets yet — sync in progress"
     index:
       title: "Budgets"
       new_budget: "New Budget"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -688,6 +688,15 @@ es:
 
   # Budgets
   budgets:
+    external_badge: "desde salary_calc"
+    unmapped_banner: "Selecciona una categoría para empezar a rastrear tus gastos"
+    pick_category: "Elige una categoría..."
+    save_category: "Guardar"
+    empty_state:
+      heading: "Conectar salary_calc"
+      body: "Importa tu presupuesto mensual para ver lo planeado vs. lo gastado."
+      cta: "Conectar salary_calc"
+      sync_in_progress: "Aún no hay presupuestos — sincronización en progreso"
     index:
       title: "Presupuestos"
       new_budget: "Nuevo Presupuesto"

--- a/spec/requests/budgets_external_source_spec.rb
+++ b/spec/requests/budgets_external_source_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Covers the PR 4 "salary_calc" UI additions on the budgets index:
+#   - empty-state CTA when no external source is linked
+#   - sync-in-progress empty state when a source IS linked
+#   - "from salary_calc" badge on external budgets
+#   - unmapped banner with inline category picker for synced_unmapped rows
+#   - no badge on native budgets
+#   - banner disappears after patching category_id via the existing update action
+RSpec.describe "Budgets external source UI", type: :request, unit: true do
+  let!(:admin_user) { create(:admin_user) }
+  let!(:email_account) { create(:email_account) }
+
+  before do
+    sign_in_admin(admin_user)
+    # Controller uses EmailAccount.active.first; stub to guarantee isolation.
+    allow(EmailAccount).to receive_message_chain(:active, :first).and_return(email_account)
+  end
+
+  describe "GET /budgets" do
+    context "with no external source and no budgets" do
+      it "renders the Connect salary_calc empty-state CTA" do
+        get budgets_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("budgets.empty_state.cta"))
+        expect(response.body).to include(I18n.t("budgets.empty_state.heading"))
+        # The CTA must be a POST form to connect_external_source_path.
+        expect(response.body).to match(
+          %r{<form[^>]+action="#{Regexp.escape(connect_external_source_path)}"}i
+        )
+        expect(response.body).to match(%r{<form[^>]+method="post"}i)
+      end
+    end
+
+    context "with an active external source and no budgets" do
+      before do
+        create(:external_budget_source, email_account: email_account, active: true)
+      end
+
+      it "renders the sync-in-progress empty state" do
+        get budgets_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("budgets.empty_state.sync_in_progress"))
+        expect(response.body).not_to include(I18n.t("budgets.empty_state.cta"))
+      end
+    end
+
+    context "with an external mapped budget" do
+      let!(:category) { create(:category) }
+      let!(:budget) do
+        create(:budget,
+          email_account: email_account,
+          category: category,
+          external_source: "salary_calculator",
+          external_id: "sc-123")
+      end
+
+      it "shows the from-salary_calc badge" do
+        get budgets_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("budgets.external_badge"))
+        # Mapped — no unmapped banner.
+        expect(response.body).not_to include(I18n.t("budgets.unmapped_banner"))
+      end
+    end
+
+    context "with an unmapped external budget" do
+      let!(:budget) do
+        create(:budget,
+          email_account: email_account,
+          category: nil,
+          external_source: "salary_calculator",
+          external_id: "sc-unmapped-1")
+      end
+
+      it "shows the unmapped banner with a category picker select" do
+        get budgets_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("budgets.unmapped_banner"))
+        expect(response.body).to match(%r{<select[^>]+name="budget\[category_id\]"})
+        # Badge still rendered because the budget is external.
+        expect(response.body).to include(I18n.t("budgets.external_badge"))
+      end
+    end
+
+    context "with a native budget" do
+      let!(:budget) do
+        create(:budget, email_account: email_account, category: nil)
+      end
+
+      it "does not render the external badge or the unmapped banner" do
+        get budgets_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(I18n.t("budgets.external_badge"))
+        expect(response.body).not_to include(I18n.t("budgets.unmapped_banner"))
+      end
+    end
+  end
+
+  describe "PATCH /budgets/:id then GET /budgets" do
+    let!(:category) { create(:category) }
+    let!(:budget) do
+      create(:budget,
+        email_account: email_account,
+        category: nil,
+        external_source: "salary_calculator",
+        external_id: "sc-42")
+    end
+
+    it "clears the unmapped banner once a category is assigned" do
+      expect(budget.reload.unmapped?).to be(true)
+
+      patch budget_path(budget), params: { budget: { category_id: category.id } }
+      expect(response).to have_http_status(:found)
+
+      expect(budget.reload.unmapped?).to be(false)
+
+      get budgets_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(I18n.t("budgets.unmapped_banner"))
+      # Badge should still be visible on the (now mapped) external budget.
+      expect(response.body).to include(I18n.t("budgets.external_badge"))
+    end
+  end
+end

--- a/spec/system/budgets_external_source_ui_spec.rb
+++ b/spec/system/budgets_external_source_ui_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# End-to-end coverage for the inline category picker on unmapped external
+# budgets. Tagged :slow so it only runs in CI (and in the worktree on demand).
+RSpec.describe "Budgets external source UI", type: :system, slow: true do
+  let(:admin_user) { create(:admin_user) }
+  let!(:email_account) { create(:email_account, active: true) }
+  let!(:category) { create(:category, name: "Comida", i18n_key: "food") }
+  # Seed at least one expense so the `has_many :categories, through: :expenses`
+  # association surfaces `category` in the picker options.
+  let!(:seed_expense) do
+    create(:expense, email_account: email_account, category: category)
+  end
+  let!(:unmapped_budget) do
+    create(:budget,
+      email_account: email_account,
+      category: nil,
+      external_source: "salary_calculator",
+      external_id: "sc-system-1",
+      name: "Salary budget")
+  end
+
+  before do
+    driven_by(:rack_test)
+    sign_in_admin_user(admin_user)
+    allow(EmailAccount).to receive_message_chain(:active, :first).and_return(email_account)
+  end
+
+  it "lets the user map an unmapped external budget to a category inline" do
+    visit budgets_path
+
+    expect(page).to have_content(I18n.t("budgets.external_badge"))
+    expect(page).to have_content(I18n.t("budgets.unmapped_banner"))
+
+    select category.display_name, from: "budget[category_id]"
+    click_button I18n.t("budgets.save_category")
+
+    # Redirects to dashboard on success; revisit the index to confirm state.
+    visit budgets_path
+
+    expect(page).not_to have_content(I18n.t("budgets.unmapped_banner"))
+    expect(page).to have_content(I18n.t("budgets.external_badge"))
+  end
+end


### PR DESCRIPTION
## Summary

Final PR of the salary_calc integration. Builds on [#452](https://github.com/esoto/expense_tracker/pull/452), [#453](https://github.com/esoto/expense_tracker/pull/453), [#454](https://github.com/esoto/expense_tracker/pull/454) — all merged.

### What's included
- `_card.html.erb` partial extracted from `budgets/index.html.erb`.
- "from salary_calc" teal pill badge on synced Budget cards.
- Amber "unmapped" banner with inline category picker for `Budget#unmapped?` rows (dropdown → Save → assigns `category_id`, existing update action handles it).
- Empty-state CTA on `/budgets` when no active `ExternalBudgetSource` AND no budgets: "Connect salary_calc" POST button → OAuth flow.
- Alternate empty-state when source is connected but still syncing: "No budgets yet — sync in progress".
- i18n keys (en + es).

### End-to-end flow now works
1. User visits `/budgets` → "Connect salary_calc" CTA (empty state).
2. User clicks → POST `/external_source/connect` → redirects to salary-calc.estebansoto.dev/oauth/authorize.
3. User authorizes → callback exchanges code for token, creates `ExternalBudgetSource`, enqueues first `PullJob`.
4. Sync runs → creates `Budget` rows with `external_source: "salary_calculator"`, `category_id: nil`.
5. User returns to `/budgets` → sees cards with "from salary_calc" badge and amber "pick a category" banner.
6. User picks category → banner disappears, `calculate_current_spend!` starts tracking (existing machinery).
7. Daily 6am cron refreshes data; user can also hit "Sync now".

## Test plan
- [x] `bundle exec rspec spec/requests/budgets_external_source_spec.rb` (6 examples)
- [x] `bundle exec rspec spec/system/budgets_external_source_ui_spec.rb` (1 scenario — `:slow`, CI-only)
- [x] `bundle exec rubocop` clean on touched files
- [x] Pre-commit hook (full unit suite, 7773 examples) passes

## Design system
Teal (primary) / amber (warning) / emerald (success) / slate (neutrals). No blue/gray/red/yellow/green per Financial Confidence palette.

## Review complexity
Medium — view refactor + new partials + controller one-liner + i18n. No new security surface.