### PR TITLE
feat(api): PR 11/14 — api_tokens.user_id + API scoping (Complex, security-sensitive)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -30,7 +30,18 @@ module Api
 
       unless @current_api_token
         render_unauthorized("Invalid or expired API token")
+        return
       end
+
+      @current_api_user = @current_api_token.user
+
+      if @current_api_user.nil? || @current_api_user.locked?
+        render_unauthorized("Token owner account is unavailable")
+      end
+    end
+
+    def current_api_user
+      @current_api_user
     end
 
     def extract_bearer_token

--- a/app/controllers/api/v1/categorization_controller.rb
+++ b/app/controllers/api/v1/categorization_controller.rb
@@ -35,7 +35,7 @@ module Api
       def feedback
         validate_feedback_params!
 
-        expense = Expense.find(feedback_params[:expense_id])
+        expense = Expense.for_user(current_api_user).find(feedback_params[:expense_id])
         category = Category.find(feedback_params[:category_id])
 
         # Find the pattern that was used (if any)

--- a/app/controllers/api/v1/categorization_controller.rb
+++ b/app/controllers/api/v1/categorization_controller.rb
@@ -83,6 +83,11 @@ module Api
 
       # GET /api/v1/categorization/statistics
       def statistics
+        # CategorizationPattern is global reference data (shared across users,
+        # same posture as Category). PatternFeedback holds per-user signals
+        # (PR 9 added user_id), so it must be scoped to the token owner.
+        user_feedback = PatternFeedback.for_user(current_api_user)
+
         stats = {
           total_patterns: CategorizationPattern.count,
           active_patterns: CategorizationPattern.active.count,
@@ -90,8 +95,8 @@ module Api
           high_confidence_patterns: CategorizationPattern.high_confidence.count,
           successful_patterns: CategorizationPattern.successful.count,
           frequently_used_patterns: CategorizationPattern.frequently_used.count,
-          recent_feedback_count: PatternFeedback.where(created_at: 7.days.ago..).count,
-          feedback_by_type: PatternFeedback.group(:feedback_type).count,
+          recent_feedback_count: user_feedback.where(created_at: 7.days.ago..).count,
+          feedback_by_type: user_feedback.group(:feedback_type).count,
           average_success_rate: CategorizationPattern.active.average(:success_rate)&.round(3) || 0,
           patterns_by_type: CategorizationPattern.group(:pattern_type).count,
           top_categories: top_categorized_categories

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -2,6 +2,7 @@ class Api::WebhooksController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
   before_action :authenticate_api_token
+  before_action :set_current_api_user
 
   rescue_from ActionController::ParameterMissing do |exception|
     render json: {
@@ -15,11 +16,18 @@ class Api::WebhooksController < ApplicationController
     since = parse_since_parameter
 
     if email_account_id.present?
-      ProcessEmailsJob.perform_later(email_account_id.to_i, since: since)
+      # Validate that the requested email account belongs to the token's owner.
+      account = @current_api_user.email_accounts.find_by(id: email_account_id.to_i)
+      unless account
+        render json: { error: "Email account not found or access denied", status: 404 }, status: :not_found
+        return
+      end
+
+      ProcessEmailsJob.perform_later(account.id, since: since)
       render json: {
         status: "success",
-        message: "Email processing queued for account #{email_account_id}",
-        email_account_id: email_account_id
+        message: "Email processing queued for account #{account.id}",
+        email_account_id: account.id
       }, status: :accepted
     else
       ProcessEmailsJob.perform_later(since: since)
@@ -38,7 +46,7 @@ class Api::WebhooksController < ApplicationController
     expense = Expense.new(expense_params)
     account = default_email_account
     expense.email_account = account
-    expense.user = account&.user  # FIXME(PR-11): replace with api_token owner once api_tokens model is scoped
+    expense.user = @current_api_user
     expense.status = "processed"
 
     if expense.save
@@ -92,11 +100,8 @@ class Api::WebhooksController < ApplicationController
     limit = [ params[:limit].to_i, 50 ].min
     limit = 10 if limit <= 0
 
-    # FIXME(PR-11): scope to api_token.user once api_tokens become user-scoped.
-    # Today a webhook token sees every user's recent expenses; acceptable in
-    # the current single-user deploy but must be tightened before a second
-    # real user onboards.
-    expenses = Expense.includes(:category, :email_account)
+    expenses = Expense.for_user(@current_api_user)
+                     .includes(:category, :email_account)
                      .recent
                      .limit(limit)
 
@@ -107,7 +112,7 @@ class Api::WebhooksController < ApplicationController
   end
 
   def expense_summary
-    service = Services::ExpenseSummaryService.new(params[:period])
+    service = Services::ExpenseSummaryService.new(params[:period], user: @current_api_user)
 
     render json: {
       status: "success",
@@ -130,7 +135,16 @@ class Api::WebhooksController < ApplicationController
 
     unless @current_api_token
       render json: { error: "Invalid or expired API token" }, status: :unauthorized
-      nil
+    end
+  end
+
+  def set_current_api_user
+    return if performed? # halt if already rendered (e.g. auth failed)
+
+    @current_api_user = @current_api_token&.user
+
+    if @current_api_user.nil? || @current_api_user.locked?
+      render json: { error: "Token owner account is unavailable" }, status: :unauthorized
     end
   end
 
@@ -159,22 +173,17 @@ class Api::WebhooksController < ApplicationController
   end
 
   def default_email_account
-    # For manual entries, use the first active account or create a default one
-    EmailAccount.active.first || create_default_manual_account
+    # For manual entries, use the current user's first active account or create a default one
+    @current_api_user.email_accounts.active.first || create_default_manual_account
   end
 
   def create_default_manual_account
-    # user_id is required since PR 4 added the NOT NULL constraint.
-    # ApiToken is not yet user-scoped (PR 11 does that), so we fall back to
-    # the first admin User.  This is the same interim pattern as
-    # EmailAccountsController#scoping_user.
-    default_user = User.admin.first || raise("No admin User found — cannot create default manual email account")
     EmailAccount.create!(
       provider: "manual",
-      email: "manual@localhost",
+      email: "manual+#{@current_api_user.id}@localhost",
       bank_name: "Manual Entry",
       active: true,
-      user: default_user
+      user: @current_api_user
     )
   end
 

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -1,15 +1,7 @@
-class Api::WebhooksController < ApplicationController
-  skip_before_action :authenticate_user!
-  skip_before_action :verify_authenticity_token
-  before_action :authenticate_api_token
-  before_action :set_current_api_user
-
-  rescue_from ActionController::ParameterMissing do |exception|
-    render json: {
-      status: "error",
-      message: exception.message
-    }, status: :unprocessable_content
-  end
+class Api::WebhooksController < Api::BaseController
+  # Inheriting from Api::BaseController gets us the canonical
+  # authenticate_api_token (with locked-user check), @current_api_user
+  # wiring, and error handlers — no duplicate auth code to drift.
 
   def process_emails
     email_account_id = params[:email_account_id]
@@ -30,10 +22,19 @@ class Api::WebhooksController < ApplicationController
         email_account_id: account.id
       }, status: :accepted
     else
-      ProcessEmailsJob.perform_later(since: since)
+      # No specific account — process ONLY the token owner's active accounts.
+      # Pre-PR-11 this fell through to "all active accounts globally", which
+      # let any valid token trigger processing for other users' mailboxes.
+      owner_account_ids = @current_api_user.email_accounts.active.pluck(:id)
+      if owner_account_ids.empty?
+        render json: { error: "No active email accounts for this user", status: 404 }, status: :not_found
+        return
+      end
+      owner_account_ids.each { |id| ProcessEmailsJob.perform_later(id, since: since) }
       render json: {
         status: "success",
-        message: "Email processing queued for all active accounts"
+        message: "Email processing queued for #{owner_account_ids.size} account(s)",
+        email_account_ids: owner_account_ids
       }, status: :accepted
     end
   end
@@ -122,31 +123,6 @@ class Api::WebhooksController < ApplicationController
   end
 
   private
-
-  def authenticate_api_token
-    token = request.headers["Authorization"]&.remove("Bearer ")
-
-    unless token.present?
-      render json: { error: "Missing API token" }, status: :unauthorized
-      return
-    end
-
-    @current_api_token = ApiToken.authenticate(token)
-
-    unless @current_api_token
-      render json: { error: "Invalid or expired API token" }, status: :unauthorized
-    end
-  end
-
-  def set_current_api_user
-    return if performed? # halt if already rendered (e.g. auth failed)
-
-    @current_api_user = @current_api_token&.user
-
-    if @current_api_user.nil? || @current_api_user.locked?
-      render json: { error: "Token owner account is unavailable" }, status: :unauthorized
-    end
-  end
 
   def parse_since_parameter
     since_param = params[:since]

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -13,10 +13,14 @@ class ApiToken < ApplicationRecord
   validates :active, inclusion: { in: [ true, false ] }
   validate :expires_at_in_future, if: :expires_at?
 
+  # Associations
+  belongs_to :user
+
   # Scopes
   scope :active, -> { where(active: true) }
   scope :expired, -> { where("expires_at < ?", Time.current) }
   scope :valid, -> { active.where("expires_at IS NULL OR expires_at > ?", Time.current) }
+  scope :for_user, ->(user) { where(user_id: user.id) }
 
   # Callbacks
   before_validation :generate_token_if_blank, on: :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
   has_many :pattern_learning_events, dependent: :restrict_with_exception
   has_many :categorization_metrics, dependent: :restrict_with_exception
   has_many :bulk_operations, dependent: :restrict_with_exception
+  has_many :api_tokens, dependent: :restrict_with_exception
 
   # Enums
   enum :role, {

--- a/app/services/expense_summary_service.rb
+++ b/app/services/expense_summary_service.rb
@@ -3,8 +3,9 @@ module Services
   VALID_PERIODS = %w[week month year].freeze
   DEFAULT_PERIOD = "month".freeze
 
-  def initialize(period = DEFAULT_PERIOD)
+  def initialize(period = DEFAULT_PERIOD, user: nil)
     @period = normalize_period(period)
+    @user = user
   end
 
   def summary
@@ -61,16 +62,20 @@ module Services
     }
   end
 
+  def scoped_expenses
+    @user ? Expense.for_user(@user) : Expense.all
+  end
+
   def total_amount_for_period(start_date, end_date)
-    Expense.total_amount_for_period(start_date, end_date).to_f
+    scoped_expenses.total_amount_for_period(start_date, end_date).to_f
   end
 
   def expense_count_for_period(start_date, end_date)
-    Expense.by_date_range(start_date, end_date).count
+    scoped_expenses.by_date_range(start_date, end_date).count
   end
 
   def category_breakdown_for_period(start_date, end_date)
-    Expense.joins(:category)
+    scoped_expenses.joins(:category)
       .by_date_range(start_date, end_date)
       .group("categories.name")
       .sum(:amount)
@@ -78,7 +83,7 @@ module Services
   end
 
   def monthly_breakdown_for_year(start_date, end_date)
-    Expense.by_date_range(start_date, end_date)
+    scoped_expenses.by_date_range(start_date, end_date)
       .group_by_month(:transaction_date)
       .sum(:amount)
       .transform_values(&:to_f)

--- a/app/services/expense_summary_service.rb
+++ b/app/services/expense_summary_service.rb
@@ -63,7 +63,12 @@ module Services
   end
 
   def scoped_expenses
-    @user ? Expense.for_user(@user) : Expense.all
+    # PR 11: raise on missing user rather than silently falling back to
+    # Expense.all. The service is used from user-facing summary endpoints,
+    # and a nil-user call was leaking cross-user totals. Callers must supply
+    # user: current_user / current_api_user explicitly.
+    raise ArgumentError, "user is required for ExpenseSummaryService" unless @user
+    Expense.for_user(@user)
   end
 
   def total_amount_for_period(start_date, end_date)

--- a/db/migrate/20260421150000_add_user_to_api_tokens.rb
+++ b/db/migrate/20260421150000_add_user_to_api_tokens.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Step 1 of 3: Add nullable `user_id` FK column to `api_tokens`.
+#
+# Strategy:
+#   - Add `user_id` as a FK to `users` (nullable for now, NOT NULL added in step 3).
+#   - Create the index CONCURRENTLY to avoid table locks in production.
+#   - `disable_ddl_transaction!` is required for CONCURRENTLY index creation.
+class AddUserToApiTokens < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :api_tokens, :user, foreign_key: true, index: false, null: true
+
+    add_index :api_tokens, :user_id,
+              algorithm: :concurrently,
+              name: "index_api_tokens_on_user_id"
+  end
+end

--- a/db/migrate/20260421150100_backfill_api_tokens_user_id.rb
+++ b/db/migrate/20260421150100_backfill_api_tokens_user_id.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Step 2 of 3: Backfill `api_tokens.user_id`.
+#
+# All api_tokens are system tokens (iPhone Shortcuts, etc.) — there is no
+# per-user mapping at this stage. Assign every token to the first admin User.
+# If no admin User exists, raise MigrationError so the operator is alerted
+# rather than leaving NULLs that would block step 3.
+class BackfillApiTokensUserId < ActiveRecord::Migration[8.1]
+  # Isolated anonymous models so this migration stays runnable after any future
+  # refactor or removal of these classes from the app codebase.
+  class MigrationApiToken < ActiveRecord::Base
+    self.table_name = "api_tokens"
+  end
+
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  def up
+    default_user = MigrationUser.where(role: 1).order(:id).first
+
+    if default_user.nil?
+      raise ActiveRecord::MigrationError,
+        "No admin User found — run PR 3 migration (CreateDefaultUserFromAdminUsers) first."
+    end
+
+    ActiveRecord::Base.transaction do
+      MigrationApiToken.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+  end
+
+  # Data migration — cannot determine which rows were NULL before the backfill,
+  # so reversal would silently destroy ownership data.
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "BackfillApiTokensUserId is a one-way data migration. " \
+      "Rows cannot be safely reverted to NULL without knowing prior state."
+  end
+end

--- a/db/migrate/20260421150200_make_api_tokens_user_id_not_null.rb
+++ b/db/migrate/20260421150200_make_api_tokens_user_id_not_null.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Step 3 of 3: Flip `api_tokens.user_id` to NOT NULL.
+#
+# Includes an inline re-backfill guard: any NULL rows that slipped in after
+# the backfill (race window during deploy) are assigned to the first admin
+# User before the NOT NULL constraint is applied.
+class MakeApiTokensUserIdNotNull < ActiveRecord::Migration[8.1]
+  class MigrationApiToken < ActiveRecord::Base
+    self.table_name = "api_tokens"
+  end
+
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  def up
+    null_count = MigrationApiToken.where(user_id: nil).count
+
+    if null_count.positive?
+      default_user = MigrationUser.where(role: 1).order(:id).first
+
+      raise ActiveRecord::MigrationError,
+        "Found #{null_count} api_tokens with NULL user_id but no admin User " \
+        "exists. Run PR 3 migration (CreateDefaultUserFromAdminUsers) first." unless default_user
+
+      Rails.logger.warn(
+        "[MakeApiTokensUserIdNotNull] #{null_count} NULL user_id rows found " \
+        "after backfill — assigning to admin user id=#{default_user.id}."
+      )
+      MigrationApiToken.where(user_id: nil).update_all(user_id: default_user.id)
+    end
+
+    change_column_null :api_tokens, :user_id, false
+  end
+
+  def down
+    change_column_null :api_tokens, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_140300) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_150200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -43,11 +43,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_140300) do
     t.string "token_digest", null: false
     t.string "token_hash"
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["active", "expires_at"], name: "index_api_tokens_on_active_and_expires_at"
     t.index ["active"], name: "index_api_tokens_on_active"
     t.index ["expires_at"], name: "index_api_tokens_on_expires_at"
     t.index ["token_digest"], name: "index_api_tokens_on_token_digest", unique: true
     t.index ["token_hash"], name: "index_api_tokens_on_token_hash", unique: true
