### PR TITLE
fix(external-sources): OAuth connect CSP + Turbo fixes

### DIFF
--- a/app/views/budgets/_external_source_empty_state.html.erb
+++ b/app/views/budgets/_external_source_empty_state.html.erb
@@ -11,5 +11,6 @@
   <%= button_to t("budgets.empty_state.cta"),
         connect_external_source_path,
         method: :post,
+        data: { turbo: false },
         class: "bg-teal-700 hover:bg-teal-800 text-white font-medium px-5 py-2.5 rounded-lg shadow-sm transition-colors" %>
 </div>

--- a/app/views/external_sources/show.html.erb
+++ b/app/views/external_sources/show.html.erb
@@ -21,6 +21,7 @@
       <%= button_to t("external_sources.connect"),
                     connect_external_source_path,
                     method: :post,
+                    data: { turbo: false },
                     class: "inline-flex items-center gap-2 bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm" %>
     </section>
 
@@ -66,6 +67,7 @@
         <%= button_to t("external_sources.reconnect"),
                       connect_external_source_path,
                       method: :post,
+                      data: { turbo: false },
                       class: "inline-flex items-center gap-2 bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm" %>
         <%= button_to t("external_sources.disconnect"),
                       external_source_path,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,6 +18,13 @@ Rails.application.configure do
     else
       policy.connect_src :self
     end
+
+    # OAuth redirect to salary_calculator — the POST /external_source/connect
+    # responds with a 302 to salary_calc's /oauth/authorize. Without an explicit
+    # form-action allowlist the browser falls back to default-src :self and
+    # blocks the cross-origin redirect. Whitelist the configured base URL.
+    salary_calc_base_url = ENV.fetch("SALARY_CALC_BASE_URL", "https://salary-calc.estebansoto.dev")
+    policy.form_action :self, salary_calc_base_url
   end
 
   # Generate per-request nonces for permitted importmap and inline scripts.


### PR DESCRIPTION
## Summary

Follow-up to [#452-#456](https://github.com/esoto/expense_tracker/pulls?q=is%3Apr+salary-calc) — the OAuth Connect/Reconnect CTAs never actually reach salary_calc because of two issues discovered while doing a local Playwright E2E walkthrough.

### 1. Missing CSP \`form-action\`

\`config/initializers/content_security_policy.rb\` did not set \`form_action\`. CSP falls back to \`default-src :self\`, so the POST \`/external_source/connect\` → 302 \`http://localhost:3000/oauth/authorize\` redirect gets blocked by the browser before salary_calc ever sees the request.

Fix: explicit \`form_action :self, SALARY_CALC_BASE_URL\` — environment-driven so the same config works in dev (\`http://localhost:3000\`) and prod (\`https://salary-calc.estebansoto.dev\`).

### 2. Turbo intercepts the Connect \`button_to\`

Rails 8 ships with Turbo on by default. \`button_to\` submits via Turbo's \`fetch\` instead of a real HTML form submit. \`fetch\` is governed by \`connect-src\` (not \`form-action\`), and redirects from \`fetch\` across origins fail silently.

Fix: \`data: { turbo: false }\` on the three CTA \`button_to\` calls (Connect on empty-state, Connect on settings, Reconnect). That makes the browser perform a full-page form submission, which is governed by \`form-action\` (allowlisted in #1) and properly navigates through the 302.

### Not fixed here
- salary_calc's own Authorize form has the same Turbo issue. Separate PR on that repo.

## How this was found
Ran the full OAuth flow in Playwright with expense_tracker on :3001 and salary_calc on :3000. Click Connect → nothing visible happened → console showed CSP \`connect-src\` violation → traced to Turbo + missing form-action. After both fixes the full flow works: token exchange, \`ExternalBudgetSource\` created with encrypted token, \`ExternalBudgets::PullJob\` pulls 3 BudgetItems, cards render with badge + unmapped banner, category picker saves and clears the banner.

## Test plan
- [x] Manual Playwright E2E — full happy path from empty state → connected → Budget cards with category picker, verified in /tmp/sc-server.log + /tmp/et-server.log.
- [ ] Automated CSP header test (deferred — middleware-level CSP is awkward to isolate in RSpec; the failure is immediately visible in browser dev tools).

## Review complexity
Easy. Three-line diff across two views + a six-line addition to the CSP initializer.