### PR TITLE
feat(user-model): PR 1/14 — users table + User model (no associations yet)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,9 @@ class User < ApplicationRecord
 
   # Class methods
   def self.authenticate(email, password)
-    user = find_by(email: email.downcase)
+    return nil if email.blank?
+
+    user = find_by(email: email.to_s.downcase)
     return nil unless user
 
     if user.locked?
@@ -112,11 +114,14 @@ class User < ApplicationRecord
     regenerate_session_token
   end
 
+  # Atomically increments the failure counter and locks the account when the
+  # threshold is crossed.  `with_lock` acquires a row-level lock, preventing
+  # two concurrent failed-login requests from each reading a stale counter and
+  # skipping the `lock_account!` branch (Codex review, PR #460).
   def handle_failed_login
-    increment!(:failed_login_attempts)
-
-    if failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS
-      lock_account!
+    with_lock do
+      increment!(:failed_login_attempts)
+      lock_account! if failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Application user model with secure authentication and role-based access control
+class User < ApplicationRecord
+  # Use Rails 8's built-in authentication generator patterns
+  has_secure_password
+
+  # Constants
+  MAX_FAILED_LOGIN_ATTEMPTS = 5
+  LOCK_DURATION = 30.minutes
+  SESSION_DURATION = 2.hours
+  PASSWORD_MIN_LENGTH = 12
+
+  # Enums
+  enum :role, {
+    user: 0,
+    admin: 1
+  }, default: :user
+
+  # Validations
+  validates :email, presence: true,
+                   uniqueness: { case_sensitive: false },
+                   format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :password, length: { minimum: PASSWORD_MIN_LENGTH },
+                      format: {
+                        with: /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).+\z/,
+                        message: "must include uppercase, lowercase, number, and special character"
+                      },
+                      if: :password_digest_changed?
+
+  # Callbacks
+  before_save :downcase_email
+  before_create :generate_session_token
+
+  # Scopes
+  scope :active, -> { where(locked_at: nil) }
+  scope :locked, -> { where.not(locked_at: nil) }
+  scope :with_expired_sessions, -> { where("session_expires_at < ?", Time.current) }
+
+  # Class methods
+  def self.authenticate(email, password)
+    user = find_by(email: email.downcase)
+    return nil unless user
+
+    if user.locked?
+      user.check_unlock_eligibility
+      return nil if user.locked?
+    end
+
+    if user.authenticate(password)
+      user.handle_successful_login
+      user
+    else
+      user.handle_failed_login
+      nil
+    end
+  end
+
+  # Looks up a user by session token, returning nil if expired.
+  # PER-213: Session extension is opt-in via `extend: true` (default true for
+  # backward compatibility).  Pass `extend: false` for read-only lookups such
+  # as Turbo Drive prefetch requests, where no user activity has occurred.
+  def self.find_by_valid_session(token, extend: true)
+    return nil if token.blank?
+
+    user = find_by(session_token: token)
+    return nil unless user
+    return nil if user.session_expired?
+
+    # Extend session on activity (skipped for prefetch / read-only lookups)
+    user.extend_session if extend
+    user
+  end
+
+  # Instance methods
+  def locked?
+    locked_at.present? && !unlock_eligible?
+  end
+
+  def unlock_eligible?
+    locked_at.present? && locked_at < LOCK_DURATION.ago
+  end
+
+  def check_unlock_eligibility
+    if unlock_eligible?
+      unlock_account!
+    end
+  end
+
+  def unlock_account!
+    update!(
+      locked_at: nil,
+      failed_login_attempts: 0
+    )
+  end
+
+  def lock_account!
+    update!(
+      locked_at: Time.current,
+      session_token: nil,
+      session_expires_at: nil
+    )
+  end
+
+  def handle_successful_login
+    update!(
+      last_login_at: Time.current,
+      failed_login_attempts: 0,
+      locked_at: nil
+    )
+    regenerate_session_token
+  end
+
+  def handle_failed_login
+    increment!(:failed_login_attempts)
+
+    if failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS
+      lock_account!
+    end
+  end
+
+  def regenerate_session_token
+    update!(
+      session_token: generate_token,
+      session_expires_at: SESSION_DURATION.from_now
+    )
+  end
+
+  def extend_session
+    update!(session_expires_at: SESSION_DURATION.from_now) if session_token.present?
+  end
+
+  def session_expired?
+    session_expires_at.nil? || session_expires_at < Time.current
+  end
+
+  def invalidate_session!
+    update!(
+      session_token: nil,
+      session_expires_at: nil
+    )
+  end
+
+  private
+
+  def downcase_email
+    self.email = email.downcase if email.present?
+  end
+
+  def generate_session_token
+    self.session_token = generate_token
+    self.session_expires_at = SESSION_DURATION.from_now
+  end
+
+  def generate_token
+    SecureRandom.urlsafe_base64(32)
+  end
+end