+    t.index ["user_id"], name: "index_api_tokens_on_user_id"
   end
 
   create_table "budgets", force: :cascade do |t|
@@ -818,6 +820,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_140300) do
     t.check_constraint "role = ANY (ARRAY[0, 1])", name: "check_users_role_valid"
   end
 
+  add_foreign_key "api_tokens", "users"
   add_foreign_key "budgets", "categories"
   add_foreign_key "budgets", "email_accounts"
   add_foreign_key "budgets", "users"

--- a/spec/controllers/api/v1/categorization_controller_unit_spec.rb
+++ b/spec/controllers/api/v1/categorization_controller_unit_spec.rb
@@ -45,7 +45,13 @@ RSpec.describe Api::V1::CategorizationController, type: :controller, unit: true 
     end
 
     before do
-      allow(Expense).to receive(:find).and_return(expense)
+      # PR 11: feedback now calls Expense.for_user(current_api_user).find(...)
+      # Stub current_api_user and the user-scoped Expense relation.
+      user_double = double("User")
+      allow(controller).to receive(:current_api_user).and_return(user_double)
+      expense_scope = double("ExpenseScope")
+      allow(Expense).to receive(:for_user).with(user_double).and_return(expense_scope)
+      allow(expense_scope).to receive(:find).and_return(expense)
       allow(Category).to receive(:find).and_return(category)
       allow(PatternFeedback).to receive(:record_feedback).and_return(double(improvement_suggestion: "Test"))
       allow(categorization_service).to receive(:learn_from_feedback)

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -48,15 +48,33 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     context "without email_account_id parameter" do
-      it "queues ProcessEmailsJob for all accounts" do
-        expect(ProcessEmailsJob).to receive(:perform_later).with(since: be_a(Time))
+      # PR 11: no email_account_id queues one job per owner account (not globally).
+      before { email_account } # ensure the token owner has at least one active account
+
+      it "queues ProcessEmailsJob once per owner active account" do
+        expect(ProcessEmailsJob).to receive(:perform_later).with(
+          email_account.id,
+          since: be_a(Time)
+        ).once
 
         post :process_emails
 
         expect(response).to have_http_status(:accepted)
         json_response = JSON.parse(response.body)
         expect(json_response["status"]).to eq("success")
