### PR TITLE
feat(auth): PR 2b/14 — /login view styled with Financial Confidence palette (frontend)

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen flex items-center justify-center bg-slate-50 py-12 px-4 sm:px-6 lg:px-8">
+<main class="min-h-screen flex items-center justify-center bg-slate-50 py-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-md w-full">
     <!-- Flash messages -->
     <% if flash[:alert] %>
@@ -25,7 +25,7 @@
         <div>
           <%= f.label :email, "Email", class: "block text-sm font-semibold text-slate-700 mb-1" %>
           <%= f.email_field :email,
-                class: "form-input appearance-none rounded-lg relative block w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 focus:z-10 sm:text-sm",
+                class: "form-input appearance-none rounded-lg w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm",
                 placeholder: "you@example.com",
                 required: true,
                 autocomplete: "email" %>
@@ -35,7 +35,7 @@
         <div>
           <%= f.label :password, "Password", class: "block text-sm font-semibold text-slate-700 mb-1" %>
           <%= f.password_field :password,
-                class: "form-input appearance-none rounded-lg relative block w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 focus:z-10 sm:text-sm",
+                class: "form-input appearance-none rounded-lg w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm",
                 placeholder: "••••••••••••",
                 required: true,
                 value: "",
@@ -45,7 +45,7 @@
         <!-- Submit button -->
         <div>
           <%= f.submit "Sign in",
-                class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-teal-700 hover:bg-teal-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition-colors duration-200" %>
+                class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-teal-700 hover:bg-teal-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition-colors duration-200" %>
         </div>
       <% end %>
     </div>
@@ -58,4 +58,4 @@
       </p>
     </div>
   </div>
-</div>
+</main>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,25 +1,61 @@
-<h1>Sign in</h1>
+<div class="min-h-screen flex items-center justify-center bg-slate-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full">
+    <!-- Flash messages -->
+    <% if flash[:alert] %>
+      <div id="flash-alert" class="mb-6 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 text-sm text-rose-700" aria-live="polite">
+        <%= flash[:alert] %>
+      </div>
+    <% end %>
 
-<% if flash[:alert] %>
-  <p id="flash-alert"><%= flash[:alert] %></p>
-<% end %>
+    <% if flash[:notice] %>
+      <div id="flash-notice" class="mb-6 bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 text-sm text-emerald-700" aria-live="polite">
+        <%= flash[:notice] %>
+      </div>
+    <% end %>
 
-<% if flash[:notice] %>
-  <p id="flash-notice"><%= flash[:notice] %></p>
-<% end %>
+    <!-- Header -->
+    <div class="text-center mb-8">
+      <h1 class="text-3xl font-bold text-slate-900">Sign in</h1>
+    </div>
 
-<%= form_with url: login_path, method: :post, local: true do |f| %>
-  <div>
-    <%= f.label :email, "Email" %>
-    <%= f.email_field :email, class: "w-full p-2 border", autocomplete: "email" %>
+    <!-- Login form -->
+    <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-8">
+      <%= form_with url: login_path, method: :post, local: true, class: "space-y-6" do |f| %>
+        <!-- Email field -->
+        <div>
+          <%= f.label :email, "Email", class: "block text-sm font-semibold text-slate-700 mb-1" %>
+          <%= f.email_field :email,
+                class: "form-input appearance-none rounded-lg relative block w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 focus:z-10 sm:text-sm",
+                placeholder: "you@example.com",
+                required: true,
+                autocomplete: "email" %>
+        </div>
+
+        <!-- Password field -->
+        <div>
+          <%= f.label :password, "Password", class: "block text-sm font-semibold text-slate-700 mb-1" %>
+          <%= f.password_field :password,
+                class: "form-input appearance-none rounded-lg relative block w-full px-3 py-2 border border-slate-300 placeholder-slate-500 text-slate-900 focus:outline-none focus:ring-teal-500 focus:border-teal-500 focus:z-10 sm:text-sm",
+                placeholder: "••••••••••••",
+                required: true,
+                value: "",
+                autocomplete: "current-password" %>
+        </div>
+
+        <!-- Submit button -->
+        <div>
+          <%= f.submit "Sign in",
+                class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-teal-700 hover:bg-teal-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition-colors duration-200" %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- Admin link -->
+    <div class="mt-6 text-center">
+      <p class="text-sm text-slate-500">
+        Need admin access?
+        <%= link_to "/admin/login", "/admin/login", class: "text-teal-600 hover:text-teal-700 font-medium" %>
+      </p>
+    </div>
   </div>
-
-  <div>
-    <%= f.label :password, "Password" %>
-    <%= f.password_field :password, class: "w-full p-2 border", autocomplete: "current-password", value: "" %>
-  </div>
-
-  <div>
-    <%= f.submit "Sign in" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,13 +2,13 @@
   <div class="max-w-md w-full">
     <!-- Flash messages -->
     <% if flash[:alert] %>
-      <div id="flash-alert" class="mb-6 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 text-sm text-rose-700" aria-live="polite">
+      <div id="flash-alert" class="mb-6 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 text-sm text-rose-700" role="alert">
         <%= flash[:alert] %>
       </div>
     <% end %>
 
     <% if flash[:notice] %>
-      <div id="flash-notice" class="mb-6 bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 text-sm text-emerald-700" aria-live="polite">
+      <div id="flash-notice" class="mb-6 bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 text-sm text-emerald-700" role="status">
         <%= flash[:notice] %>
       </div>
     <% end %>
@@ -54,7 +54,7 @@
     <div class="mt-6 text-center">
       <p class="text-sm text-slate-500">
         Need admin access?
-        <%= link_to "/admin/login", "/admin/login", class: "text-teal-600 hover:text-teal-700 font-medium" %>
+        <%= link_to "Admin login", admin_login_path, class: "text-teal-600 hover:text-teal-700 font-medium" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
PR 2b of 14. Frontend-only follow-up to PR 2a: replaces the 25-LOC scaffold /login view with a 62-LOC styled page using the project's teal/amber Financial Confidence palette. No backend changes.

**Implementation:** Haiku agent.

**Review chain:**
1. frontend-architect — APPROVE-WITH-CHANGES → 2 blockers applied: role='alert' on flash-alert + role='status' on flash-notice (replaces aria-live='polite' — WCAG 4.1.3, matches project shared/_flash pattern). link_to argument order corrected — was rendering the URL as anchor text; now uses 'Admin login' label + admin_login_path helper (WCAG 2.4.6).
2. Palette compliance: PASS — grep confirmed zero forbidden color classes (blue-/gray-/red-/yellow-/green-).

**Verification:**
- TEST_ENV_NUMBER=pr2b bundle exec rspec spec/requests/sessions_spec.rb → 32/32 green (unchanged from PR 2a).
- Pre-commit hook (rubocop + brakeman + unit-tagged specs) passed both commits.

**Scope:** 1 file, 62 LOC (was 25).