--- a/db/migrate/20260420120000_create_users.rb
+++ b/db/migrate/20260420120000_create_users.rb
@@ -16,9 +16,11 @@ class CreateUsers < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :users, :email, unique: true
+    add_index :users, "lower(email)", unique: true, name: "index_users_on_lower_email"
     add_index :users, :session_token, unique: true, where: "session_token IS NOT NULL"
     add_index :users, :session_expires_at
     add_index :users, :locked_at
+
+    add_check_constraint :users, "role IN (0, 1)", name: "check_users_role_valid"
   end
 end

--- a/db/migrate/20260420120000_create_users.rb
+++ b/db/migrate/20260420120000_create_users.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+      t.integer :role, null: false, default: 0
+      t.string :name, null: false
+      t.string :session_token
+      t.datetime :session_expires_at
+      t.datetime :last_login_at
+      t.integer :failed_login_attempts, null: false, default: 0
+      t.datetime :locked_at
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, :session_token, unique: true, where: "session_token IS NOT NULL"
+    add_index :users, :session_expires_at
+    add_index :users, :locked_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -785,10 +785,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120000) do
     t.datetime "session_expires_at"
     t.string "session_token"
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
     t.index ["locked_at"], name: "index_users_on_locked_at"
     t.index ["session_expires_at"], name: "index_users_on_session_expires_at"
     t.index ["session_token"], name: "index_users_on_session_token", unique: true, where: "(session_token IS NOT NULL)"
+    t.check_constraint "role = ANY (ARRAY[0, 1])", name: "check_users_role_valid"
   end
 
   add_foreign_key "budgets", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_191023) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -771,6 +771,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_191023) do
     t.index ["context_type", "context_value", "preference_weight"], name: "idx_user_prefs_context_weight"
     t.index ["email_account_id", "context_type", "context_value", "preference_weight"], name: "idx_user_pref_lookup"
     t.index ["preference_weight", "usage_count"], name: "idx_user_pref_priority", where: "(preference_weight >= 5)"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.integer "failed_login_attempts", default: 0, null: false
+    t.datetime "last_login_at"
+    t.datetime "locked_at"
+    t.string "name", null: false
+    t.string "password_digest", null: false
+    t.integer "role", default: 0, null: false
+    t.datetime "session_expires_at"
+    t.string "session_token"
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["locked_at"], name: "index_users_on_locked_at"
+    t.index ["session_expires_at"], name: "index_users_on_session_expires_at"
+    t.index ["session_token"], name: "index_users_on_session_token", unique: true, where: "(session_token IS NOT NULL)"
   end
 
   add_foreign_key "budgets", "categories"

--- a/spec/db/index_audit_per126_spec.rb
+++ b/spec/db/index_audit_per126_spec.rb
@@ -474,7 +474,8 @@ RSpec.describe "PER-126 Index Audit", :unit do
       # +11 for Phase 2 categorization tables (categorization_metrics: 6, categorization_vectors: 3, llm_categorization_cache: 2)
       # +3 for external sources integration (external_budget_sources: 1 unique; budgets external columns: 2;
       #     we dropped the redundant composite idx_ebs_on_account_active)