-        expect(json_response["message"]).to include("all active accounts")
+        expect(json_response["email_account_ids"]).to eq([ email_account.id ])
+        expect(json_response["message"]).to match(/queued for \d+ account\(s\)/)
+      end
+
+      it "returns 404 when token owner has no active accounts" do
+        # email_account_owner has no accounts — just a freshly-created token
+        token_no_accounts = create(:api_token, :active)
+        allow(ApiToken).to receive(:authenticate).with(token_no_accounts.token).and_return(token_no_accounts)
+        request.headers["Authorization"] = "Bearer #{token_no_accounts.token}"
+
+        post :process_emails
+
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -154,10 +172,16 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     context "error scenarios" do
+      # PR 11: BaseController rescues StandardError → 500 internal_server_error.
+      # Ensure owner has an active account so the per-account path is reached.
+      before { email_account }
+
       it "handles job enqueueing failures gracefully" do
         allow(ProcessEmailsJob).to receive(:perform_later).and_raise(StandardError.new("Queue error"))
 
-        expect { post :process_emails }.to raise_error(StandardError, "Queue error")
+        post :process_emails
+
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end
@@ -388,10 +412,13 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     context "error handling" do
+      # PR 11: BaseController rescues StandardError (and its subclasses) → 500.
       it "handles database connection errors gracefully" do
         allow(Expense).to receive(:for_user).and_raise(ActiveRecord::ConnectionNotEstablished.new("DB error"))
 
-        expect { get :recent_expenses }.to raise_error(ActiveRecord::ConnectionNotEstablished)
+        get :recent_expenses
+
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end
@@ -428,10 +455,13 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     context "error handling" do
+      # PR 11: BaseController rescues StandardError → 500; errors no longer propagate.
       it "handles service initialization failures" do
         allow(Services::ExpenseSummaryService).to receive(:new).and_raise(StandardError.new("Service error"))
 
-        expect { get :expense_summary }.to raise_error(StandardError, "Service error")
+        get :expense_summary
+
+        expect(response).to have_http_status(:internal_server_error)
       end
 
       it "handles service method failures" do
@@ -439,7 +469,9 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
         allow(Services::ExpenseSummaryService).to receive(:new).and_return(summary_service)
         allow(summary_service).to receive(:period).and_raise(StandardError.new("Period error"))
 
-        expect { get :expense_summary }.to raise_error(StandardError, "Period error")
+        get :expense_summary
+
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
 
@@ -837,10 +869,10 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
       end
 
       it "handles job enqueueing delays" do
-        # Test job enqueueing without actual delays. No email_account_id so
-        # we bypass the user-ownership check (queues for all active accounts).
+        # PR 11: no email_account_id queues per owner account. Ensure one exists.
+        email_account # trigger creation of owner's active account
         job_enqueued = false
-        allow(ProcessEmailsJob).to receive(:perform_later) do |*args|
+        allow(ProcessEmailsJob).to receive(:perform_later) do |*_args|
           job_enqueued = true
           true
         end
@@ -853,275 +885,6 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
   end
 
