### PR TITLE
fix(budgets): precompute category options + label picker for a11y

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -18,6 +18,9 @@ class BudgetsController < ApplicationController
     # Calculate overall budget health
     @overall_health = calculate_overall_budget_health
 
+    # Precompute category options for unmapped external budgets to avoid N+1 queries
+    @category_options = @email_account.categories.distinct.to_a
+
     # Whether an active external budget source (e.g., salary_calculator) is linked.
     # Drives the empty-state CTA and sync-in-progress messaging.
     @has_external_source = @email_account.external_budget_source&.active? || false

--- a/app/views/budgets/_card.html.erb
+++ b/app/views/budgets/_card.html.erb
@@ -16,8 +16,9 @@
     <div class="bg-amber-50 border border-amber-200 rounded-md p-3 mb-4">
       <p class="text-sm text-amber-800"><%= t("budgets.unmapped_banner") %></p>
       <%= form_with(model: budget, local: true, class: "flex items-center gap-2 mt-2") do |f| %>
+        <%= f.label :category_id, t("budgets.pick_category"), class: "sr-only" %>
         <%= f.select :category_id,
-              options_from_collection_for_select(budget.email_account.categories.distinct, :id, :display_name),
+              options_from_collection_for_select(categories, :id, :display_name),
               { include_blank: t("budgets.pick_category") },
               class: "rounded border-slate-300 text-sm" %>
         <%= f.submit t("budgets.save_category"),

--- a/app/views/budgets/_card.html.erb
+++ b/app/views/budgets/_card.html.erb
@@ -15,11 +15,13 @@
   <% if budget.unmapped? %>
     <div class="bg-amber-50 border border-amber-200 rounded-md p-3 mb-4">
       <p class="text-sm text-amber-800"><%= t("budgets.unmapped_banner") %></p>
+      <% picker_id = "budget_#{budget.id}_category_id" %>
       <%= form_with(model: budget, local: true, class: "flex items-center gap-2 mt-2") do |f| %>
-        <%= f.label :category_id, t("budgets.pick_category"), class: "sr-only" %>
+        <%= f.label :category_id, t("budgets.pick_category"), class: "sr-only", for: picker_id %>
         <%= f.select :category_id,
               options_from_collection_for_select(categories, :id, :display_name),
               { include_blank: t("budgets.pick_category") },
+              id: picker_id,
               class: "rounded border-slate-300 text-sm" %>
         <%= f.submit t("budgets.save_category"),
               class: "bg-teal-700 hover:bg-teal-800 text-white px-3 py-1.5 rounded text-sm" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -16,7 +16,7 @@
 
         <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <% budgets.each do |budget| %>
-            <%= render "budgets/card", budget: budget %>
+            <%= render "budgets/card", budget: budget, categories: @category_options %>
           <% end %>
         </div>
       </div>

--- a/spec/requests/budgets_external_source_spec.rb
+++ b/spec/requests/budgets_external_source_spec.rb
@@ -131,12 +131,9 @@ RSpec.describe "Budgets external source UI", type: :request, unit: true do
   end
 
   describe "Query efficiency for multiple unmapped external budgets" do
-    it "renders multiple unmapped external cards without raising" do
-      # email_account.categories is `through: :expenses`, so expenses anchor the categories.
+    it "loads categories once regardless of unmapped-card count (N+1 guard)" do
       categories = create_list(:category, 2)
-      categories.each do |cat|
-        create(:expense, email_account: email_account, category: cat)
-      end
+      categories.each { |cat| create(:expense, email_account: email_account, category: cat) }
 
       3.times do |i|
         create(:budget,
@@ -147,13 +144,24 @@ RSpec.describe "Budgets external source UI", type: :request, unit: true do
           name: "Unmapped Budget #{i}")
       end
 
-      get budgets_path
+      categories_query_count = 0
+      counter = lambda do |_, _, _, _, payload|
+        next if payload[:cached] || payload[:name] =~ /SCHEMA|TRANSACTION/
+        categories_query_count += 1 if payload[:sql] =~ /FROM "categories"/i
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get budgets_path
+      end
 
       expect(response).to have_http_status(:ok)
       expect(assigns(:category_options)).to be_an(Array)
       expect(response.body).to include("Unmapped Budget 0", "Unmapped Budget 1", "Unmapped Budget 2")
+      # With N unmapped cards (3 here), a regressed N+1 would fire >= N categories queries.
+      # Ceiling of 2 permits the controller's single load + at most one other legitimate categories
+      # lookup (e.g., Budget#category eager-load). Anything more signals the N+1 returned.
+      expect(categories_query_count).to be <= 2
       categories.each do |cat|
-        # Each category renders once per unmapped card's dropdown.
         expect(response.body.scan(cat.display_name).size).to be >= 3
       end
     end

--- a/spec/requests/budgets_external_source_spec.rb
+++ b/spec/requests/budgets_external_source_spec.rb
@@ -129,4 +129,33 @@ RSpec.describe "Budgets external source UI", type: :request, unit: true do
       expect(response.body).to include(I18n.t("budgets.external_badge"))
     end
   end
+
+  describe "Query efficiency for multiple unmapped external budgets" do
+    it "renders multiple unmapped external cards without raising" do
+      # email_account.categories is `through: :expenses`, so expenses anchor the categories.
+      categories = create_list(:category, 2)
+      categories.each do |cat|
+        create(:expense, email_account: email_account, category: cat)
+      end
+
+      3.times do |i|
+        create(:budget,
+          email_account: email_account,
+          category: nil,
+          external_source: "salary_calculator",
+          external_id: 200 + i,
+          name: "Unmapped Budget #{i}")
+      end
+
+      get budgets_path
+
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:category_options)).to be_an(Array)
+      expect(response.body).to include("Unmapped Budget 0", "Unmapped Budget 1", "Unmapped Budget 2")
+      categories.each do |cat|
+        # Each category renders once per unmapped card's dropdown.
+        expect(response.body.scan(cat.display_name).size).to be >= 3
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Post-merge follow-up to [#455](https://github.com/esoto/expense_tracker/pull/455) addressing Codex review findings on the Budget UI:

1. **N+1 query fix**: `budget.email_account.categories.distinct` was evaluated inside `_card.html.erb` for every unmapped external card. Precomputed once into `@category_options` in `BudgetsController#index` and passed as a local.
2. **Accessibility**: the inline category `<select>` had no label. Added a visually-hidden `<label>` (`class: "sr-only"`) using the existing `budgets.pick_category` i18n key.
3. **Regression test**: spec renders 3 unmapped external budgets and asserts each category option appears ≥3 times without raising (guards against the N+1 shape regressing).

## Test plan
- [x] `bundle exec rspec spec/requests/budgets_external_source_spec.rb` (7 examples)
- [x] Pre-commit hook passes full unit suite

## Review complexity
Easy. Surgical — 4 files, 35 lines added.