-      expect(total).to be <= 227  # small buffer for schema drift
+      # +4 for users table (email unique, session_token unique, session_expires_at, locked_at)
+      expect(total).to be <= 231  # small buffer for schema drift
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -12,7 +12,13 @@ FactoryBot.define do
     end
 
     trait :locked do
-      locked_at { Time.current }
+      locked_at { 1.hour.ago }
+      failed_login_attempts { 5 }
+    end
+
+    trait :with_session do
+      session_token { SecureRandom.urlsafe_base64(32) }
+      session_expires_at { 2.hours.from_now }
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "TestPass123!" }
+    name { "Test User" }
+    role { :user }
+
+    trait :admin do
+      role { :admin }
+    end
+
+    trait :locked do
+      locked_at { Time.current }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,21 +189,21 @@ RSpec.describe User, type: :model, unit: true do
     end
 
     describe '.with_expired_sessions' do
-      it 'returns users with expired sessions' do
-        # Mock the scope to return a relation
-        expired_users_relation = double("ActiveRecord::Relation")
-        allow(User).to receive(:with_expired_sessions).and_return(expired_users_relation)
+      it 'returns users with expired sessions and excludes non-expired ones' do
+        expired_user = create(:user)
+        valid_user   = create(:user)
+        nil_user     = create(:user)
 
-        # Mock the expected behavior
-        expired_user = build_stubbed(:user, session_expires_at: 1.hour.ago)
-        valid_user = build_stubbed(:user, session_expires_at: 1.hour.from_now)
-
-        allow(expired_users_relation).to receive(:include?).with(expired_user).and_return(true)
-        allow(expired_users_relation).to receive(:include?).with(valid_user).and_return(false)
+        # before_create sets session_expires_at to 2h from now; override via
+        # update_columns to bypass the callback without rewriting the model.
+        expired_user.update_columns(session_expires_at: 1.hour.ago)
+        valid_user.update_columns(session_expires_at: 1.hour.from_now)
+        nil_user.update_columns(session_expires_at: nil)
 
         result = User.with_expired_sessions
         expect(result).to include(expired_user)
         expect(result).not_to include(valid_user)
+        expect(result).not_to include(nil_user)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,6 +257,12 @@ RSpec.describe User, type: :model, unit: true do
           expect(result).to be_nil
         end
 