-  # Unit tests for the overridden authenticate_api_token method
-  describe "Authentication Unit Tests", unit: true do
-    describe "#authenticate_api_token (overridden method)" do
-      let(:test_api_token) { create(:api_token, name: "webhooks-test-token") }
-
-      # Override the global authentication setup for these unit tests
-      before do
-        # Clear the global authentication setup
-        request.headers["Authorization"] = nil
-        allow(ApiToken).to receive(:authenticate).and_call_original
-      end
-
-      context "with valid Bearer token" do
-        before do
-          request.headers["Authorization"] = "Bearer #{test_api_token.token}"
-          allow(ApiToken).to receive(:authenticate).with(test_api_token.token).and_return(test_api_token)
-        end
-
-        it "sets @current_api_token instance variable" do
-          controller.send(:authenticate_api_token)
-          expect(controller.instance_variable_get(:@current_api_token)).to eq(test_api_token)
-        end
-
-        it "calls ApiToken.authenticate with extracted token" do
-          controller.send(:authenticate_api_token)
-          expect(ApiToken).to have_received(:authenticate).with(test_api_token.token)
-        end
-
-        it "does not render unauthorized response" do
-          expect(controller).not_to receive(:render)
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "without Authorization header" do
-        it "renders unauthorized JSON response with missing token message" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Missing API token" },
-            status: :unauthorized
-          )
-          result = controller.send(:authenticate_api_token)
-          expect(result).to be_nil
-        end
-
-        it "does not call ApiToken.authenticate due to early return" do
-          allow(controller).to receive(:render)
-          expect(ApiToken).not_to receive(:authenticate)
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "with empty Authorization header" do
-        before do
-          request.headers["Authorization"] = ""
-        end
-
-        it "renders unauthorized JSON response" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Missing API token" },
-            status: :unauthorized
-          )
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "with Authorization header without Bearer prefix" do
-        before do
-          request.headers["Authorization"] = "token_without_bearer"
-          allow(ApiToken).to receive(:authenticate).with("token_without_bearer").and_return(nil)
-        end
-
-        it "extracts token correctly and attempts authentication" do
-          allow(controller).to receive(:render)
-          controller.send(:authenticate_api_token)
-          expect(ApiToken).to have_received(:authenticate).with("token_without_bearer")
-        end
-
-        it "renders unauthorized response when token is invalid" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Invalid or expired API token" },
-            status: :unauthorized
-          )
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "with invalid Bearer token" do
-        before do
-          request.headers["Authorization"] = "Bearer invalid_token_123"
-          allow(ApiToken).to receive(:authenticate).with("invalid_token_123").and_return(nil)
-        end
-
-        it "calls ApiToken.authenticate with invalid token" do
-          allow(controller).to receive(:render)
-          controller.send(:authenticate_api_token)
-          expect(ApiToken).to have_received(:authenticate).with("invalid_token_123")
-        end
-
-        it "renders unauthorized JSON response" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Invalid or expired API token" },
-            status: :unauthorized
-          )
-          controller.send(:authenticate_api_token)
-        end
-
-        it "returns nil" do
-          allow(controller).to receive(:render)
-          result = controller.send(:authenticate_api_token)
-          expect(result).to be_nil
-        end
-
-        it "does not set @current_api_token" do
-          allow(controller).to receive(:render)
-          controller.send(:authenticate_api_token)
-          expect(controller.instance_variable_get(:@current_api_token)).to be_nil
-        end
-      end
-
-      context "with expired token" do
-        let(:expired_token) { create(:api_token, expires_at: 1.day.from_now) }
-
-        before do
-          # Manually expire the token after creation
-          expired_token.update_column(:expires_at, 1.day.ago)
-          request.headers["Authorization"] = "Bearer #{expired_token.token}"
-          allow(ApiToken).to receive(:authenticate).with(expired_token.token).and_return(nil)
-        end
-
-        it "renders unauthorized response for expired token" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Invalid or expired API token" },
-            status: :unauthorized
-          )
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "with malformed Authorization header" do
-        before do
-          request.headers["Authorization"] = "Malformed header format"
-          allow(ApiToken).to receive(:authenticate).with("Malformed header format").and_return(nil)
-        end
-
-        it "attempts to authenticate with malformed header content" do
-          allow(controller).to receive(:render)
-          controller.send(:authenticate_api_token)
-          expect(ApiToken).to have_received(:authenticate).with("Malformed header format")
-        end
-
-        it "renders unauthorized response" do
-          expect(controller).to receive(:render).with(
-            json: { error: "Invalid or expired API token" },
-            status: :unauthorized
-          )
-          controller.send(:authenticate_api_token)
-        end
-      end
-
-      context "security edge cases" do
-        it "handles extremely long tokens" do
-          long_token = "a" * 10000
-          request.headers["Authorization"] = "Bearer #{long_token}"
-          allow(ApiToken).to receive(:authenticate).with(long_token).and_return(nil)
-          allow(controller).to receive(:render)
-
-          controller.send(:authenticate_api_token)
-
-          expect(ApiToken).to have_received(:authenticate).with(long_token)
-        end
-
-        it "handles tokens with special characters" do
-          special_token = "token-with-special@#$%^&*()characters"
-          request.headers["Authorization"] = "Bearer #{special_token}"
-          allow(ApiToken).to receive(:authenticate).with(special_token).and_return(nil)
-          allow(controller).to receive(:render)
-
-          controller.send(:authenticate_api_token)
-
-          expect(ApiToken).to have_received(:authenticate).with(special_token)
-        end
-
-        it "handles SQL injection attempts in token" do
-          malicious_token = "'; DROP TABLE api_tokens; --"
-          request.headers["Authorization"] = "Bearer #{malicious_token}"
-          allow(ApiToken).to receive(:authenticate).with(malicious_token).and_return(nil)
-          allow(controller).to receive(:render)
-
-          controller.send(:authenticate_api_token)
-
-          expect(ApiToken).to have_received(:authenticate).with(malicious_token)
-        end
-
-        it "handles Unicode characters in token" do
-          unicode_token = "token_with_unicode_🔑_characters"
-          request.headers["Authorization"] = "Bearer #{unicode_token}"
-          allow(ApiToken).to receive(:authenticate).with(unicode_token).and_return(nil)
-          allow(controller).to receive(:render)
-
-          controller.send(:authenticate_api_token)
-
-          expect(ApiToken).to have_received(:authenticate).with(unicode_token)
-        end
-      end
-
-      context "method behavior differences from BaseController" do
-        it "renders JSON response directly (no render_unauthorized helper)" do
-          # The webhooks controller renders JSON directly instead of using BaseController's helper
-          expect(controller).to receive(:render).with(
-            json: { error: "Missing API token" },
-            status: :unauthorized
-          )
-
-          controller.send(:authenticate_api_token)
-        end
-
-        it "uses different JSON structure than BaseController" do
-          request.headers["Authorization"] = "Bearer invalid"
-          allow(ApiToken).to receive(:authenticate).with("invalid").and_return(nil)
-
-          expect(controller).to receive(:render).with(
-            json: { error: "Invalid or expired API token" },
-            status: :unauthorized
-          )
-
-          controller.send(:authenticate_api_token)
-        end
-
-        it "returns nil on authentication failure (different from BaseController)" do
-          request.headers["Authorization"] = "Bearer invalid"
-          allow(ApiToken).to receive(:authenticate).with("invalid").and_return(nil)
-          allow(controller).to receive(:render)
-
-          result = controller.send(:authenticate_api_token)
-
-          expect(result).to be_nil
-        end
-      end
-
-      context "integration with ApiToken model" do
-        it "properly handles ApiToken.authenticate returning truthy value" do
-          valid_token_obj = test_api_token
-          request.headers["Authorization"] = "Bearer #{valid_token_obj.token}"
-          allow(ApiToken).to receive(:authenticate).with(valid_token_obj.token).and_return(valid_token_obj)
-
-          controller.send(:authenticate_api_token)
-
-          expect(controller.instance_variable_get(:@current_api_token)).to eq(valid_token_obj)
-        end
-
-        it "properly handles ApiToken.authenticate returning falsy value" do
-          request.headers["Authorization"] = "Bearer falsy_token"
-          allow(ApiToken).to receive(:authenticate).with("falsy_token").and_return(false)
-          allow(controller).to receive(:render)
-
-          controller.send(:authenticate_api_token)
-
-          expect(controller.instance_variable_get(:@current_api_token)).to be_falsy
-        end
-
-        it "properly handles ApiToken.authenticate raising an exception" do
-          request.headers["Authorization"] = "Bearer error_token"
-          allow(ApiToken).to receive(:authenticate).with("error_token").and_raise(StandardError.new("DB error"))
-
-          expect {
-            controller.send(:authenticate_api_token)
-          }.to raise_error(StandardError, "DB error")
-        end
-      end
-    end
-  end
+  # Auth unit tests moved to spec/controllers/api/base_controller_spec.rb in PR 11.
+  # WebhooksController now inherits authenticate_api_token from Api::BaseController.
 end

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Api::WebhooksController, type: :controller, unit: true do
   let(:api_token) { create(:api_token, :active) }
