### PR TITLE
feat(learning): PR 9/14 — learning signals cluster user_id (3 tables)

### DIFF
--- a/app/controllers/admin/patterns_controller.rb
+++ b/app/controllers/admin/patterns_controller.rb
@@ -527,6 +527,8 @@ module Admin
       end_date = Date.current
       start_date = end_date - days.days
 
+      # FIXME(PR-12): platform-admin aggregation, intentionally cross-user.
+      # PR 12 decides whether this dashboard stays global or splits per-admin.
       daily_stats = PatternFeedback
         .where(created_at: start_date..end_date)
         .group("DATE(created_at)", :was_correct)

--- a/app/models/categorization_metric.rb
+++ b/app/models/categorization_metric.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 class CategorizationMetric < ApplicationRecord
+  belongs_to :user
   belongs_to :expense
   belongs_to :category, optional: true
   belongs_to :corrected_to_category, class_name: "Category", optional: true
@@ -10,4 +13,5 @@ class CategorizationMetric < ApplicationRecord
   scope :uncorrected, -> { where(was_corrected: false) }
   scope :for_layer, ->(layer) { where(layer_used: layer) }
   scope :recent, ->(period = 30.days) { where(created_at: period.ago..) }
+  scope :for_user, ->(user) { where(user: user) }
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -161,6 +161,7 @@ class Expense < ApplicationRecord
 
       # Create learning event for pattern improvement
       pattern_learning_events.create!(
+        user: user,
         category_id: new_category_id,
         pattern_used: "manual_correction",
         was_correct: true,
@@ -187,6 +188,7 @@ class Expense < ApplicationRecord
       self.ml_suggested_category_id = nil
 
       pattern_learning_events.create!(
+        user: user,
         category_id: category_id || dismissed_category_id,
         pattern_used: "dismissed_suggestion",
         was_correct: false,

--- a/app/models/pattern_feedback.rb
+++ b/app/models/pattern_feedback.rb
@@ -2,9 +2,12 @@
 
 class PatternFeedback < ApplicationRecord
   include CacheVersioning
+  belongs_to :user
   belongs_to :categorization_pattern, optional: true
   belongs_to :expense
   belongs_to :category # The correct category from the migration schema
+
+  scope :for_user, ->(user) { where(user: user) }
 
   validates :feedback_type, presence: true, inclusion: { in: %w[accepted rejected corrected correction] }
 
@@ -24,6 +27,7 @@ class PatternFeedback < ApplicationRecord
   def self.record_feedback(expense:, correct_category:, pattern: nil, was_correct:, confidence: nil, type: "confirmation")
     create!(
       expense: expense,
+      user: expense.user,
       category: correct_category,
       categorization_pattern: pattern,
       was_correct: was_correct,

--- a/app/models/pattern_learning_event.rb
+++ b/app/models/pattern_learning_event.rb
@@ -2,8 +2,11 @@
 
 class PatternLearningEvent < ApplicationRecord
   include CacheVersioning
+  belongs_to :user
   belongs_to :expense
   belongs_to :category
+
+  scope :for_user, ->(user) { where(user: user) }
 
   validates :pattern_used, presence: true
   validates :was_correct, inclusion: { in: [ true, false ] }
@@ -28,6 +31,7 @@ class PatternLearningEvent < ApplicationRecord
 
     create!(
       expense: expense,
+      user: expense.user,
       category: category,
       pattern_used: pattern_name,
       was_correct: was_correct,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,9 @@ class User < ApplicationRecord
   has_many :user_category_preferences, dependent: :restrict_with_exception
   has_many :external_budget_sources, dependent: :restrict_with_exception
   has_many :undo_histories, dependent: :restrict_with_exception
+  has_many :pattern_feedbacks, dependent: :restrict_with_exception
+  has_many :pattern_learning_events, dependent: :restrict_with_exception
+  has_many :categorization_metrics, dependent: :restrict_with_exception
 
   # Enums
   enum :role, {

--- a/app/services/categorization/enhanced_categorization_service.rb
+++ b/app/services/categorization/enhanced_categorization_service.rb
@@ -188,6 +188,7 @@ module Services::Categorization
 
       PatternLearningEvent.create!(
         expense: expense,
+        user: expense.user,
         category: category,
         pattern_used: pattern_name,
         was_correct: was_correct,

--- a/app/services/categorization/learning/metrics_recorder.rb
+++ b/app/services/categorization/learning/metrics_recorder.rb
@@ -18,6 +18,7 @@ module Services::Categorization
       def record(expense:, result:, layer_name:, api_cost: 0)
         CategorizationMetric.create!(
           expense: expense,
+          user: expense.user,
           layer_used: layer_name,
           confidence: result.successful? ? result.confidence : nil,
           category: result.successful? ? result.category : nil,

--- a/app/services/categorization/monitoring/metrics_dashboard_service.rb
+++ b/app/services/categorization/monitoring/metrics_dashboard_service.rb
@@ -4,6 +4,11 @@ module Services::Categorization
   module Monitoring
     # Aggregates categorization metrics for the admin dashboard.
     # Uses single-query conditional aggregation for efficiency.
+    #
+    # FIXME(PR-12): all CategorizationMetric queries here are intentionally
+    # cross-user — this is a platform-admin dashboard. PR 12 will decide
+    # whether this stays global or splits into per-admin + platform surfaces.
+    # Access is already admin-gated via Admin::BaseController callers.
     class MetricsDashboardService
       def overview(period: 30.days)
         result = CategorizationMetric.recent(period).pick(

--- a/app/services/categorization/pattern_learner.rb
+++ b/app/services/categorization/pattern_learner.rb
@@ -607,6 +607,7 @@ module Services::Categorization
 
       feedback = PatternFeedback.create!(
         expense: expense,
+        user: expense.user,
         category: correct_category,
         was_correct: was_correct,
         feedback_type: feedback_type
@@ -633,6 +634,7 @@ module Services::Categorization
 
       PatternLearningEvent.create!(
         expense: expense,
+        user: expense.user,
         category: category,
         pattern_used: pattern ? "#{pattern.pattern_type}:#{pattern.pattern_value}" : "manual",
         was_correct: true,

--- a/db/migrate/20260421130000_add_user_to_pattern_feedbacks.rb
+++ b/db/migrate/20260421130000_add_user_to_pattern_feedbacks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Adds the `user_id` FK to `pattern_feedbacks` as a nullable column.
+# The backfill runs in the next migration; the NOT NULL flip runs in the one
+# after that.
+#
+# The index is created with `algorithm: :concurrently` so production writes
+# are not blocked during deploy.  That forces `disable_ddl_transaction!`.
+class AddUserToPatternFeedbacks < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :pattern_feedbacks, :user, foreign_key: true, index: false, null: true
+    add_index :pattern_feedbacks, :user_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260421130100_backfill_pattern_feedbacks_user_id.rb
+++ b/db/migrate/20260421130100_backfill_pattern_feedbacks_user_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class BackfillPatternFeedbacksUserId < ActiveRecord::Migration[8.1]
+  # Local anonymous models isolate this migration from future class changes.
+  class MigrationPatternFeedback < ActiveRecord::Base
+    self.table_name = "pattern_feedbacks"
+  end
+
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  def up
+    default_user = MigrationUser.where(role: 1).order(:id).first
+
+    if default_user.nil?
+      raise ActiveRecord::MigrationError,
+        "No admin User found — run PR 3 migration (CreateDefaultUserFromAdminUsers) first."
+    end
+
+    # Prefer inheriting user_id from the associated expense where available.
+    # Fall back to the default admin user for any orphaned or already-null rows.
+    ActiveRecord::Base.transaction do
+      # Rows whose expense has a user_id — inherit from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE pattern_feedbacks pf
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE pf.expense_id = e.id
+          AND pf.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      # Remaining NULL rows — assign to first admin user
+      MigrationPatternFeedback.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+  end
+
+  # Data migration — cannot safely determine which rows had a NULL user_id
+  # before the backfill ran, so reversal would silently destroy ownership data.
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "BackfillPatternFeedbacksUserId is a one-way data migration. " \
+      "Rows cannot be safely reverted to NULL without knowing prior state."
+  end
+end

--- a/db/migrate/20260421130200_make_pattern_feedbacks_user_id_not_null.rb
+++ b/db/migrate/20260421130200_make_pattern_feedbacks_user_id_not_null.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MakePatternFeedbacksUserIdNotNull < ActiveRecord::Migration[8.1]
+  # Local anonymous models — PR 14 may remove AdminUser but this migration
+  # must still run. Matches the pattern established in the backfill migration.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  class MigrationPatternFeedback < ActiveRecord::Base
+    self.table_name = "pattern_feedbacks"
+  end
+
+  def up
+    # Re-run the backfill immediately before the NOT NULL flip to close the
+    # narrow race between the backfill migration and this one. A concurrent
+    # insert from an old code path could have written a NULL user_id after
+    # the backfill ran but before this migration locks the column.
+    null_count = MigrationPatternFeedback.where(user_id: nil).count
+    if null_count.positive?
+      default_user = MigrationUser.where(role: 1).order(:id).first
+      raise ActiveRecord::MigrationError,
+        "Found #{null_count} pattern_feedbacks with NULL user_id but no admin User " \
+        "exists. Run PR 3 migration first." unless default_user
+
+      # Prefer inheriting from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE pattern_feedbacks pf
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE pf.expense_id = e.id
+          AND pf.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      MigrationPatternFeedback.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+
+    change_column_null :pattern_feedbacks, :user_id, false
+  end
+
+  def down
+    change_column_null :pattern_feedbacks, :user_id, true
+  end
+end

--- a/db/migrate/20260421130300_add_user_to_pattern_learning_events.rb
+++ b/db/migrate/20260421130300_add_user_to_pattern_learning_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Adds the `user_id` FK to `pattern_learning_events` as a nullable column.
+# The backfill runs in the next migration; the NOT NULL flip runs in the one
+# after that.
+#
+# The index is created with `algorithm: :concurrently` so production writes
+# are not blocked during deploy.  That forces `disable_ddl_transaction!`.
+class AddUserToPatternLearningEvents < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :pattern_learning_events, :user, foreign_key: true, index: false, null: true
+    add_index :pattern_learning_events, :user_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260421130400_backfill_pattern_learning_events_user_id.rb
+++ b/db/migrate/20260421130400_backfill_pattern_learning_events_user_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class BackfillPatternLearningEventsUserId < ActiveRecord::Migration[8.1]
+  # Local anonymous models isolate this migration from future class changes.
+  class MigrationPatternLearningEvent < ActiveRecord::Base
+    self.table_name = "pattern_learning_events"
+  end
+
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  def up
+    default_user = MigrationUser.where(role: 1).order(:id).first
+
+    if default_user.nil?
+      raise ActiveRecord::MigrationError,
+        "No admin User found — run PR 3 migration (CreateDefaultUserFromAdminUsers) first."
+    end
+
+    # Prefer inheriting user_id from the associated expense where available.
+    # Fall back to the default admin user for any orphaned or already-null rows.
+    ActiveRecord::Base.transaction do
+      # Rows whose expense has a user_id — inherit from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE pattern_learning_events ple
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE ple.expense_id = e.id
+          AND ple.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      # Remaining NULL rows — assign to first admin user
+      MigrationPatternLearningEvent.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+  end
+
+  # Data migration — cannot safely determine which rows had a NULL user_id
+  # before the backfill ran, so reversal would silently destroy ownership data.
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "BackfillPatternLearningEventsUserId is a one-way data migration. " \
+      "Rows cannot be safely reverted to NULL without knowing prior state."
+  end
+end

--- a/db/migrate/20260421130500_make_pattern_learning_events_user_id_not_null.rb
+++ b/db/migrate/20260421130500_make_pattern_learning_events_user_id_not_null.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MakePatternLearningEventsUserIdNotNull < ActiveRecord::Migration[8.1]
+  # Local anonymous models — PR 14 may remove AdminUser but this migration
+  # must still run. Matches the pattern established in the backfill migration.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  class MigrationPatternLearningEvent < ActiveRecord::Base
+    self.table_name = "pattern_learning_events"
+  end
+
+  def up
+    # Re-run the backfill immediately before the NOT NULL flip to close the
+    # narrow race between the backfill migration and this one. A concurrent
+    # insert from an old code path could have written a NULL user_id after
+    # the backfill ran but before this migration locks the column.
+    null_count = MigrationPatternLearningEvent.where(user_id: nil).count
+    if null_count.positive?
+      default_user = MigrationUser.where(role: 1).order(:id).first
+      raise ActiveRecord::MigrationError,
+        "Found #{null_count} pattern_learning_events with NULL user_id but no admin User " \
+        "exists. Run PR 3 migration first." unless default_user
+
+      # Prefer inheriting from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE pattern_learning_events ple
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE ple.expense_id = e.id
+          AND ple.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      MigrationPatternLearningEvent.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+
+    change_column_null :pattern_learning_events, :user_id, false
+  end
+
+  def down
+    change_column_null :pattern_learning_events, :user_id, true
+  end
+end

--- a/db/migrate/20260421130600_add_user_to_categorization_metrics.rb
+++ b/db/migrate/20260421130600_add_user_to_categorization_metrics.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Adds the `user_id` FK to `categorization_metrics` as a nullable column.
+# The backfill runs in the next migration; the NOT NULL flip runs in the one
+# after that.
+#
+# The index is created with `algorithm: :concurrently` so production writes
+# are not blocked during deploy.  That forces `disable_ddl_transaction!`.
+class AddUserToCategorizationMetrics < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :categorization_metrics, :user, foreign_key: true, index: false, null: true
+    add_index :categorization_metrics, :user_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260421130700_backfill_categorization_metrics_user_id.rb
+++ b/db/migrate/20260421130700_backfill_categorization_metrics_user_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class BackfillCategorizationMetricsUserId < ActiveRecord::Migration[8.1]
+  # Local anonymous models isolate this migration from future class changes.
+  class MigrationCategorizationMetric < ActiveRecord::Base
+    self.table_name = "categorization_metrics"
+  end
+
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  def up
+    default_user = MigrationUser.where(role: 1).order(:id).first
+
+    if default_user.nil?
+      raise ActiveRecord::MigrationError,
+        "No admin User found — run PR 3 migration (CreateDefaultUserFromAdminUsers) first."
+    end
+
+    # Prefer inheriting user_id from the associated expense where available.
+    # Fall back to the default admin user for any orphaned or already-null rows.
+    ActiveRecord::Base.transaction do
+      # Rows whose expense has a user_id — inherit from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE categorization_metrics cm
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE cm.expense_id = e.id
+          AND cm.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      # Remaining NULL rows — assign to first admin user
+      MigrationCategorizationMetric.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+  end
+
+  # Data migration — cannot safely determine which rows had a NULL user_id
+  # before the backfill ran, so reversal would silently destroy ownership data.
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "BackfillCategorizationMetricsUserId is a one-way data migration. " \
+      "Rows cannot be safely reverted to NULL without knowing prior state."
+  end
+end

--- a/db/migrate/20260421130800_make_categorization_metrics_user_id_not_null.rb
+++ b/db/migrate/20260421130800_make_categorization_metrics_user_id_not_null.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MakeCategorizationMetricsUserIdNotNull < ActiveRecord::Migration[8.1]
+  # Local anonymous models — PR 14 may remove AdminUser but this migration
+  # must still run. Matches the pattern established in the backfill migration.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  class MigrationCategorizationMetric < ActiveRecord::Base
+    self.table_name = "categorization_metrics"
+  end
+
+  def up
+    # Re-run the backfill immediately before the NOT NULL flip to close the
+    # narrow race between the backfill migration and this one. A concurrent
+    # insert from an old code path could have written a NULL user_id after
+    # the backfill ran but before this migration locks the column.
+    null_count = MigrationCategorizationMetric.where(user_id: nil).count
+    if null_count.positive?
+      default_user = MigrationUser.where(role: 1).order(:id).first
+      raise ActiveRecord::MigrationError,
+        "Found #{null_count} categorization_metrics with NULL user_id but no admin User " \
+        "exists. Run PR 3 migration first." unless default_user
+
+      # Prefer inheriting from expense
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE categorization_metrics cm
+        SET user_id = e.user_id
+        FROM expenses e
+        WHERE cm.expense_id = e.id
+          AND cm.user_id IS NULL
+          AND e.user_id IS NOT NULL
+      SQL
+
+      MigrationCategorizationMetric.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+
+    change_column_null :categorization_metrics, :user_id, false
+  end
+
+  def down
+    change_column_null :categorization_metrics, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,11 +171,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.integer "time_to_correction_hours"
     t.datetime "updated_at", null: false
     t.boolean "was_corrected", default: false, null: false
+    t.bigint "user_id", null: false
     t.index ["category_id"], name: "index_categorization_metrics_on_category_id"
     t.index ["corrected_to_category_id"], name: "index_categorization_metrics_on_corrected_to_category_id"
     t.index ["created_at"], name: "index_categorization_metrics_on_created_at"
     t.index ["expense_id"], name: "index_categorization_metrics_on_expense_id"
     t.index ["layer_used"], name: "index_categorization_metrics_on_layer_used"
+    t.index ["user_id"], name: "index_categorization_metrics_on_user_id"
     t.index ["was_corrected"], name: "index_categorization_metrics_on_was_corrected"
   end
 
@@ -475,6 +477,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.string "feedback_type"
     t.datetime "updated_at", null: false
     t.boolean "was_correct"
+    t.bigint "user_id", null: false
     t.index ["categorization_pattern_id", "created_at"], name: "idx_feedbacks_pattern_time"
     t.index ["categorization_pattern_id", "was_correct", "created_at"], name: "idx_feedback_pattern_performance"
     t.index ["categorization_pattern_id", "was_correct"], name: "idx_feedbacks_pattern_correct"
@@ -487,6 +490,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.index ["expense_id", "created_at"], name: "idx_feedbacks_expense_created"
     t.index ["expense_id", "feedback_type", "created_at"], name: "idx_feedbacks_expense_type_created"
     t.index ["feedback_type", "created_at"], name: "idx_feedback_type_recent", where: "((feedback_type)::text = ANY (ARRAY[('correction'::character varying)::text, ('corrected'::character varying)::text]))"
+    t.index ["user_id"], name: "index_pattern_feedbacks_on_user_id"
   end
 
   create_table "pattern_learning_events", force: :cascade do |t|
@@ -500,6 +504,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.string "pattern_used"
     t.datetime "updated_at", null: false
     t.boolean "was_correct"
+    t.bigint "user_id", null: false
     t.index ["category_id", "created_at"], name: "idx_learning_events_category_time"
     t.index ["category_id", "pattern_used", "created_at"], name: "idx_learning_category_pattern_created"
     t.index ["confidence_score", "was_correct"], name: "idx_learning_confidence", where: "(confidence_score IS NOT NULL)"
@@ -508,6 +513,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.index ["event_type", "created_at"], name: "index_pattern_learning_events_on_event_type_and_created_at"
     t.index ["expense_id"], name: "index_pattern_learning_events_on_expense_id"
     t.index ["pattern_used", "was_correct", "created_at"], name: "idx_learning_events_analysis"
+    t.index ["user_id"], name: "index_pattern_learning_events_on_user_id"
     t.index ["was_correct", "created_at"], name: "idx_learning_correct_created"
   end
 
@@ -824,6 +830,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
   add_foreign_key "categorization_metrics", "categories"
   add_foreign_key "categorization_metrics", "categories", column: "corrected_to_category_id"
   add_foreign_key "categorization_metrics", "expenses"
+  add_foreign_key "categorization_metrics", "users"
   add_foreign_key "categorization_patterns", "categories"
   add_foreign_key "categorization_vectors", "categories"
   add_foreign_key "composite_patterns", "categories"
@@ -842,8 +849,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
   add_foreign_key "pattern_feedbacks", "categories"
   add_foreign_key "pattern_feedbacks", "categorization_patterns"
   add_foreign_key "pattern_feedbacks", "expenses"
+  add_foreign_key "pattern_feedbacks", "users"
   add_foreign_key "pattern_learning_events", "categories"
   add_foreign_key "pattern_learning_events", "expenses"
+  add_foreign_key "pattern_learning_events", "users"
   add_foreign_key "processed_emails", "email_accounts"
   add_foreign_key "processed_emails", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_130800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -170,8 +170,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.float "processing_time_ms"
     t.integer "time_to_correction_hours"
     t.datetime "updated_at", null: false
-    t.boolean "was_corrected", default: false, null: false
     t.bigint "user_id", null: false
+    t.boolean "was_corrected", default: false, null: false
     t.index ["category_id"], name: "index_categorization_metrics_on_category_id"
     t.index ["corrected_to_category_id"], name: "index_categorization_metrics_on_corrected_to_category_id"
     t.index ["created_at"], name: "index_categorization_metrics_on_created_at"
@@ -476,8 +476,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.bigint "expense_id"
     t.string "feedback_type"
     t.datetime "updated_at", null: false
-    t.boolean "was_correct"
     t.bigint "user_id", null: false
+    t.boolean "was_correct"
     t.index ["categorization_pattern_id", "created_at"], name: "idx_feedbacks_pattern_time"
     t.index ["categorization_pattern_id", "was_correct", "created_at"], name: "idx_feedback_pattern_performance"
     t.index ["categorization_pattern_id", "was_correct"], name: "idx_feedbacks_pattern_correct"
@@ -503,8 +503,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120800) do
     t.jsonb "metadata", default: {}
     t.string "pattern_used"
     t.datetime "updated_at", null: false
-    t.boolean "was_correct"
     t.bigint "user_id", null: false
+    t.boolean "was_correct"
     t.index ["category_id", "created_at"], name: "idx_learning_events_category_time"
     t.index ["category_id", "pattern_used", "created_at"], name: "idx_learning_category_pattern_created"
     t.index ["confidence_score", "was_correct"], name: "idx_learning_confidence", where: "(confidence_score IS NOT NULL)"

--- a/spec/db/backfill_categorization_metrics_user_id_spec.rb
+++ b/spec/db/backfill_categorization_metrics_user_id_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+migration_file = Dir[Rails.root.join("db/migrate/*backfill_categorization_metrics_user_id*.rb")].first
+require migration_file
+
+# Run explicitly: TEST_ENV_NUMBER=pr9 bundle exec rspec spec/db/backfill_categorization_metrics_user_id_spec.rb
+RSpec.describe BackfillCategorizationMetricsUserId, unit: false, migration: true do
+  let(:migration) { described_class.new }
+
+  def insert_user(email:, role: 0)
+    digest = BCrypt::Password.create("TestPass123!", cost: BCrypt::Engine::MIN_COST)
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO users
+        (email, name, password_digest, role, failed_login_attempts, created_at, updated_at)
+      VALUES
+        (#{conn.quote(email)}, #{conn.quote("Test User")}, #{conn.quote(digest)},
+         #{conn.quote(role)}, 0, NOW(), NOW())
+    SQL
+    User.find_by!(email: email)
+  end
+
+  def insert_expense(user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    conn.execute(<<~SQL.squish)
+      INSERT INTO expenses
+        (description, amount, currency, transaction_date, source, user_id, created_at, updated_at)
+      VALUES
+        ('Test expense', 10.0, 'USD', NOW(), 'manual', #{uid_sql}, NOW(), NOW())
+    SQL
+    Expense.order(:id).last
+  end
+
+  def insert_categorization_metric(expense_id:, user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    conn.execute(<<~SQL.squish)
+      INSERT INTO categorization_metrics
+        (expense_id, layer_used, was_corrected, user_id, created_at, updated_at)
+      VALUES
+        (#{conn.quote(expense_id)}, 'pattern', false, #{uid_sql}, NOW(), NOW())
+    SQL
+    CategorizationMetric.order(:id).last
+  end
+
+  def allow_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:categorization_metrics, :user_id, true)
+  end
+
+  def enforce_not_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:categorization_metrics, :user_id, false)
+  rescue ActiveRecord::StatementInvalid
+    ActiveRecord::Base.connection.execute(
+      "UPDATE categorization_metrics SET user_id = (SELECT id FROM users WHERE role = 1 ORDER BY id LIMIT 1) WHERE user_id IS NULL"
+    )
+    ActiveRecord::Base.connection.change_column_null(:categorization_metrics, :user_id, false)
+  end
+
+  def cleanup
+    CategorizationMetric.delete_all
+    Expense.delete_all
+    User.delete_all
+  end
+
+  before do
+    allow_null_user_id
+    cleanup
+  end
+
+  after do
+    cleanup
+    enforce_not_null_user_id
+  end
+
+  describe "#up" do
+    context "when no admin User exists" do
+      it "raises ActiveRecord::MigrationError" do
+        insert_user(email: "regular@example.com", role: 0)
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+
+      it "raises when users table is completely empty" do
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+    end
+
+    context "when an admin User exists" do
+      let!(:admin_user) { insert_user(email: "admin@example.com", role: 1) }
+
+      it "inherits user_id from the associated expense" do
+        other_user = insert_user(email: "owner@example.com", role: 0)
+        expense    = insert_expense(user_id: other_user.id)
+        metric     = insert_categorization_metric(expense_id: expense.id)
+
+        migration.up
+
+        expect(metric.reload.user_id).to eq(other_user.id)
+      end
+
+      it "falls back to admin user when expense has no user_id" do
+        expense = insert_expense(user_id: nil)
+        metric  = insert_categorization_metric(expense_id: expense.id)
+
+        migration.up
+
+        expect(metric.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "does not overwrite already-assigned user_id values" do
+        other_user   = insert_user(email: "other@example.com", role: 0)
+        expense1     = insert_expense(user_id: other_user.id)
+        expense2     = insert_expense(user_id: admin_user.id)
+        assigned     = insert_categorization_metric(expense_id: expense1.id, user_id: other_user.id)
+        null_metric  = insert_categorization_metric(expense_id: expense2.id)
+
+        migration.up
+
+        expect(assigned.reload.user_id).to eq(other_user.id)
+        expect(null_metric.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "handles zero categorization_metrics gracefully (no-op)" do
+        expect { migration.up }.not_to raise_error
+      end
+
+      it "is idempotent — running twice does not change user_id" do
+        expense = insert_expense(user_id: admin_user.id)
+        metric  = insert_categorization_metric(expense_id: expense.id, user_id: admin_user.id)
+
+        migration.up
+        migration.up
+
+        expect(metric.reload.user_id).to eq(admin_user.id)
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migration.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/db/backfill_pattern_feedbacks_user_id_spec.rb
+++ b/spec/db/backfill_pattern_feedbacks_user_id_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+migration_file = Dir[Rails.root.join("db/migrate/*backfill_pattern_feedbacks_user_id*.rb")].first
+require migration_file
+
+# Run explicitly: TEST_ENV_NUMBER=pr9 bundle exec rspec spec/db/backfill_pattern_feedbacks_user_id_spec.rb
+RSpec.describe BackfillPatternFeedbacksUserId, unit: false, migration: true do
+  let(:migration) { described_class.new }
+
+  def insert_user(email:, role: 0)
+    digest = BCrypt::Password.create("TestPass123!", cost: BCrypt::Engine::MIN_COST)
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO users
+        (email, name, password_digest, role, failed_login_attempts, created_at, updated_at)
+      VALUES
+        (#{conn.quote(email)}, #{conn.quote("Test User")}, #{conn.quote(digest)},
+         #{conn.quote(role)}, 0, NOW(), NOW())
+    SQL
+    User.find_by!(email: email)
+  end
+
+  def insert_expense(user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    conn.execute(<<~SQL.squish)
+      INSERT INTO expenses
+        (description, amount, currency, transaction_date, source, user_id, created_at, updated_at)
+      VALUES
+        ('Test expense', 10.0, 'USD', NOW(), 'manual', #{uid_sql}, NOW(), NOW())
+    SQL
+    Expense.order(:id).last
+  end
+
+  def insert_category
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO categories (name, created_at, updated_at)
+      VALUES (#{conn.quote("TestCat-#{SecureRandom.hex(4)}")}, NOW(), NOW())
+    SQL
+    Category.order(:id).last
+  end
+
+  def insert_pattern_feedback(expense_id:, user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    category = insert_category
+    conn.execute(<<~SQL.squish)
+      INSERT INTO pattern_feedbacks
+        (expense_id, category_id, feedback_type, user_id, created_at, updated_at)
+      VALUES
+        (#{conn.quote(expense_id)}, #{conn.quote(category.id)},
+         'accepted', #{uid_sql}, NOW(), NOW())
+    SQL
+    PatternFeedback.order(:id).last
+  end
+
+  def allow_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:pattern_feedbacks, :user_id, true)
+  end
+
+  def enforce_not_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:pattern_feedbacks, :user_id, false)
+  rescue ActiveRecord::StatementInvalid
+    ActiveRecord::Base.connection.execute(
+      "UPDATE pattern_feedbacks SET user_id = (SELECT id FROM users WHERE role = 1 ORDER BY id LIMIT 1) WHERE user_id IS NULL"
+    )
+    ActiveRecord::Base.connection.change_column_null(:pattern_feedbacks, :user_id, false)
+  end
+
+  def cleanup
+    PatternFeedback.delete_all
+    Category.delete_all
+    Expense.delete_all
+    User.delete_all
+  end
+
+  before do
+    allow_null_user_id
+    cleanup
+  end
+
+  after do
+    cleanup
+    enforce_not_null_user_id
+  end
+
+  describe "#up" do
+    context "when no admin User exists" do
+      it "raises ActiveRecord::MigrationError" do
+        insert_user(email: "regular@example.com", role: 0)
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+
+      it "raises when users table is completely empty" do
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+    end
+
+    context "when an admin User exists" do
+      let!(:admin_user) { insert_user(email: "admin@example.com", role: 1) }
+
+      it "inherits user_id from the associated expense" do
+        other_user = insert_user(email: "owner@example.com", role: 0)
+        expense    = insert_expense(user_id: other_user.id)
+        feedback   = insert_pattern_feedback(expense_id: expense.id)
+
+        migration.up
+
+        expect(feedback.reload.user_id).to eq(other_user.id)
+      end
+
+      it "falls back to admin user when expense has no user_id" do
+        expense  = insert_expense(user_id: nil)
+        feedback = insert_pattern_feedback(expense_id: expense.id)
+
+        migration.up
+
+        expect(feedback.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "does not overwrite already-assigned user_id values" do
+        other_user       = insert_user(email: "other@example.com", role: 0)
+        expense          = insert_expense(user_id: admin_user.id)
+        assigned_expense = insert_expense(user_id: other_user.id)
+        assigned         = insert_pattern_feedback(expense_id: assigned_expense.id, user_id: other_user.id)
+        null_feedback    = insert_pattern_feedback(expense_id: expense.id)
+
+        migration.up
+
+        expect(assigned.reload.user_id).to eq(other_user.id)
+        expect(null_feedback.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "handles zero pattern_feedbacks gracefully (no-op)" do
+        expect { migration.up }.not_to raise_error
+      end
+
+      it "is idempotent — running twice does not change user_id" do
+        expense  = insert_expense(user_id: admin_user.id)
+        feedback = insert_pattern_feedback(expense_id: expense.id, user_id: admin_user.id)
+
+        migration.up
+        migration.up
+
+        expect(feedback.reload.user_id).to eq(admin_user.id)
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migration.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/db/backfill_pattern_learning_events_user_id_spec.rb
+++ b/spec/db/backfill_pattern_learning_events_user_id_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+migration_file = Dir[Rails.root.join("db/migrate/*backfill_pattern_learning_events_user_id*.rb")].first
+require migration_file
+
+# Run explicitly: TEST_ENV_NUMBER=pr9 bundle exec rspec spec/db/backfill_pattern_learning_events_user_id_spec.rb
+RSpec.describe BackfillPatternLearningEventsUserId, unit: false, migration: true do
+  let(:migration) { described_class.new }
+
+  def insert_user(email:, role: 0)
+    digest = BCrypt::Password.create("TestPass123!", cost: BCrypt::Engine::MIN_COST)
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO users
+        (email, name, password_digest, role, failed_login_attempts, created_at, updated_at)
+      VALUES
+        (#{conn.quote(email)}, #{conn.quote("Test User")}, #{conn.quote(digest)},
+         #{conn.quote(role)}, 0, NOW(), NOW())
+    SQL
+    User.find_by!(email: email)
+  end
+
+  def insert_expense(user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    conn.execute(<<~SQL.squish)
+      INSERT INTO expenses
+        (description, amount, currency, transaction_date, source, user_id, created_at, updated_at)
+      VALUES
+        ('Test expense', 10.0, 'USD', NOW(), 'manual', #{uid_sql}, NOW(), NOW())
+    SQL
+    Expense.order(:id).last
+  end
+
+  def insert_category
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO categories (name, created_at, updated_at)
+      VALUES (#{conn.quote("TestCat-#{SecureRandom.hex(4)}")}, NOW(), NOW())
+    SQL
+    Category.order(:id).last
+  end
+
+  def insert_learning_event(expense_id:, user_id: nil)
+    conn = ActiveRecord::Base.connection
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    category = insert_category
+    conn.execute(<<~SQL.squish)
+      INSERT INTO pattern_learning_events
+        (expense_id, category_id, pattern_used, was_correct, user_id, created_at, updated_at)
+      VALUES
+        (#{conn.quote(expense_id)}, #{conn.quote(category.id)},
+         'keyword:test', true, #{uid_sql}, NOW(), NOW())
+    SQL
+    PatternLearningEvent.order(:id).last
+  end
+
+  def allow_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:pattern_learning_events, :user_id, true)
+  end
+
+  def enforce_not_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:pattern_learning_events, :user_id, false)
+  rescue ActiveRecord::StatementInvalid
+    ActiveRecord::Base.connection.execute(
+      "UPDATE pattern_learning_events SET user_id = (SELECT id FROM users WHERE role = 1 ORDER BY id LIMIT 1) WHERE user_id IS NULL"
+    )
+    ActiveRecord::Base.connection.change_column_null(:pattern_learning_events, :user_id, false)
+  end
+
+  def cleanup
+    PatternLearningEvent.delete_all
+    Category.delete_all
+    Expense.delete_all
+    User.delete_all
+  end
+
+  before do
+    allow_null_user_id
+    cleanup
+  end
+
+  after do
+    cleanup
+    enforce_not_null_user_id
+  end
+
+  describe "#up" do
+    context "when no admin User exists" do
+      it "raises ActiveRecord::MigrationError" do
+        insert_user(email: "regular@example.com", role: 0)
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+
+      it "raises when users table is completely empty" do
+        expect { migration.up }.to raise_error(ActiveRecord::MigrationError, /No admin User found/)
+      end
+    end
+
+    context "when an admin User exists" do
+      let!(:admin_user) { insert_user(email: "admin@example.com", role: 1) }
+
+      it "inherits user_id from the associated expense" do
+        other_user = insert_user(email: "owner@example.com", role: 0)
+        expense    = insert_expense(user_id: other_user.id)
+        event      = insert_learning_event(expense_id: expense.id)
+
+        migration.up
+
+        expect(event.reload.user_id).to eq(other_user.id)
+      end
+
+      it "falls back to admin user when expense has no user_id" do
+        expense = insert_expense(user_id: nil)
+        event   = insert_learning_event(expense_id: expense.id)
+
+        migration.up
+
+        expect(event.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "does not overwrite already-assigned user_id values" do
+        other_user    = insert_user(email: "other@example.com", role: 0)
+        expense1      = insert_expense(user_id: other_user.id)
+        expense2      = insert_expense(user_id: admin_user.id)
+        assigned      = insert_learning_event(expense_id: expense1.id, user_id: other_user.id)
+        null_event    = insert_learning_event(expense_id: expense2.id)
+
+        migration.up
+
+        expect(assigned.reload.user_id).to eq(other_user.id)
+        expect(null_event.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "handles zero pattern_learning_events gracefully (no-op)" do
+        expect { migration.up }.not_to raise_error
+      end
+
+      it "is idempotent — running twice does not change user_id" do
+        expense = insert_expense(user_id: admin_user.id)
+        event   = insert_learning_event(expense_id: expense.id, user_id: admin_user.id)
+
+        migration.up
+        migration.up
+
+        expect(event.reload.user_id).to eq(admin_user.id)
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migration.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/db/index_audit_per126_spec.rb
+++ b/spec/db/index_audit_per126_spec.rb
@@ -482,7 +482,9 @@ RSpec.describe "PER-126 Index Audit", :unit do
       #     processed_emails, email_parsing_failures — one concurrent index each)
       # +2 for preferences cluster user_id FK indexes (PR 8: user_category_preferences, external_budget_sources —
       #     one concurrent index each; undo_histories uses existing composite index)
-      expect(total).to be <= 241  # small buffer for schema drift
+      # +3 for learning signals cluster user_id FK indexes (PR 9: pattern_feedbacks,
+      #     pattern_learning_events, categorization_metrics — one concurrent index each)
+      expect(total).to be <= 244  # small buffer for schema drift
     end
   end
 end

--- a/spec/factories/categorization_metrics.rb
+++ b/spec/factories/categorization_metrics.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :categorization_metric do
     expense
+    user { expense.user }
     category
     layer_used { "pattern" }
     confidence { 0.85 }

--- a/spec/factories/pattern_feedbacks.rb
+++ b/spec/factories/pattern_feedbacks.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :pattern_feedback do
     association :expense
     association :category
+    user { expense.user }
     was_correct { true }
     feedback_type { "accepted" }
 

--- a/spec/factories/pattern_learning_events.rb
+++ b/spec/factories/pattern_learning_events.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :pattern_learning_event do
     association :expense
     association :category
+    user { expense.user }
     pattern_used { "keyword:test_pattern" }
     was_correct { true }
     confidence_score { 0.85 }

--- a/spec/models/categorization_metric_spec.rb
+++ b/spec/models/categorization_metric_spec.rb
@@ -1,49 +1,63 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe CategorizationMetric, type: :model, unit: true do
-  let(:expense) { create(:expense) }
+  let(:user)    { create(:user) }
+  let(:expense) { create(:expense, user: user) }
   let(:category) { create(:category) }
 
   describe "validations" do
     it "requires layer_used" do
-      metric = CategorizationMetric.new(expense: expense, layer_used: nil)
+      metric = CategorizationMetric.new(expense: expense, user: user, layer_used: nil)
       expect(metric).not_to be_valid
       expect(metric.errors[:layer_used]).to be_present
     end
 
     it "requires expense" do
-      metric = CategorizationMetric.new(layer_used: "pattern")
+      metric = CategorizationMetric.new(user: user, layer_used: "pattern")
       expect(metric).not_to be_valid
       expect(metric.errors[:expense]).to be_present
     end
 
+    it "requires user" do
+      metric = CategorizationMetric.new(expense: expense, layer_used: "pattern")
+      expect(metric).not_to be_valid
+      expect(metric.errors[:user]).to be_present
+    end
+
     it "validates layer_used inclusion" do
       %w[pattern pg_trgm haiku manual].each do |layer|
-        metric = CategorizationMetric.new(expense: expense, layer_used: layer)
+        metric = CategorizationMetric.new(expense: expense, user: user, layer_used: layer)
         metric.valid?
         expect(metric.errors[:layer_used]).to be_empty
       end
 
-      metric = CategorizationMetric.new(expense: expense, layer_used: "invalid")
+      metric = CategorizationMetric.new(expense: expense, user: user, layer_used: "invalid")
       expect(metric).not_to be_valid
     end
   end
 
   describe "associations" do
+    it "belongs to user" do
+      metric = CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern")
+      expect(metric.user).to eq(user)
+    end
+
     it "belongs to expense" do
-      metric = CategorizationMetric.create!(expense: expense, layer_used: "pattern", category: category)
+      metric = CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern", category: category)
       expect(metric.expense).to eq(expense)
     end
 
     it "belongs to category (optional)" do
-      metric = CategorizationMetric.create!(expense: expense, layer_used: "pattern")
+      metric = CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern")
       expect(metric.category).to be_nil
     end
 
     it "belongs to corrected_to_category (optional)" do
       other_category = create(:category, name: "Other", i18n_key: "other_test")
       metric = CategorizationMetric.create!(
-        expense: expense, layer_used: "pattern",
+        expense: expense, user: user, layer_used: "pattern",
         category: category, was_corrected: true,
         corrected_to_category: other_category
       )
@@ -52,9 +66,12 @@ RSpec.describe CategorizationMetric, type: :model, unit: true do
   end
 
   describe "scopes" do
+    let(:user_b)    { create(:user) }
+    let(:expense_b) { create(:expense, user: user_b) }
+
     before do
-      CategorizationMetric.create!(expense: expense, layer_used: "pattern", was_corrected: false)
-      CategorizationMetric.create!(expense: create(:expense), layer_used: "haiku", was_corrected: true)
+      CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern", was_corrected: false)
+      CategorizationMetric.create!(expense: expense_b, user: user_b, layer_used: "haiku", was_corrected: true)
     end
 
     it ".corrected returns only corrected metrics" do
@@ -74,21 +91,38 @@ RSpec.describe CategorizationMetric, type: :model, unit: true do
     end
 
     it ".recent filters by period" do
-      old = CategorizationMetric.create!(expense: create(:expense), layer_used: "manual")
+      user_c = create(:user)
+      old_expense = create(:expense, user: user_c)
+      old = CategorizationMetric.create!(expense: old_expense, user: user_c, layer_used: "manual")
       old.update_columns(created_at: 60.days.ago)
 
       expect(CategorizationMetric.recent(30.days).count).to eq(2)
+    end
+
+    describe ".for_user" do
+      it "returns only metrics for the given user" do
+        expect(CategorizationMetric.for_user(user).pluck(:layer_used)).to eq([ "pattern" ])
+      end
+
+      it "excludes metrics from other users" do
+        expect(CategorizationMetric.for_user(user).count).to eq(1)
+      end
+
+      it "returns empty when user has no metrics" do
+        new_user = create(:user)
+        expect(CategorizationMetric.for_user(new_user)).to be_empty
+      end
     end
   end
 
   describe "defaults" do
     it "defaults was_corrected to false" do
-      metric = CategorizationMetric.create!(expense: expense, layer_used: "pattern")
+      metric = CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern")
       expect(metric.was_corrected).to be false
     end
 
     it "defaults api_cost to 0" do
-      metric = CategorizationMetric.create!(expense: expense, layer_used: "pattern")
+      metric = CategorizationMetric.create!(expense: expense, user: user, layer_used: "pattern")
       expect(metric.api_cost).to eq(0)
     end
   end

--- a/spec/models/categorization_models_integration_spec.rb
+++ b/spec/models/categorization_models_integration_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe "Categorization Models Integration", type: :model, integration: t
       # User corrects to right category
       feedback = PatternFeedback.create!(
         expense: expense,
+        user: expense.user,
         category: category, # Correct category
         was_correct: false,
         feedback_type: "correction"
@@ -179,6 +180,7 @@ RSpec.describe "Categorization Models Integration", type: :model, integration: t
       feedback = PatternFeedback.create!(
         categorization_pattern: pattern,
         expense: expense,
+        user: expense.user,
         category: category,
         was_correct: true
       )

--- a/spec/models/pattern_feedback_unit_spec.rb
+++ b/spec/models/pattern_feedback_unit_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe PatternFeedback, type: :model, unit: true do
   describe "associations" do
+    it { should belong_to(:user) }
     it { should belong_to(:categorization_pattern).optional }
     it { should belong_to(:expense) }
     it { should belong_to(:category) }
@@ -189,17 +190,34 @@ RSpec.describe PatternFeedback, type: :model, unit: true do
   end
 
   describe "scopes" do
+    describe ".for_user" do
+      it "returns only feedbacks belonging to the given user" do
+        user_a = create(:user)
+        user_b = create(:user)
+        feedback_a = create(:pattern_feedback, user: user_a, expense: create(:expense, user: user_a))
+        _feedback_b = create(:pattern_feedback, user: user_b, expense: create(:expense, user: user_b))
+
+        expect(PatternFeedback.for_user(user_a)).to eq([ feedback_a ])
+      end
+
+      it "returns an empty collection when user has no feedbacks" do
+        user = create(:user)
+        expect(PatternFeedback.for_user(user)).to be_empty
+      end
+    end
   end
 
   describe "class methods" do
     describe ".record_feedback" do
-      let(:expense) { build_stubbed(:expense) }
+      let(:user)    { build_stubbed(:user) }
+      let(:expense) { build_stubbed(:expense, user: user) }
       let(:category) { build_stubbed(:category) }
       let(:pattern) { build_stubbed(:categorization_pattern) }
 
-      it "creates feedback with all parameters" do
+      it "creates feedback with all parameters and derives user from expense" do
         expect(PatternFeedback).to receive(:create!).with(
           expense: expense,
+          user: user,
           category: category,
           categorization_pattern: pattern,
           was_correct: true,
@@ -219,7 +237,7 @@ RSpec.describe PatternFeedback, type: :model, unit: true do
 
       it "validates feedback type" do
         expect(PatternFeedback).to receive(:create!).with(
-          hash_including(feedback_type: "correction")
+          hash_including(feedback_type: "correction", user: user)
         )
 
         PatternFeedback.record_feedback(
@@ -233,7 +251,7 @@ RSpec.describe PatternFeedback, type: :model, unit: true do
 
       it "defaults to accepted for invalid feedback types" do
         expect(PatternFeedback).to receive(:create!).with(
-          hash_including(feedback_type: "accepted")
+          hash_including(feedback_type: "accepted", user: user)
         )
 
         PatternFeedback.record_feedback(
@@ -247,7 +265,7 @@ RSpec.describe PatternFeedback, type: :model, unit: true do
 
       it "handles nil pattern" do
         expect(PatternFeedback).to receive(:create!).with(
-          hash_including(categorization_pattern: nil)
+          hash_including(categorization_pattern: nil, user: user)
         )
 
         PatternFeedback.record_feedback(
@@ -260,7 +278,7 @@ RSpec.describe PatternFeedback, type: :model, unit: true do
 
       it "handles nil confidence" do
         expect(PatternFeedback).to receive(:create!).with(
-          hash_including(confidence_score: nil)
+          hash_including(confidence_score: nil, user: user)
         )
 
         PatternFeedback.record_feedback(

--- a/spec/models/pattern_learning_event_unit_spec.rb
+++ b/spec/models/pattern_learning_event_unit_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe PatternLearningEvent, type: :model, unit: true do
   describe "associations" do
+    it { should belong_to(:user) }
     it { should belong_to(:expense) }
     it { should belong_to(:category) }
   end
@@ -80,6 +81,22 @@ RSpec.describe PatternLearningEvent, type: :model, unit: true do
   end
 
   describe "scopes" do
+    describe ".for_user" do
+      it "returns only events belonging to the given user" do
+        user_a = create(:user)
+        user_b = create(:user)
+        event_a = create(:pattern_learning_event, user: user_a, expense: create(:expense, user: user_a))
+        _event_b = create(:pattern_learning_event, user: user_b, expense: create(:expense, user: user_b))
+
+        expect(PatternLearningEvent.for_user(user_a)).to eq([ event_a ])
+      end
+
+      it "returns an empty collection when user has no events" do
+        user = create(:user)
+        expect(PatternLearningEvent.for_user(user)).to be_empty
+      end
+    end
+
     describe ".successful" do
     end
 
@@ -124,11 +141,12 @@ RSpec.describe PatternLearningEvent, type: :model, unit: true do
 
   describe "class methods" do
     describe ".record_event" do
-      let(:expense) { build_stubbed(:expense, id: 1) }
+      let(:user)    { build_stubbed(:user) }
+      let(:expense) { build_stubbed(:expense, id: 1, user: user) }
       let(:category) { build_stubbed(:category, id: 2) }
 
       context "with CategorizationPattern" do
-        it "creates event with pattern details" do
+        it "creates event with pattern details and derives user from expense" do
           pattern = build_stubbed(:categorization_pattern,
             id: 10,
             pattern_type: "merchant",
@@ -137,6 +155,7 @@ RSpec.describe PatternLearningEvent, type: :model, unit: true do
 
           expect(PatternLearningEvent).to receive(:create!).with(
             expense: expense,
+            user: user,
             category: category,
             pattern_used: "merchant:Store Name",
             was_correct: true,
@@ -170,6 +189,7 @@ RSpec.describe PatternLearningEvent, type: :model, unit: true do
 
           expect(PatternLearningEvent).to receive(:create!).with(
             expense: expense,
+            user: user,
             category: category,
             pattern_used: "CustomPattern#30",
             was_correct: true,
@@ -194,7 +214,7 @@ RSpec.describe PatternLearningEvent, type: :model, unit: true do
         pattern = build_stubbed(:categorization_pattern, pattern_type: "merchant", pattern_value: "Store")
 
         expect(PatternLearningEvent).to receive(:create!).with(
-          hash_including(confidence_score: nil)
+          hash_including(confidence_score: nil, user: user)
         )
 
         PatternLearningEvent.record_event(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -686,4 +686,75 @@ RSpec.describe User, type: :model, unit: true do
       end
     end
   end
+
+  # PR 9 — learning signals cluster associations
+  describe 'learning signals cluster associations (PR 9)' do
+    let(:user) { create(:user) }
+
+    %i[pattern_feedbacks pattern_learning_events categorization_metrics].each do |assoc|
+      it "responds to #{assoc}" do
+        expect(user).to respond_to(assoc)
+      end
+
+      it "has #{assoc} with restrict_with_exception dependent" do
+        reflection = User.reflect_on_association(assoc)
+        expect(reflection).to be_present
+        expect(reflection.options[:dependent]).to eq(:restrict_with_exception)
+      end
+    end
+
+    it "returns only the user's pattern_feedbacks" do
+      user_a = create(:user)
+      user_b = create(:user)
+      expense_a = create(:expense, user: user_a)
+      expense_b = create(:expense, user: user_b)
+      feedback_a = create(:pattern_feedback, user: user_a, expense: expense_a)
+      create(:pattern_feedback, user: user_b, expense: expense_b)
+
+      expect(user_a.pattern_feedbacks).to eq([ feedback_a ])
+    end
+
+    it "returns only the user's pattern_learning_events" do
+      user_a = create(:user)
+      user_b = create(:user)
+      expense_a = create(:expense, user: user_a)
+      expense_b = create(:expense, user: user_b)
+      event_a = create(:pattern_learning_event, user: user_a, expense: expense_a)
+      create(:pattern_learning_event, user: user_b, expense: expense_b)
+
+      expect(user_a.pattern_learning_events).to eq([ event_a ])
+    end
+
+    it "returns only the user's categorization_metrics" do
+      user_a = create(:user)
+      user_b = create(:user)
+      expense_a = create(:expense, user: user_a)
+      expense_b = create(:expense, user: user_b)
+      metric_a = create(:categorization_metric, user: user_a, expense: expense_a)
+      create(:categorization_metric, user: user_b, expense: expense_b)
+
+      expect(user_a.categorization_metrics).to eq([ metric_a ])
+    end
+
+    it "raises DeleteRestrictionError when destroying user with pattern_feedbacks" do
+      user_a = create(:user)
+      expense = create(:expense, user: user_a)
+      create(:pattern_feedback, user: user_a, expense: expense)
+      expect { user_a.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "raises DeleteRestrictionError when destroying user with pattern_learning_events" do
+      user_a = create(:user)
+      expense = create(:expense, user: user_a)
+      create(:pattern_learning_event, user: user_a, expense: expense)
+      expect { user_a.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "raises DeleteRestrictionError when destroying user with categorization_metrics" do
+      user_a = create(:user)
+      expense = create(:expense, user: user_a)
+      create(:categorization_metric, user: user_a, expense: expense)
+      expect { user_a.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+  end
 end

--- a/spec/services/categorization/learning/metrics_recorder_spec.rb
+++ b/spec/services/categorization/learning/metrics_recorder_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :service, unit: true do
   let(:category) { create(:category) }
-  let(:expense) { create(:expense, category: category) }
+  let(:user)     { create(:user) }
+  let(:expense)  { create(:expense, category: category, user: user) }
   let(:recorder) { described_class.new }
 
   describe "#record" do
@@ -24,11 +25,12 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
       }.to change(CategorizationMetric, :count).by(1)
     end
 
-    it "stores the correct attributes" do
+    it "stores the correct attributes and derives user from expense" do
       recorder.record(expense: expense, result: result, layer_name: "pattern")
 
       metric = CategorizationMetric.last
       expect(metric.expense).to eq(expense)
+      expect(metric.user).to eq(user)
       expect(metric.layer_used).to eq("pattern")
       expect(metric.confidence).to eq(0.85)
       expect(metric.category).to eq(category)
@@ -75,6 +77,7 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
     let!(:metric) do
       CategorizationMetric.create!(
         expense: expense,
+        user: user,
         layer_used: "pattern",
         confidence: 0.85,
         category: category,
@@ -103,7 +106,8 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
     end
 
     it "handles missing metric row gracefully without modifying anything" do
-      other_expense = create(:expense)
+      other_user    = create(:user)
+      other_expense = create(:expense, user: other_user)
 
       recorder.record_correction(expense: other_expense, corrected_to_category: new_category)
 
@@ -127,6 +131,7 @@ RSpec.describe Services::Categorization::Learning::MetricsRecorder, type: :servi
     it "updates the most recent metric for the expense" do
       older_metric = CategorizationMetric.create!(
         expense: expense,
+        user: user,
         layer_used: "pg_trgm",
         confidence: 0.7,
         category: category,


### PR DESCRIPTION
PR 9 of 14. Adds user_id FK to the ML/learning-signals cluster: pattern_feedbacks, pattern_learning_events, categorization_metrics.

**Migrations (9):** 3-step per table. No pre-existing user_id columns — all three use standard add_reference + concurrent index + IrreversibleMigration backfill + inline re-backfill before NOT NULL. Backfill SQL JOINs through expenses.user_id as source-of-truth, with first-admin fallback for orphans.

**Models:** belongs_to :user + for_user scope on all 3. User gets 3 has_many, dependent: :restrict_with_exception.

**Services/jobs user_id-stamped (8 call sites):**
- MetricsRecorder#record (expense.user)
- PatternLearner#record_feedback / #record_learning_event (expense.user)
- EnhancedCategorizationService#record_learning_event (expense.user)
- PatternFeedback.record_feedback / PatternLearningEvent.record_event class methods
- Expense#reject_ml_suggestion! / #dismiss_ml_suggestion! (self.user)

**Factories:** derive user from expense association.

**Admin surfaces:** Admin::PatternsController#time_series_performance_data and MetricsDashboardService legitimately aggregate cross-user. Both now carry FIXME(PR-12) comments for the tracking convention.

**Review chain:**
1. tdd-feature-developer (Sonnet) — single clean commit.
2. DB+backend architect (Sonnet) — **APPROVE**, no blockers. Nit: missing FIXME(PR-12) annotations — added in follow-up commit.
3. Codex review requested below.

**Verification:** 9052/9052 green, rubocop + brakeman clean. Index audit ceiling +3 to 244.