+        it 'returns nil for blank email without raising' do
+          expect { User.authenticate(nil, password) }.not_to raise_error
+          expect(User.authenticate(nil, password)).to be_nil
+          expect(User.authenticate('', password)).to be_nil
+        end
+
         it 'increments failed login attempts' do
           User.authenticate(email, 'WrongPassword123@')
           expect(test_user.reload.failed_login_attempts).to eq(1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,567 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model, unit: true do
+  # Use build_stubbed for true unit tests
+  let(:user) { build_stubbed(:user) }
+
+  describe 'validations' do
+    context 'email validation' do
+      it 'requires presence of email' do
+        user = build(:user, email: nil)
+        expect(user).not_to be_valid
+        expect(user.errors[:email]).to include("no puede estar en blanco")
+      end
+
+      it 'validates email format' do
+        invalid_emails = [ 'invalid', 'invalid@', '@example.com', 'user@', 'user space@example.com' ]
+        invalid_emails.each do |invalid_email|
+          user = build(:user, email: invalid_email)
+          expect(user).not_to be_valid
+          expect(user.errors[:email]).to include("no es válido")
+        end
+      end
+
+      it 'accepts valid email formats' do
+        valid_emails = [ 'user@example.com', 'user.name@example.co.uk', 'user+tag@example.org' ]
+        valid_emails.each do |valid_email|
+          user = build(:user, email: valid_email)
+          expect(user).to be_valid
+        end
+      end
+
+      it 'validates email uniqueness case-insensitively' do
+        create(:user, email: 'USER@EXAMPLE.COM')
+        new_user = build(:user, email: 'user@example.com')
+        expect(new_user).not_to be_valid
+        expect(new_user.errors[:email]).to include("ya está en uso")
+      end
+    end
+
+    context 'name validation' do
+      it 'requires presence of name' do
+        user = build(:user, name: nil)
+        expect(user).not_to be_valid
+        expect(user.errors[:name]).to include("no puede estar en blanco")
+      end
+
+      it 'validates name maximum length' do
+        user = build(:user, name: 'a' * 101)
+        expect(user).not_to be_valid
+        expect(user.errors[:name]).to include("es demasiado largo (100 caracteres máximo)")
+      end
+
+      it 'accepts names within length limit' do
+        user = build(:user, name: 'a' * 100)
+        expect(user).to be_valid
+      end
+    end
+
+    context 'password validation' do
+      it 'requires minimum length of 12 characters' do
+        user = build(:user, password: 'Short1@')
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("es demasiado corto (12 caracteres mínimo)")
+      end
+
+      it 'requires uppercase letter' do
+        user = build(:user, password: 'lowercase123@abc')
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("must include uppercase, lowercase, number, and special character")
+      end
+
+      it 'requires lowercase letter' do
+        user = build(:user, password: 'UPPERCASE123@ABC')
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("must include uppercase, lowercase, number, and special character")
+      end
+
+      it 'requires number' do
+        user = build(:user, password: 'NoNumbers@Here')
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("must include uppercase, lowercase, number, and special character")
+      end
+
+      it 'requires special character' do
+        user = build(:user, password: 'NoSpecialChar123')
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("must include uppercase, lowercase, number, and special character")
+      end
+
+      it 'accepts valid passwords' do
+        valid_passwords = [
+          'ValidPass123@',
+          'Another$Pass99',
+          'Complex!Pass2024',
+          'Super@Secure123'
+        ]
+        valid_passwords.each do |password|
+          user = build(:user, password: password, password_confirmation: password)
+          expect(user).to be_valid, "Password '#{password}' should be valid"
+        end
+      end
+
+      it 'only validates password when password_digest changes' do
+        user = create(:user)
+        user.name = 'Updated Name'
+        expect(user).to be_valid
+      end
+    end
+  end
+
+  describe 'enums' do
+    it 'defines role enum with correct values' do
+      expect(User.roles).to eq({
+        'user' => 0,
+        'admin' => 1
+      })
+    end
+
+    it 'defaults to user role' do
+      user = User.new
+      expect(user.role).to eq('user')
+    end
+
+    it 'provides role query methods' do
+      admin_user = build_stubbed(:user, role: :admin)
+      expect(admin_user.admin?).to be true
+      expect(admin_user.user?).to be false
+    end
+  end
+
+  describe 'callbacks' do
+    describe '#downcase_email' do
+      it 'downcases email before save' do
+        user = build(:user, email: 'UPPER@EXAMPLE.COM')
+        user.save
+        expect(user.email).to eq('upper@example.com')
+      end
+
+      it 'handles nil email gracefully' do
+        user = build(:user)
+        user.email = nil
+        expect { user.save }.not_to raise_error
+      end
+    end
+
+    describe '#generate_session_token on create' do
+      it 'generates session token on create' do
+        user = build(:user, session_token: nil)
+        user.save
+        expect(user.session_token).to be_present
+        expect(user.session_token.length).to be >= 32
+      end
+
+      it 'sets session expiration on create' do
+        freeze_time = Time.current
+
+        user = build(:user)
+        user.save
+
+        expect(user.session_expires_at).to be_present
+        expect(user.session_expires_at).to be_within(2.seconds).of(freeze_time + User::SESSION_DURATION)
+      end
+    end
+  end
+
+  describe 'scopes' do
+    describe '.active' do
+      it 'returns users without locked_at' do
+        active_user = create(:user, locked_at: nil)
+        locked_user = create(:user, locked_at: Time.current)
+
+        result = User.active
+        expect(result).to include(active_user)
+        expect(result).not_to include(locked_user)
+      end
+    end
+
+    describe '.locked' do
+      it 'returns users with locked_at' do
+        active_user = create(:user, locked_at: nil)
+        locked_user = create(:user, locked_at: Time.current)
+
+        result = User.locked
+        expect(result).not_to include(active_user)
+        expect(result).to include(locked_user)
+      end
+    end
+
+    describe '.with_expired_sessions' do
+      it 'returns users with expired sessions' do
+        # Mock the scope to return a relation
+        expired_users_relation = double("ActiveRecord::Relation")
+        allow(User).to receive(:with_expired_sessions).and_return(expired_users_relation)
+
+        # Mock the expected behavior
+        expired_user = build_stubbed(:user, session_expires_at: 1.hour.ago)
+        valid_user = build_stubbed(:user, session_expires_at: 1.hour.from_now)
+
+        allow(expired_users_relation).to receive(:include?).with(expired_user).and_return(true)
+        allow(expired_users_relation).to receive(:include?).with(valid_user).and_return(false)
+
+        result = User.with_expired_sessions
+        expect(result).to include(expired_user)
+        expect(result).not_to include(valid_user)
+      end
+    end
+  end
+
+  describe 'class methods' do
+    describe '.authenticate' do
+      let(:email) { 'test@example.com' }
+      let(:password) { 'ValidPass123@' }
+      let!(:test_user) { create(:user, email: email, password: password) }
+
+      context 'with valid credentials' do
+        it 'returns the user' do
+          result = User.authenticate(email, password)
+          expect(result).to eq(test_user)
+        end
+
+        it 'handles uppercase email' do
+          result = User.authenticate('TEST@EXAMPLE.COM', password)
+          expect(result).to eq(test_user)
+        end
+
+        it 'resets failed login attempts' do
+          test_user.update(failed_login_attempts: 3)
+          User.authenticate(email, password)
+          expect(test_user.reload.failed_login_attempts).to eq(0)
+        end
+
+        it 'updates last_login_at' do
+          freeze_time = Time.current
+          allow(Time).to receive(:current).and_return(freeze_time)
+
+          User.authenticate(email, password)
+          expect(test_user.reload.last_login_at).to be_within(1.second).of(freeze_time)
+        end
+
+        it 'regenerates session token' do
+          old_token = test_user.session_token
+          User.authenticate(email, password)
+          expect(test_user.reload.session_token).not_to eq(old_token)
+        end
+      end
+
+      context 'with invalid credentials' do
+        it 'returns nil for wrong password' do
+          result = User.authenticate(email, 'WrongPassword123@')
+          expect(result).to be_nil
+        end
+
+        it 'returns nil for non-existent email' do
+          result = User.authenticate('nonexistent@example.com', password)
+          expect(result).to be_nil
+        end
+
+        it 'increments failed login attempts' do
+          User.authenticate(email, 'WrongPassword123@')
+          expect(test_user.reload.failed_login_attempts).to eq(1)
+        end
+
+        it 'locks account after max failed attempts' do
+          User::MAX_FAILED_LOGIN_ATTEMPTS.times do
+            User.authenticate(email, 'WrongPassword123@')
+          end
+          expect(test_user.reload.locked_at).to be_present
+        end
+      end
+
+      context 'with locked account' do
+        before do
+          test_user.update(locked_at: Time.current, failed_login_attempts: 5)
+        end
+
+        it 'returns nil even with correct password' do
+          result = User.authenticate(email, password)
+          expect(result).to be_nil
+        end
+
+        it 'unlocks account after lock duration' do
+          test_user.update(locked_at: (User::LOCK_DURATION + 1.minute).ago)
+          result = User.authenticate(email, password)
+          expect(result).to eq(test_user)
+          expect(test_user.reload.locked_at).to be_nil
+        end
+      end
+    end
+
+    describe '.find_by_valid_session' do
+      let(:test_user) { create(:user) }
+
+      context 'with valid session' do
+        it 'returns the user' do
+          test_user.update(session_expires_at: 1.hour.from_now)
+          result = User.find_by_valid_session(test_user.session_token)
+          expect(result).to eq(test_user)
+        end
+
+        it 'extends session on activity' do
+          freeze_time = Time.current
+          allow(Time).to receive(:current).and_return(freeze_time)
+
+          test_user.update(session_expires_at: 30.minutes.from_now)
+          User.find_by_valid_session(test_user.session_token)
+
+          expected_expiration = freeze_time + User::SESSION_DURATION
+          expect(test_user.reload.session_expires_at).to be_within(1.second).of(expected_expiration)
+        end
+      end
+
+      context 'with invalid session' do
+        it 'returns nil for blank token' do
+          result = User.find_by_valid_session(nil)
+          expect(result).to be_nil
+
+          result = User.find_by_valid_session('')
+          expect(result).to be_nil
+        end
+
+        it 'returns nil for non-existent token' do
+          result = User.find_by_valid_session('nonexistent_token')
+          expect(result).to be_nil
+        end
+
+        it 'returns nil for expired session' do
+          test_user.update(session_expires_at: 1.hour.ago)
+          result = User.find_by_valid_session(test_user.session_token)
+          expect(result).to be_nil
+        end
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    describe '#locked?' do
+      it 'returns true when locked and not eligible for unlock' do
+        user = build_stubbed(:user, locked_at: 5.minutes.ago)
+        expect(user.locked?).to be true
+      end
+
+      it 'returns false when not locked' do
+        user = build_stubbed(:user, locked_at: nil)
+        expect(user.locked?).to be false
+      end
+
+      it 'returns false when eligible for unlock' do
+        user = build_stubbed(:user, locked_at: (User::LOCK_DURATION + 1.minute).ago)
+        expect(user.locked?).to be false
+      end
+    end
+
+    describe '#unlock_eligible?' do
+      it 'returns true when lock duration has passed' do
+        user = build_stubbed(:user, locked_at: (User::LOCK_DURATION + 1.minute).ago)
+        expect(user.unlock_eligible?).to be true
+      end
+
+      it 'returns false when lock duration has not passed' do
+        user = build_stubbed(:user, locked_at: 5.minutes.ago)
+        expect(user.unlock_eligible?).to be false
+      end
+
+      it 'returns false when not locked' do
+        user = build_stubbed(:user, locked_at: nil)
+        expect(user.unlock_eligible?).to be false
+      end
+    end
+
+    describe '#check_unlock_eligibility' do
+      it 'unlocks account when eligible' do
+        user = create(:user, locked_at: (User::LOCK_DURATION + 1.minute).ago)
+        user.check_unlock_eligibility
+        expect(user.reload.locked_at).to be_nil
+      end
+
+      it 'does not unlock when not eligible' do
+        user = create(:user, locked_at: 5.minutes.ago)
+        user.check_unlock_eligibility
+        expect(user.reload.locked_at).to be_present
+      end
+    end
+
+    describe '#unlock_account!' do
+      it 'clears locked_at and failed_login_attempts' do
+        user = create(:user, locked_at: Time.current, failed_login_attempts: 5)
+        user.unlock_account!
+
+        user.reload
+        expect(user.locked_at).to be_nil
+        expect(user.failed_login_attempts).to eq(0)
+      end
+    end
+
+    describe '#lock_account!' do
+      it 'sets locked_at and clears session' do
+        freeze_time = Time.current
+        allow(Time).to receive(:current).and_return(freeze_time)
+
+        user = create(:user, session_token: 'token', session_expires_at: 1.hour.from_now)
+        user.lock_account!
+
+        user.reload
+        expect(user.locked_at).to be_within(1.second).of(freeze_time)
+        expect(user.session_token).to be_nil
+        expect(user.session_expires_at).to be_nil
+      end
+    end
+
+    describe '#handle_successful_login' do
+      it 'updates login tracking fields' do
+        freeze_time = Time.current
+        allow(Time).to receive(:current).and_return(freeze_time)
+
+        user = create(:user, failed_login_attempts: 3, locked_at: 1.hour.ago)
+        old_token = user.session_token
+
+        user.handle_successful_login
+
+        user.reload
+        expect(user.last_login_at).to be_within(1.second).of(freeze_time)
+        expect(user.failed_login_attempts).to eq(0)
+        expect(user.locked_at).to be_nil
+        expect(user.session_token).not_to eq(old_token)
+      end
+    end
+
+    describe '#handle_failed_login' do
+      it 'increments failed login attempts' do
+        user = create(:user, failed_login_attempts: 2)
+        user.handle_failed_login
+        expect(user.reload.failed_login_attempts).to eq(3)
+      end
+
+      it 'locks account after max attempts' do
+        user = create(:user, failed_login_attempts: User::MAX_FAILED_LOGIN_ATTEMPTS - 1)
+        user.handle_failed_login
+        expect(user.reload.locked_at).to be_present
+      end
+    end
+
+    describe '#regenerate_session_token' do
+      it 'generates new token and sets expiration' do
+        freeze_time = Time.current
+        allow(Time).to receive(:current).and_return(freeze_time)
+
+        user = create(:user)
+        old_token = user.session_token
+
+        user.regenerate_session_token
+
+        user.reload
+        expect(user.session_token).not_to eq(old_token)
+        expect(user.session_token).to be_present
+        expected_expiration = freeze_time + User::SESSION_DURATION
+        expect(user.session_expires_at).to be_within(1.second).of(expected_expiration)
+      end
+    end
+
+    describe '#extend_session' do
+      it 'extends session expiration when token present' do
+        freeze_time = Time.current
+        allow(Time).to receive(:current).and_return(freeze_time)
+
+        user = create(:user, session_token: 'token', session_expires_at: 30.minutes.from_now)
+        user.extend_session
+
+        expected_expiration = freeze_time + User::SESSION_DURATION
+        expect(user.reload.session_expires_at).to be_within(1.second).of(expected_expiration)
+      end
+
+      it 'does nothing when no session token' do
+        user = create(:user)
+        user.update_columns(session_token: nil, session_expires_at: nil)
+        user.extend_session
+        expect(user.reload.session_expires_at).to be_nil
+      end
+    end
+
+    describe '#session_expired?' do
+      it 'returns true when session_expires_at is nil' do
+        user = build_stubbed(:user, session_expires_at: nil)
+        expect(user.session_expired?).to be true
+      end
+
+      it 'returns true when session has expired' do
+        user = build_stubbed(:user, session_expires_at: 1.hour.ago)
+        expect(user.session_expired?).to be true
+      end
+
+      it 'returns false when session is valid' do
+        user = build_stubbed(:user, session_expires_at: 1.hour.from_now)
+        expect(user.session_expired?).to be false
+      end
+    end
+
+    describe '#invalidate_session!' do
+      it 'clears session token and expiration' do
+        user = create(:user, session_token: 'token', session_expires_at: 1.hour.from_now)
+        user.invalidate_session!
+
+        user.reload
+        expect(user.session_token).to be_nil
+        expect(user.session_expires_at).to be_nil
+      end
+    end
+  end
+
+  describe 'constants' do
+    it 'defines expected constants' do
+      expect(User::MAX_FAILED_LOGIN_ATTEMPTS).to eq(5)
+      expect(User::LOCK_DURATION).to eq(30.minutes)
+      expect(User::SESSION_DURATION).to eq(2.hours)
+      expect(User::PASSWORD_MIN_LENGTH).to eq(12)
+    end
+  end
+
+  describe 'edge cases' do
+    describe 'concurrent login attempts' do
+      it 'handles race condition in failed login counting' do
+        user = create(:user, failed_login_attempts: 4)
+
+        initial_attempts = user.failed_login_attempts
+
+        user.handle_failed_login
+
+        user.reload
+        expect(user.failed_login_attempts).to eq(initial_attempts + 1)
+        expect(user.locked_at).to be_present, "User should be locked after reaching max failed attempts"
+
+        expect { user.handle_failed_login }.not_to raise_error
+        user.reload
+        expect(user.locked_at).to be_present, "User should remain locked"
+      end
+    end
+
+    describe 'password with special regex characters' do
+      it 'handles passwords with regex special characters' do
+        special_passwords = [
+          'Valid$Pass123',
+          'Valid.Pass123!',
+          'Valid*Pass123?',
+          'Valid+Pass123&',
+          'Valid(Pass)123@'
+        ]
+
+        special_passwords.each do |password|
+          user = build(:user, password: password, password_confirmation: password)
+          expect(user).to be_valid, "Password '#{password}' should be valid"
+        end
+      end
+    end
+
+    describe 'session token uniqueness' do
+      it 'generates unique tokens' do
+        tokens = []
+        10.times do |i|
+          user = create(:user, email: "test_user_#{i}@example.com")
+          expect(tokens).not_to include(user.session_token)
+          tokens << user.session_token
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First of 14 PRs introducing a unified \`User\` model with role-based access, per plan at \`~/.claude/plans/i-need-you-to-radiant-curry.md\`.

This PR is intentionally **isolated**: it creates the \`users\` table and \`User\` model, but wires it to **nothing** (no associations, no auth routes, no controller changes). Everything in the running app continues to work exactly as before.

### What's in

- Migration \`CreateUsers\` — email, password_digest, role enum (\`{user: 0, admin: 1}\`), name, session token/expiry, lockout fields. Case-insensitive unique index on \`lower(email)\`, check constraint on role, partial unique index on session_token.
- \`app/models/user.rb\` — verbatim port of \`AdminUser\`'s security-critical logic (\`has_secure_password\`, 5-attempt lockout, 30-min lock, 2-hour session with PER-213 prefetch-safe extension). Two role levels instead of four. No associations.
- \`spec/models/user_spec.rb\` (64 examples) — ports the relevant AdminUser specs.
- \`spec/factories/user.rb\` — \`:user\` default, \`:admin\`, \`:locked\`, \`:with_session\` traits.
- \`spec/db/index_audit_per126_spec.rb\` — index ceiling raised 227 → 231 (4 new indexes).

### What's NOT in

- No associations on \`User\` — those are added incrementally in PRs 4–13.
- No \`Authentication\` concern, no \`/login\` route, no \`SessionsController\` — that's **PR 2**.
- No default user seeding, \`AdminUser\` untouched — that's **PR 3**.

### Review workflow applied (per project CLAUDE.md)

1. \`tdd-feature-developer\` (Sonnet) built the initial implementation.
2. **Domain architect review in parallel:**
   - \`database-architect\` → APPROVE-WITH-CHANGES → applied: \`lower(email)\` functional unique index + role check constraint.
   - \`backend-architect\` → APPROVE-WITH-CHANGES → applied: \`:locked\` trait completeness, added \`:with_session\` trait, rewrote \`.with_expired_sessions\` scope test with real records.
3. Rubocop + Brakeman clean, full unit suite green (1 unrelated flaky engine spec — passes in isolation).

## Test plan

- [x] \`TEST_ENV_NUMBER=pr1 bundle exec rspec spec/models/user_spec.rb --tag unit\` — 64/64 pass
- [x] \`TEST_ENV_NUMBER=pr1 bundle exec rspec --tag unit\` — full suite green modulo known flake
- [x] \`bundle exec rubocop\` on touched files — 0 offenses
- [x] \`bundle exec brakeman -q\` — 0 warnings
- [x] Migration reversibility: \`db:migrate\` → \`db:rollback\` → \`db:migrate\` clean
- [ ] Codex review requested below

## Follow-ups for subsequent PRs

- **PR 2:** port \`AdminAuthentication\` concern → \`Authentication\`, add \`SessionsController\`, \`/login\` route.
- **PR 3:** backfill default \`User\` from \`AdminUser\`.
- **PR 10:** \`bulk_operations.user_id\` is currently a \`string\` — will need a type-change migration to a bigint FK.