-  let(:email_account) { create(:email_account) }
+  # email_account must belong to the token's owner so user-scoped lookups work
+  let(:email_account) { create(:email_account, user: api_token.user) }
   let(:category) { create(:category) }
 
   before do
@@ -24,7 +25,8 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
         expect(response).to have_http_status(:accepted)
         json_response = JSON.parse(response.body)
         expect(json_response["status"]).to eq("success")
-        expect(json_response["email_account_id"]).to eq(email_account.id.to_s)
+        # PR 11: email_account_id is returned as an integer (from account.id, not string param)
+        expect(json_response["email_account_id"]).to eq(email_account.id)
       end
 
       it "handles string email_account_id parameter" do
@@ -38,13 +40,10 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
       end
 
       it "handles non-numeric email_account_id gracefully" do
-        expect(ProcessEmailsJob).to receive(:perform_later).with(
-          0,
-          since: be_a(Time)
-        )
-
+        # Non-numeric id resolves to 0, which won't match any user-owned account.
+        # PR 11: now returns 404 (access denied) rather than enqueueing for id 0.
         post :process_emails, params: { email_account_id: "invalid" }
-        expect(response).to have_http_status(:accepted)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -293,9 +292,10 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
   end
 
   describe "GET #recent_expenses" do
-    let!(:expense1) { create(:expense, transaction_date: 2.days.ago) }
-    let!(:expense2) { create(:expense, transaction_date: 1.day.ago) }
-    let!(:expense3) { create(:expense, transaction_date: Time.current) }
+    # Expenses must belong to the token's owner for user-scoped queries to return them.
+    let!(:expense1) { create(:expense, user: api_token.user, email_account: email_account, transaction_date: 2.days.ago) }
+    let!(:expense2) { create(:expense, user: api_token.user, email_account: email_account, transaction_date: 1.day.ago) }
+    let!(:expense3) { create(:expense, user: api_token.user, email_account: email_account, transaction_date: Time.current) }
 
     it "returns recent expenses in descending order" do
       # Debug: Verify our expenses exist in the database
@@ -364,7 +364,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     context "edge cases" do
       it "returns empty array when no expenses exist" do
         # Mock the query to return empty results instead of destroying all expenses
-        allow(Expense).to receive_message_chain(:includes, :recent, :limit).and_return([])
+        allow(Expense).to receive_message_chain(:for_user, :includes, :recent, :limit).and_return([])
 
         get :recent_expenses
 
@@ -376,7 +376,12 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
     context "database query optimization" do
       it "includes necessary associations to avoid N+1 queries" do
-        expect(Expense).to receive(:includes).with(:category, :email_account).and_call_original
+        # PR 11: Expense.for_user(user).includes(:category, :email_account)...
+        # Use a simple double because and_call_original requires a partial double.
+        user_scope = double("ExpenseUserScope")
+        allow(Expense).to receive(:for_user).and_return(user_scope)
+        included_scope = double("IncludedScope", recent: double("RecentScope", limit: []))
+        expect(user_scope).to receive(:includes).with(:category, :email_account).and_return(included_scope)
 
         get :recent_expenses
       end
@@ -384,7 +389,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
     context "error handling" do
       it "handles database connection errors gracefully" do
-        allow(Expense).to receive(:includes).and_raise(ActiveRecord::ConnectionNotEstablished.new("DB error"))
+        allow(Expense).to receive(:for_user).and_raise(ActiveRecord::ConnectionNotEstablished.new("DB error"))
 
         expect { get :recent_expenses }.to raise_error(ActiveRecord::ConnectionNotEstablished)
       end
@@ -417,7 +422,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     it "passes period parameter to service" do
-      expect(Services::ExpenseSummaryService).to receive(:new).with("week")
+      expect(Services::ExpenseSummaryService).to receive(:new).with("week", user: api_token.user)
 
       get :expense_summary, params: { period: "week" }
     end
@@ -440,19 +445,19 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
     context "parameter validation" do
       it "handles nil period parameter" do
-        expect(Services::ExpenseSummaryService).to receive(:new).with(nil)
+        expect(Services::ExpenseSummaryService).to receive(:new).with(nil, user: api_token.user)
 
         get :expense_summary, params: { period: nil }
       end
 
       it "handles empty string period parameter" do
-        expect(Services::ExpenseSummaryService).to receive(:new).with("")
+        expect(Services::ExpenseSummaryService).to receive(:new).with("", user: api_token.user)
 
         get :expense_summary, params: { period: "" }
       end
 
       it "handles invalid period parameter" do
-        expect(Services::ExpenseSummaryService).to receive(:new).with("invalid_period")
+        expect(Services::ExpenseSummaryService).to receive(:new).with("invalid_period", user: api_token.user)
 
         get :expense_summary, params: { period: "invalid_period" }
       end
@@ -589,10 +594,20 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     end
 
     describe "#default_email_account" do
+      before do
+        # Inject @current_api_user into the controller so the method can call
+        # @current_api_user.email_accounts.active.first (PR 11 scoping).
+        controller.instance_variable_set(:@current_api_user, api_token.user)
+        controller.instance_variable_set(:@current_api_token, api_token)
+      end
+
       context "when active account exists" do
         it "returns first active account" do
           active_account = double("EmailAccount", provider: "gmail", active: true)
-          allow(EmailAccount).to receive_message_chain(:active, :first).and_return(active_account)
+          accounts_scope = double("accounts_scope")
+          allow(api_token.user).to receive(:email_accounts).and_return(accounts_scope)
+          allow(accounts_scope).to receive(:active).and_return(accounts_scope)
+          allow(accounts_scope).to receive(:first).and_return(active_account)
 
           result = controller.send(:default_email_account)
           expect(result).to eq(active_account)
@@ -601,7 +616,10 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
       context "when no active account exists" do
         it "creates and returns default manual account" do
-          allow(EmailAccount).to receive_message_chain(:active, :first).and_return(nil)
+          accounts_scope = double("accounts_scope")
+          allow(api_token.user).to receive(:email_accounts).and_return(accounts_scope)
+          allow(accounts_scope).to receive(:active).and_return(accounts_scope)
+          allow(accounts_scope).to receive(:first).and_return(nil)
           allow(controller).to receive(:create_default_manual_account).and_return(
             double("EmailAccount", provider: "manual", active: true)
           )
@@ -704,7 +722,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
     context "large dataset handling" do
       it "handles large limit parameter efficiently" do
-        allow(Expense).to receive_message_chain(:includes, :recent, :limit).and_return([])
+        allow(Expense).to receive_message_chain(:for_user, :includes, :recent, :limit).and_return([])
 
         get :recent_expenses, params: { limit: 1000 }
 
@@ -718,7 +736,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
         allow(expenses_relation).to receive(:includes).and_return(expenses_relation)
         allow(expenses_relation).to receive(:recent).and_return(expenses_relation)
         allow(expenses_relation).to receive(:limit).with(50).and_return([])
-        allow(Expense).to receive(:includes).and_return(expenses_relation)
+        allow(Expense).to receive(:for_user).and_return(expenses_relation)
 
         get :recent_expenses, params: { limit: 999999 }
 
@@ -730,7 +748,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
         allow(expenses_relation).to receive(:includes).and_return(expenses_relation)
         allow(expenses_relation).to receive(:recent).and_return(expenses_relation)
         allow(expenses_relation).to receive(:limit).with(10).and_return([])
-        allow(Expense).to receive(:includes).and_return(expenses_relation)
+        allow(Expense).to receive(:for_user).and_return(expenses_relation)
 
         get :recent_expenses, params: { limit: -5 }
 
@@ -743,10 +761,12 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
     context "database optimization" do
       it "uses includes to prevent N+1 queries in recent_expenses" do
         expenses_relation = double("expenses_relation")
+        allow(expenses_relation).to receive(:includes).and_return(expenses_relation)
         allow(expenses_relation).to receive(:recent).and_return(expenses_relation)
         allow(expenses_relation).to receive(:limit).and_return([])
+        allow(Expense).to receive(:for_user).and_return(expenses_relation)
 
-        expect(Expense).to receive(:includes).with(:category, :email_account).and_return(expenses_relation)
+        expect(expenses_relation).to receive(:includes).with(:category, :email_account).and_return(expenses_relation)
 
         get :recent_expenses
       end
@@ -790,8 +810,8 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
 
     context "memory usage" do
       it "efficiently formats many expenses" do
-        many_expenses = Array.new(45) { create(:expense) }
-        allow(Expense).to receive_message_chain(:includes, :recent, :limit).and_return(many_expenses)
+        many_expenses = Array.new(45) { create(:expense, user: api_token.user, email_account: email_account) }
+        allow(Expense).to receive_message_chain(:for_user, :includes, :recent, :limit).and_return(many_expenses)
 
         get :recent_expenses, params: { limit: 50 }
 
@@ -805,7 +825,7 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
       it "handles slow database queries gracefully" do
         # Simulate slow query with stubbing instead of actual sleep
         slow_query_executed = false
-        allow(Expense).to receive_message_chain(:includes, :recent, :limit) do
+        allow(Expense).to receive_message_chain(:for_user, :includes, :recent, :limit) do
           slow_query_executed = true
           []
         end
@@ -817,14 +837,15 @@ RSpec.describe Api::WebhooksController, type: :controller, unit: true do
       end
 
       it "handles job enqueueing delays" do
-        # Test job enqueueing without actual delays
+        # Test job enqueueing without actual delays. No email_account_id so
+        # we bypass the user-ownership check (queues for all active accounts).
         job_enqueued = false
         allow(ProcessEmailsJob).to receive(:perform_later) do |*args|
           job_enqueued = true
           true
         end
 
-        post :process_emails, params: { email_account_id: 1 }
+        post :process_emails
 
         expect(response).to have_http_status(:accepted)
         expect(job_enqueued).to be true

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -68,7 +68,10 @@ RSpec.describe ApplicationController, type: :controller, unit: true do
   describe "inheritance chain", unit: true do
     it "provides base functionality for other controllers" do
       expect(ExpensesController.superclass).to eq(ApplicationController)
-      expect(Api::WebhooksController.superclass).to eq(ApplicationController)
+      # PR 11: WebhooksController now inherits from Api::BaseController (which itself
+      # inherits from ApplicationController), not directly from ApplicationController.
+      expect(Api::WebhooksController.superclass).to eq(Api::BaseController)
+      expect(Api::BaseController.superclass).to eq(ApplicationController)
     end
   end
 end

--- a/spec/db/backfill_api_tokens_user_id_spec.rb
+++ b/spec/db/backfill_api_tokens_user_id_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+migration_file = Dir[Rails.root.join("db/migrate/*backfill_api_tokens_user_id*.rb")].first
+require migration_file
+
+# This spec does DDL (change_column_null) that cannot run within a transaction.
+# Run it explicitly: TEST_ENV_NUMBER=pr11 bundle exec rspec spec/db/backfill_api_tokens_user_id_spec.rb
+RSpec.describe BackfillApiTokensUserId, unit: false, migration: true do
+  let(:migration) { described_class.new }
+
+  def insert_user(email:, role: 0)
+    digest = BCrypt::Password.create("TestPass123!", cost: BCrypt::Engine::MIN_COST)
+    conn = ActiveRecord::Base.connection
+    conn.execute(<<~SQL.squish)
+      INSERT INTO users
+        (email, name, password_digest, role, failed_login_attempts, created_at, updated_at)
+      VALUES
+        (#{conn.quote(email)}, #{conn.quote("Test User")}, #{conn.quote(digest)},
+         #{conn.quote(role)}, 0, NOW(), NOW())
+    SQL
+    User.find_by!(email: email)
+  end
+
+  def insert_api_token(name:, user_id: nil)
+    conn = ActiveRecord::Base.connection
+    token_string = SecureRandom.urlsafe_base64(32)
+    digest = BCrypt::Password.create(token_string, cost: BCrypt::Engine::MIN_COST)
+    token_hash = Digest::SHA256.hexdigest(token_string)
+    uid_sql = user_id.nil? ? "NULL" : conn.quote(user_id)
+    conn.execute(<<~SQL.squish)
+      INSERT INTO api_tokens
+        (name, token_digest, token_hash, active, created_at, updated_at, user_id)
+      VALUES
+        (#{conn.quote(name)}, #{conn.quote(digest)}, #{conn.quote(token_hash)},
+         true, NOW(), NOW(), #{uid_sql})
+    SQL
+    ApiToken.find_by!(name: name)
+  end
+
+  def allow_null_user_id
+    # Temporarily relax NOT NULL so tests can insert NULL rows as they would
+    # at the migration sequence point between step 1 (nullable) and step 3 (not null).
+    ActiveRecord::Base.connection.change_column_null(:api_tokens, :user_id, true)
+  end
+
+  def enforce_not_null_user_id
+    ActiveRecord::Base.connection.change_column_null(:api_tokens, :user_id, false)
+  rescue ActiveRecord::StatementInvalid
+    admin = User.where(role: 1).order(:id).first
+    if admin
+      ActiveRecord::Base.connection.execute(
+        "UPDATE api_tokens SET user_id = #{admin.id} WHERE user_id IS NULL"
+      )
+    end
+    ActiveRecord::Base.connection.change_column_null(:api_tokens, :user_id, false)
+  end
+
+  def cleanup
+    ApiToken.delete_all
+    User.delete_all
+  end
+
+  before do
+    allow_null_user_id
+    cleanup
+  end
+
+  after do
+    cleanup
+    enforce_not_null_user_id
+  end
+
+  describe "#up" do
+    context "when no admin User exists" do
+      it "raises ActiveRecord::MigrationError" do
+        insert_user(email: "regular@example.com", role: 0)
+
+        expect { migration.up }.to raise_error(
+          ActiveRecord::MigrationError,
+          /No admin User found/
+        )
+      end
+
+      it "raises when users table is completely empty" do
+        expect { migration.up }.to raise_error(
+          ActiveRecord::MigrationError,
+          /No admin User found/
+        )
+      end
+    end
+
+    context "when an admin User exists" do
+      let!(:admin_user) { insert_user(email: "admin@example.com", role: 1) }
+
+      it "assigns all NULL user_id api_tokens to the first admin" do
+        t1 = insert_api_token(name: "Token One")
+        t2 = insert_api_token(name: "Token Two")
+
+        migration.up
+
+        expect(t1.reload.user_id).to eq(admin_user.id)
+        expect(t2.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "picks the admin with the lowest id when multiple admins exist" do
+        second_admin = insert_user(email: "admin2@example.com", role: 1)
+        t = insert_api_token(name: "Token X")
+
+        migration.up
+
+        expect(t.reload.user_id).to eq(admin_user.id)
+        expect(t.reload.user_id).not_to eq(second_admin.id)
+      end
+
+      it "does not overwrite already-assigned user_id values" do
+        other_user = insert_user(email: "other@example.com", role: 0)
+        assigned_token = insert_api_token(name: "Assigned Token", user_id: other_user.id)
+        null_token = insert_api_token(name: "Null Token")
+
+        migration.up
+
+        expect(assigned_token.reload.user_id).to eq(other_user.id)
+        expect(null_token.reload.user_id).to eq(admin_user.id)
+      end
+
+      it "handles zero api_tokens gracefully (no-op)" do
+        expect { migration.up }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migration.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/db/index_audit_per126_spec.rb
+++ b/spec/db/index_audit_per126_spec.rb
@@ -484,7 +484,8 @@ RSpec.describe "PER-126 Index Audit", :unit do
       #     one concurrent index each; undo_histories uses existing composite index)
       # +3 for learning signals cluster user_id FK indexes (PR 9: pattern_feedbacks,
       #     pattern_learning_events, categorization_metrics — one concurrent index each)
-      expect(total).to be <= 244  # small buffer for schema drift
+      # +1 for api_tokens.user_id FK index (PR 11: api token user ownership)
+      expect(total).to be <= 245  # small buffer for schema drift
     end
   end
 end

--- a/spec/factories/api_tokens.rb
+++ b/spec/factories/api_tokens.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     expires_at { 1.year.from_now }
     active { true }
     last_used_at { nil }
+    association :user, factory: [ :user, :admin ]
 
     trait :inactive do
       active { false }

--- a/spec/models/api_token_unit_spec.rb
+++ b/spec/models/api_token_unit_spec.rb
@@ -90,6 +90,30 @@ RSpec.describe ApiToken, type: :model, unit: true do
     end
   end
 
+  # PR 11 — user association and for_user scope
+  describe 'associations (PR 11)', unit: true do
+    it 'belongs_to :user' do
+      reflection = ApiToken.reflect_on_association(:user)
+      expect(reflection).to be_present
+      expect(reflection.macro).to eq(:belongs_to)
+    end
+
+    it 'requires a user (not optional)' do
+      reflection = ApiToken.reflect_on_association(:user)
+      expect(reflection.options[:optional]).not_to be true
+    end
+  end
+
+  describe 'scopes (PR 11)', unit: true do
+    describe '.for_user' do
+      it 'filters tokens by user_id' do
+        user = build_stubbed(:user, id: 42)
+        sql = ApiToken.for_user(user).to_sql
+        expect(sql).to include('"user_id" = 42')
+      end
+    end
+  end
+
   describe 'constants' do
     it 'defines expected constants' do
       expect(ApiToken::TOKEN_LENGTH).to eq(32)
@@ -123,7 +147,11 @@ RSpec.describe ApiToken, type: :model, unit: true do
   describe 'callbacks' do
     describe '#generate_token_if_blank' do
       it 'generates token on create when token_digest is blank' do
-        api_token = build(:api_token)
+        # Pre-create the user so User#generate_session_token does not also call
+        # SecureRandom during the save below, which would break the exact-count
+        # expectation on SecureRandom.
+        user = create(:user, :admin)
+        api_token = build(:api_token, user: user)
         api_token.token_digest = nil
 
         expect(SecureRandom).to receive(:urlsafe_base64).with(ApiToken::TOKEN_LENGTH).and_return('generated_token')
@@ -137,7 +165,10 @@ RSpec.describe ApiToken, type: :model, unit: true do
       end
 
       it 'does not generate token when token_digest is present' do
-        api_token = build(:api_token)
+        # Pre-create the user so User#generate_session_token does not also call
+        # SecureRandom during the save below.
+        user = create(:user, :admin)
+        api_token = build(:api_token, user: user)
         api_token.token_digest = 'existing_digest'
 
         expect(SecureRandom).not_to receive(:urlsafe_base64)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -687,6 +687,41 @@ RSpec.describe User, type: :model, unit: true do
     end
   end
 
+  # PR 11 — api_tokens association
+  describe 'api_tokens association (PR 11)' do
+    it 'responds to api_tokens' do
+      user = create(:user)
+      expect(user).to respond_to(:api_tokens)
+    end
+
+    it 'has api_tokens with restrict_with_exception dependent' do
+      reflection = User.reflect_on_association(:api_tokens)
+      expect(reflection).to be_present
+      expect(reflection.options[:dependent]).to eq(:restrict_with_exception)
+    end
+
+    it 'returns only the user\'s api_tokens' do
+      user_a = create(:user, :admin)
+      user_b = create(:user, :admin)
+      token_a = create(:api_token, user: user_a)
+      create(:api_token, user: user_b)
+
+      expect(user_a.api_tokens).to eq([ token_a ])
+    end
+
+    it 'raises DeleteRestrictionError when destroying a user that has api_tokens' do
+      user = create(:user, :admin)
+      create(:api_token, user: user)
+
+      expect { user.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it 'allows destroying a user with no api_tokens' do
+      user = create(:user)
+      expect { user.destroy! }.not_to raise_error
+    end
+  end
+
   # PR 9 — learning signals cluster associations
   describe 'learning signals cluster associations (PR 9)' do
     let(:user) { create(:user) }

--- a/spec/requests/api/v1/categorization_spec.rb
+++ b/spec/requests/api/v1/categorization_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe "Api::V1::Categorization", type: :request, integration: true do
   end
 
   let(:category) { create(:category, name: "Groceries") }
-  let(:expense) { create(:expense, merchant_name: "Walmart", description: "Grocery shopping", amount: 125.50) }
+  # PR 11: expense must belong to the token's user for for_user scoping in the feedback action.
+  let(:user_email_account) { create(:email_account, user: api_token.user) }
+  let(:expense) { create(:expense, user: api_token.user, email_account: user_email_account, merchant_name: "Walmart", description: "Grocery shopping", amount: 125.50) }
   let!(:default_pattern) do
     create(:categorization_pattern,
            pattern_type: "merchant",

--- a/spec/requests/api/v1/token_isolation_spec.rb
+++ b/spec/requests/api/v1/token_isolation_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# PR 11 — Cross-user isolation contract
+#
+# Every /api/v1/* endpoint that returns user-owned data must return ONLY data
+# belonging to the token's owner. Tokens from user_b must not leak user_a's data.
+RSpec.describe "API token isolation (PR 11)", type: :request, unit: true do
+  let(:user_a) { create(:user, :admin) }
+  let(:user_b) { create(:user, :admin) }
+
+  let(:token_a) { create(:api_token, user: user_a) }
+  let(:token_b) { create(:api_token, user: user_b) }
+
+  let(:headers_a) do
+    { "Authorization" => "Bearer #{token_a.token}" }
+  end
+
+  let(:headers_b) do
+    { "Authorization" => "Bearer #{token_b.token}" }
+  end
+
+  let(:json_headers_a) do
+    { "Authorization" => "Bearer #{token_a.token}", "Content-Type" => "application/json" }
+  end
+
+  let(:email_account_a) { create(:email_account, user: user_a) }
+  let(:email_account_b) { create(:email_account, user: user_b) }
+
+  let!(:expense_a1) { create(:expense, user: user_a, email_account: email_account_a) }
+  let!(:expense_a2) { create(:expense, user: user_a, email_account: email_account_a) }
+  let!(:expense_b1) { create(:expense, user: user_b, email_account: email_account_b) }
+
+  describe "GET /api/webhooks/recent_expenses" do
+    it "returns only user_a's expenses for token_a" do
+      get "/api/webhooks/recent_expenses", headers: headers_a
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      returned_ids = json["expenses"].map { |e| e["id"] }
+      expect(returned_ids).to include(expense_a1.id, expense_a2.id)
+      expect(returned_ids).not_to include(expense_b1.id)
+    end
+
+    it "returns only user_b's expenses for token_b" do
+      get "/api/webhooks/recent_expenses", headers: headers_b
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      returned_ids = json["expenses"].map { |e| e["id"] }
+      expect(returned_ids).to include(expense_b1.id)
+      expect(returned_ids).not_to include(expense_a1.id, expense_a2.id)
+    end
+  end
+
+  describe "GET /api/webhooks/expense_summary" do
+    it "returns user_a's summary only for token_a" do
+      get "/api/webhooks/expense_summary", headers: headers_a
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq("success")
+      # Summary should reflect only user_a's count
+      expect(json["summary"]["expense_count"]).to eq(
+        Expense.for_user(user_a).by_date_range(1.month.ago.beginning_of_day, Time.current.end_of_day).count
+      )
+    end
+  end
+
+  describe "POST /api/webhooks/process_emails" do
+    # Use plain (non-JSON) headers so params are sent as form data — the
+    # webhooks controller reads params, not a JSON body.
+    it "allows processing own email account" do
+      post "/api/webhooks/process_emails",
+           params: { email_account_id: email_account_a.id },
+           headers: headers_a
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it "returns 404 when trying to process another user's email account" do
+      post "/api/webhooks/process_emails",
+           params: { email_account_id: email_account_b.id },
+           headers: headers_a
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "locked user token" do
+    # locked_at: 5.minutes.ago is within LOCK_DURATION (30 min), so locked? returns true.
+    # The :locked trait uses 1.hour.ago which exceeds the lock window (unlock_eligible? = true).
+    let(:locked_user) { create(:user, :admin, locked_at: 5.minutes.ago, failed_login_attempts: 5) }
+    let(:locked_token) { create(:api_token, user: locked_user) }
+    let(:locked_headers) do
+      { "Authorization" => "Bearer #{locked_token.token}" }
+    end
+
+    it "returns 401 for a locked user's token on webhooks endpoint" do
+      get "/api/webhooks/recent_expenses", headers: locked_headers
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 for a locked user's token on v1 patterns endpoint" do
+      get "/api/v1/patterns", headers: locked_headers
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "cross-user isolation on v1 patterns (global data)" do
+    it "both tokens can read global category patterns" do
+      get "/api/v1/patterns", headers: headers_a
+      expect(response).to have_http_status(:ok)
+
+      get "/api/v1/patterns", headers: headers_b
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/webhooks_add_expense_spec.rb
+++ b/spec/requests/api/webhooks_add_expense_spec.rb
@@ -12,33 +12,32 @@ RSpec.describe "POST /api/webhooks/add_expense", type: :request do
 
   describe "input validation", :unit do
     context "when the request body is completely missing the expense key" do
-      it "returns 422 JSON instead of 500 HTML" do
+      # PR 11: BaseController rescues ParameterMissing via bad_request → 400.
+      it "returns 400 JSON instead of 500 HTML" do
         post "/api/webhooks/add_expense",
              params: {}.to_json,
              headers: auth_headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:bad_request)
         expect(response.media_type).to eq("application/json")
 
         json = JSON.parse(response.body)
-        expect(json["status"]).to eq("error")
-        expect(json["message"]).to be_present
+        expect(json["error"]).to be_present
       end
     end
 
     context "when expense key is present but body is empty" do
-      it "returns 422 JSON with error message (empty hash triggers ParameterMissing)" do
+      # PR 11: empty hash still raises ParameterMissing → bad_request → 400.
+      it "returns 400 JSON with error message (empty hash triggers ParameterMissing)" do
         post "/api/webhooks/add_expense",
              params: { expense: {} }.to_json,
              headers: auth_headers
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:bad_request)
         expect(response.media_type).to eq("application/json")
 
         json = JSON.parse(response.body)
-        expect(json["status"]).to eq("error")
-        expect(json["message"]).to be_present
-        expect(json).not_to have_key("errors")
+        expect(json["error"]).to be_present
       end
     end
 

--- a/spec/services/expense_summary_service_spec.rb
+++ b/spec/services/expense_summary_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Services::ExpenseSummaryService, integration: true do
     end
 
     context 'with week period' do
-      let(:service) { described_class.new("week") }
+      let(:service) { described_class.new("week", user: email_account.user) }
 
       it 'returns weekly summary with correct structure' do
         result = service.summary
@@ -58,7 +58,7 @@ RSpec.describe Services::ExpenseSummaryService, integration: true do
     end
 
     context 'with month period' do
-      let(:service) { described_class.new("month") }
+      let(:service) { described_class.new("month", user: email_account.user) }
 
       it 'returns monthly summary with correct totals' do
         result = service.summary
@@ -72,7 +72,7 @@ RSpec.describe Services::ExpenseSummaryService, integration: true do
     end
 
     context 'with year period' do
-      let(:service) { described_class.new("year") }
+      let(:service) { described_class.new("year", user: email_account.user) }
 
       it 'returns yearly summary with monthly breakdown' do
         result = service.summary
@@ -88,7 +88,7 @@ RSpec.describe Services::ExpenseSummaryService, integration: true do
     end
 
     context 'with invalid period that gets normalized' do
-      let(:service) { described_class.new("something") }
+      let(:service) { described_class.new("something", user: email_account.user) }
 
       it 'falls back to monthly summary via else clause' do
         result = service.summary
@@ -104,7 +104,10 @@ RSpec.describe Services::ExpenseSummaryService, integration: true do
   end
 
   describe 'private methods', integration: true do
-    let(:service) { described_class.new("month") }
+    # PR 11: ExpenseSummaryService now requires a user (raises on nil). Supply
+    # the email_account's owner so these integration tests exercise the real
+    # scope with a real owner.
+    let(:service) { described_class.new("month", user: email_account.user) }
     let(:private_test_date) { Date.new(2023, 3, 15) } # Different test date to avoid conflicts
     let(:start_date) { 1.month.ago.beginning_of_day }
     let(:end_date) { Time.current.end_of_day }


### PR DESCRIPTION
PR 11 of 14. Most security-sensitive change besides auth. Wires user_id onto api_tokens and scopes every /api/v1/* endpoint + webhooks by the authenticated token's user.

**Migrations (3):** standard 3-step with race guard + inline re-backfill. Schema.rb version 2026_04_21_150200.

**Model:** ApiToken.belongs_to :user (no optional:), scope :for_user. User.has_many :api_tokens, dependent: :restrict_with_exception.

**Base controller:** authenticate_api_token now sets @current_api_user, returns 401 if token owner is nil or locked. Single canonical auth path.

**Webhooks:** now inherits Api::BaseController (no duplicate auth methods). process_emails without email_account_id queues only for @current_api_user.email_accounts.active (was global!). add_expense, recent_expenses, expense_summary, default_email_account all scope via @current_api_user.

**API v1 scoping:** categorization#feedback scopes via Expense.for_user(current_api_user); categorization#statistics scopes PatternFeedback queries (per PR 9 user_id). Categories and Patterns stay global by design.

**ExpenseSummaryService:** now raises ArgumentError on nil user (was Expense.all fallback — cross-user data leak).

**Review chain:**
1. tdd-feature-developer (Sonnet) — initial 1-commit scaffold.
2. Security-reviewer (Sonnet): REQUEST-CHANGES → 3 blockers.
3. Backend-architect (Sonnet): REQUEST-CHANGES → 3 blockers (overlap with security).
4. Consolidated + applied 4 blockers: WebhooksController inheritance unification, process_emails owner-only scope, ExpenseSummaryService nil-user raise, categorization#statistics PatternFeedback scoping.
5. Spec sweep (Sonnet agent): updated webhooks_controller_spec (deleted duplicate auth tests, rewrote process_emails-without-account spec, fixed error-handling specs), webhooks_add_expense_spec (400 vs 422), application_controller_spec (superclass change).

**Cross-user isolation spec:** spec/requests/api/v1/token_isolation_spec.rb — 8 scenarios including locked-user 401, forged email_account_id 404.

**Verification:** 9045 examples 0 failures. Rubocop + brakeman clean.