### PR TITLE
feat(admin): PR 13a/14 — admin users CRUD backend (controller + routes + specs)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -101,6 +101,11 @@ module Admin
       @user.password = new_password
       @user.password_confirmation = new_password
       @user.save!
+      # Invalidate the target user's existing session token so any live
+      # sessions they have open are immediately refused. Without this, a
+      # compromised user whose password was just reset could keep using
+      # the app with the old cookie until session_expires_at (default 2h).
+      @user.invalidate_session!
       # Session (encrypted cookie) rather than flash[:notice] — see #create.
       session[:one_time_password] = { email: @user.email, password: new_password }
       redirect_to admin_users_path, notice: "Password reset for #{@user.email}."

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,9 +41,12 @@ module Admin
       end
 
       if @user.save
-        msg = "User #{@user.email} created."
-        msg += " Temporary password: #{temp_password}" if temp_password
-        redirect_to admin_users_path, notice: msg
+        # Put the temporary password in session (encrypted cookie) rather
+        # than flash[:notice], so it never shows up in Rails logs or
+        # exception-tracker breadcrumbs that capture flash strings. The
+        # index view reads session[:one_time_password] once and clears it.
+        session[:one_time_password] = { email: @user.email, password: temp_password } if temp_password
+        redirect_to admin_users_path, notice: "User #{@user.email} created."
       else
         render :new, status: :unprocessable_content
       end
@@ -98,8 +101,9 @@ module Admin
       @user.password = new_password
       @user.password_confirmation = new_password
       @user.save!
-      redirect_to admin_users_path,
-        notice: "Password reset for #{@user.email}. New password: #{new_password}"
+      # Session (encrypted cookie) rather than flash[:notice] — see #create.
+      session[:one_time_password] = { email: @user.email, password: new_password }
+      redirect_to admin_users_path, notice: "Password reset for #{@user.email}."
     end
 
     private
@@ -140,25 +144,33 @@ module Admin
 
     # Generates a password that satisfies User model complexity requirements:
     # min 12 chars, uppercase, lowercase, digit, special character.
+    # Uses SecureRandom for all random selections — Array#sample is backed
+    # by Mersenne Twister and is not cryptographically secure, which makes
+    # it unsuitable for credential generation.
     def generate_strong_password
       charset_lower   = ("a".."z").to_a
       charset_upper   = ("A".."Z").to_a
       charset_digit   = ("0".."9").to_a
       charset_special = %w[@ $ ! % * ? &]
 
-      # Guarantee at least one of each required class
+      # Guarantee at least one of each required class.
       required = [
-        charset_upper.sample,
-        charset_lower.sample,
-        charset_digit.sample,
-        charset_special.sample
+        secure_pick(charset_upper),
+        secure_pick(charset_lower),
+        secure_pick(charset_digit),
+        secure_pick(charset_special)
       ]
 
-      # Fill the rest with a random mix
+      # Fill the rest with a cryptographically random mix.
       all_chars = charset_lower + charset_upper + charset_digit + charset_special
-      filler = Array.new(12) { all_chars.sample }
+      filler = Array.new(12) { secure_pick(all_chars) }
 
-      (required + filler).shuffle.join
+      # SecureRandom-backed shuffle (sort_by { SecureRandom.random_number })
+      (required + filler).sort_by { SecureRandom.random_number }.join
+    end
+
+    def secure_pick(array)
+      array[SecureRandom.random_number(array.length)]
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module Admin
+  # Manages User accounts from the admin panel.
+  # All actions are gated behind require_admin! (inherited from BaseController).
+  #
+  # Security notes:
+  # - Strong params explicitly permit only :name, :email, :role, :password.
+  # - :session_token, :password_digest, :locked_at, :failed_login_attempts are
+  #   never permitted — those fields are managed exclusively via dedicated
+  #   actions (lock, unlock, reset_password).
+  # - role is validated against User.roles.keys before assignment to prevent
+  #   enum coercion bugs with unknown strings.
+  # - Passwords are generated server-side when not supplied and shown ONCE in
+  #   flash so the admin can share them out of band.
+  class UsersController < Admin::BaseController
+    before_action :set_user, only: [ :edit, :update, :destroy, :lock, :unlock, :reset_password ]
+
+    # GET /admin/users
+    def index
+      @users = User.order(:email)
+      page = [ (params[:page] || 1).to_i, 1 ].max
+      @pagy = Pagy::Offset.new(count: @users.count, page: page, limit: 25)
+      @users = @users.offset(@pagy.offset).limit(@pagy.limit)
+    end
+
+    # GET /admin/users/new
+    def new
+      @user = User.new
+    end
+
+    # POST /admin/users
+    def create
+      @user = User.new(create_user_params)
+      temp_password = nil
+
+      if @user.password.blank?
+        temp_password = generate_strong_password
+        @user.password = temp_password
+        @user.password_confirmation = temp_password
+      end
+
+      if @user.save
+        msg = "User #{@user.email} created."
+        msg += " Temporary password: #{temp_password}" if temp_password
+        redirect_to admin_users_path, notice: msg
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    # GET /admin/users/:id/edit
+    def edit; end
+
+    # PATCH/PUT /admin/users/:id
+    def update
+      if @user.update(update_user_params)
+        redirect_to admin_users_path, notice: "User #{@user.email} updated."
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    # DELETE /admin/users/:id
+    def destroy
+      if @user == current_app_user
+        redirect_to admin_users_path, alert: "You cannot delete your own account."
+        return
+      end
+
+      if @user.admin? && User.admin.where.not(id: @user.id).none?
+        redirect_to admin_users_path, alert: "Cannot delete the last admin account."
+        return
+      end
+
+      @user.destroy!
+      redirect_to admin_users_path, notice: "User #{@user.email} deleted."
+    rescue ActiveRecord::DeleteRestrictionError => e
+      redirect_to admin_users_path,
+        alert: "User #{@user.email} cannot be deleted because they have associated records. #{e.message}"
+    end
+
+    # POST /admin/users/:id/lock
+    def lock
+      @user.lock_account!
+      redirect_to admin_users_path, notice: "User #{@user.email} locked."
+    end
+
+    # POST /admin/users/:id/unlock
+    def unlock
+      @user.unlock_account!
+      redirect_to admin_users_path, notice: "User #{@user.email} unlocked."
+    end
+
+    # POST /admin/users/:id/reset_password
+    def reset_password
+      new_password = generate_strong_password
+      @user.password = new_password
+      @user.password_confirmation = new_password
+      @user.save!
+      redirect_to admin_users_path,
+        notice: "Password reset for #{@user.email}. New password: #{new_password}"
+    end
+
+    private
+
+    def set_user
+      @user = User.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render plain: "Not Found", status: :not_found
+    end
+
+    # Params permitted for creation: includes password (optional — generated if blank).
+    def create_user_params
+      permitted = params.require(:user).permit(:name, :email, :role, :password, :password_confirmation)
+      validate_role!(permitted)
+      permitted
+    end
+
+    # Params permitted for update: password intentionally excluded
+    # (use reset_password action instead).
+    def update_user_params
+      permitted = params.require(:user).permit(:name, :email, :role)
+      validate_role!(permitted)
+      permitted
+    end
+
+    # Validate role against the enum keys to prevent coercion bugs.
+    # Strips the role key from permitted params and re-raises as a validation
+    # error so the form re-renders with a clear message.
+    def validate_role!(permitted)
+      return unless permitted.key?(:role) && permitted[:role].present?
+
+      unless User.roles.key?(permitted[:role])
+        # Remove the bad role so has_secure_password doesn't try to assign it
+        permitted.delete(:role)
+        raise ActionController::BadRequest, "Invalid role: #{params.dig(:user, :role).inspect}"
+      end
+    end
+
+    # Generates a password that satisfies User model complexity requirements:
+    # min 12 chars, uppercase, lowercase, digit, special character.
+    def generate_strong_password
+      charset_lower   = ("a".."z").to_a
+      charset_upper   = ("A".."Z").to_a
+      charset_digit   = ("0".."9").to_a
+      charset_special = %w[@ $ ! % * ? &]
+
+      # Guarantee at least one of each required class
+      required = [
+        charset_upper.sample,
+        charset_lower.sample,
+        charset_digit.sample,
+        charset_special.sample
+      ]
+
+      # Fill the rest with a random mix
+      all_chars = charset_lower + charset_upper + charset_digit + charset_special
+      filler = Array.new(12) { all_chars.sample }
+
+      (required + filler).shuffle.join
+    end
+  end
+end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(model: [:admin, @user]) do |f| %>
+  <% if @user.errors.any? %>
+    <ul id="user-errors">
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :email %>
+    <%= f.email_field :email %>
+  </div>
+
+  <div>
+    <%= f.label :role %>
+    <%= f.select :role, User.roles.keys.map { |r| [r.humanize, r] } %>
+  </div>
+
+  <% if @user.new_record? %>
+    <div>
+      <%= f.label :password, "Password (leave blank to auto-generate)" %>
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+  <% end %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit User: <%= @user.email %></h1>
+
+<%= render "form" %>
+
+<%= link_to "Back to Users", admin_users_path %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -9,6 +9,16 @@
   <p id="flash-alert"><%= flash[:alert] %></p>
 <% end %>
 
+<%# One-time password display — session-stored (not flash) to keep the
+    credential out of Rails logs. Cleared after first render. %>
+<% if (otp = session.delete(:one_time_password)) %>
+  <p id="one-time-password" role="alert">
+    Temporary password for <strong><%= otp["email"] || otp[:email] %></strong>:
+    <code><%= otp["password"] || otp[:password] %></code>
+    — copy it now; it will not be shown again.
+  </p>
+<% end %>
+
 <table>
   <thead>
     <tr>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,40 @@
+<h1>Users</h1>
+
+<%= link_to "New User", new_admin_user_path %>
+
+<% if flash[:notice] %>
+  <p id="flash-notice"><%= flash[:notice] %></p>
+<% end %>
+<% if flash[:alert] %>
+  <p id="flash-alert"><%= flash[:alert] %></p>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Name</th>
+      <th>Role</th>
+      <th>Locked</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.email %></td>
+        <td><%= user.name %></td>
+        <td><%= user.role %></td>
+        <td><%= user.locked_at? ? "Yes" : "No" %></td>
+        <td>
+          <%= link_to "Edit", edit_admin_user_path(user) %>
+          <%= button_to "Lock", lock_admin_user_path(user), method: :post %>
+          <%= button_to "Unlock", unlock_admin_user_path(user), method: :post %>
+          <%= button_to "Reset Password", reset_password_admin_user_path(user), method: :post %>
+          <%= button_to "Delete", admin_user_path(user), method: :delete,
+                data: { confirm: "Delete #{user.email}?" } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New User</h1>
+
+<%= render "form" %>
+
+<%= link_to "Back to Users", admin_users_path %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,26 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "e623899df256a99b9b2ebb1245fedb5d5ff82a8c16f88619e7722a892bcd47eb",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/admin/users_controller.rb",
+      "line": 115,
+      "note": "Admin::UsersController#create_user_params: :role is intentionally permitted for admin-only user management. The endpoint is gated behind require_admin! and role is validated against User.roles.keys before assignment."
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "cf8d294f52e49488e8ed5e93bb20e4add4fce2849f42d1b7b36009e420366a17",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/admin/users_controller.rb",
+      "line": 123,
+      "note": "Admin::UsersController#update_user_params: :role is intentionally permitted for admin-only user management. The endpoint is gated behind require_admin! and role is validated against User.roles.keys before assignment."
+    },
+    {
       "warning_type": "HTTP Verb Confusion",
       "warning_code": 118,
       "fingerprint": "7110067dff86b7b3cf2f34d5175c86ff2d4974d750db836a70e42cbeac669276",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,13 @@ Rails.application.routes.draw do
 
     resources :patterns
     resources :categorization_metrics, only: [ :index ]
+    resources :users do
+      member do
+        post :lock
+        post :unlock
+        post :reset_password
+      end
+    end
     resources :composite_patterns do
       member do
         post :toggle_active

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -461,5 +461,21 @@ RSpec.describe "Admin::Users", type: :request do
       sign_in_as(other_user, password: new_pass)
       expect(response).to redirect_to(root_path)
     end
+
+    it "invalidates the target user's existing session (forces re-login)" do
+      # Give the user a live session token, then reset their password.
+      other_user.update_columns(
+        session_token: SecureRandom.urlsafe_base64(32),
+        session_expires_at: 2.hours.from_now
+      )
+      expect(other_user.reload.session_token).to be_present
+
+      post reset_password_admin_user_path(other_user)
+
+      # Session token and expires_at should be nil after reset —
+      # any open cookie for this user is now useless.
+      expect(other_user.reload.session_token).to be_nil
+      expect(other_user.reload.session_expires_at).to be_nil
+    end
   end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -143,19 +143,21 @@ RSpec.describe "Admin::Users", type: :request do
         expect(response).to redirect_to(admin_users_path)
       end
 
-      it "exposes the generated temp password in the flash" do
+      it "exposes the generated temp password in the session (not flash)" do
+        # PR 13a architect blocker: password stored in session[:one_time_password]
+        # instead of flash[:notice] to keep it out of Rails logs / error trackers.
         post admin_users_path, params: valid_params
-        expect(flash[:notice]).to be_present
-        expect(flash[:notice]).to include("Temporary password:")
+        otp = session[:one_time_password]
+        expect(otp).to be_present
+        expect(otp[:email] || otp["email"]).to eq(valid_params[:user][:email])
+        expect(otp[:password] || otp["password"]).to be_present
+        expect(flash[:notice].to_s).not_to include(otp[:password] || otp["password"])
       end
 
       it "generated password satisfies User model complexity requirements" do
         post admin_users_path, params: valid_params
-        # Extract the password from flash
-        password_match = flash[:notice].match(/Temporary password: (\S+)/)
-        expect(password_match).not_to be_nil
-
-        generated_password = password_match[1]
+        otp = session[:one_time_password]
+        generated_password = otp[:password] || otp["password"]
         expect(generated_password.length).to be >= User::PASSWORD_MIN_LENGTH
         expect(generated_password).to match(/[A-Z]/)
         expect(generated_password).to match(/[a-z]/)
@@ -429,9 +431,11 @@ RSpec.describe "Admin::Users", type: :request do
       expect(other_user.reload.password_digest).not_to eq(old_digest)
     end
 
-    it "exposes the new password ONCE in the flash" do
+    it "exposes the new password ONCE in the session, not flash" do
       post reset_password_admin_user_path(other_user)
-      expect(flash[:notice]).to include("New password:")
+      otp = session[:one_time_password]
+      expect(otp[:password] || otp["password"]).to be_present
+      expect(flash[:notice].to_s).not_to include(otp[:password] || otp["password"])
     end
 
     it "redirects after resetting" do
@@ -441,9 +445,8 @@ RSpec.describe "Admin::Users", type: :request do
 
     it "generated password satisfies complexity requirements" do
       post reset_password_admin_user_path(other_user)
-      password_match = flash[:notice].match(/New password: (\S+)/)
-      expect(password_match).not_to be_nil
-      new_pass = password_match[1]
+      otp = session[:one_time_password]
+      new_pass = otp[:password] || otp["password"]
       expect(new_pass.length).to be >= User::PASSWORD_MIN_LENGTH
       expect(new_pass).to match(/[A-Z]/)
       expect(new_pass).to match(/[a-z]/)
@@ -453,8 +456,8 @@ RSpec.describe "Admin::Users", type: :request do
 
     it "allows the user to log in with the new password" do
       post reset_password_admin_user_path(other_user)
-      new_pass = flash[:notice].match(/New password: (\S+)/)[1]
-
+      otp = session[:one_time_password]
+      new_pass = otp[:password] || otp["password"]
       sign_in_as(other_user, password: new_pass)
       expect(response).to redirect_to(root_path)
     end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1,0 +1,462 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Users", type: :request do
+  let(:password) { "TestPass123!" }
+
+  let(:admin) do
+    create(:user, :admin,
+      email: "admin-#{SecureRandom.hex(4)}@example.com",
+      password: password)
+  end
+
+  let(:regular_user) do
+    create(:user,
+      email: "user-#{SecureRandom.hex(4)}@example.com",
+      password: password)
+  end
+
+  let(:other_user) do
+    create(:user,
+      email: "other-#{SecureRandom.hex(4)}@example.com",
+      password: password)
+  end
+
+  before { sign_in_as(admin, password: password) }
+
+  # ---------------------------------------------------------------------------
+  # Unauthorized access
+  # ---------------------------------------------------------------------------
+  describe "non-admin access", :unit do
+    before { sign_in_as(regular_user, password: password) }
+
+    it "GET /admin/users redirects away (not 200)" do
+      get admin_users_path
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "POST /admin/users redirects away (not 200)" do
+      post admin_users_path, params: { user: { name: "X", email: "x@example.com", role: "user", password: password } }
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "PATCH /admin/users/:id redirects away" do
+      get edit_admin_user_path(regular_user)
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "DELETE /admin/users/:id redirects away" do
+      delete admin_user_path(regular_user)
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "POST lock redirects away" do
+      post lock_admin_user_path(regular_user)
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "POST unlock redirects away" do
+      post unlock_admin_user_path(regular_user)
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "POST reset_password redirects away" do
+      post reset_password_admin_user_path(regular_user)
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+
+  describe "unauthenticated access", :unit do
+    before do
+      # sign out by deleting session
+      delete logout_path
+    end
+
+    it "GET /admin/users redirects to login" do
+      get admin_users_path
+      expect(response).to redirect_to(login_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/users
+  # ---------------------------------------------------------------------------
+  describe "GET /admin/users", :unit do
+    before do
+      # Ensure both users exist
+      admin
+      regular_user
+      other_user
+    end
+
+    it "returns 200" do
+      get admin_users_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists all users (cross-user scope)" do
+      get admin_users_path
+      # Admin can see all users' emails in the response body
+      expect(response.body).to include(regular_user.email)
+      expect(response.body).to include(other_user.email)
+    end
+
+    it "includes the admin themselves in the list" do
+      get admin_users_path
+      expect(response.body).to include(admin.email)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/users/new
+  # ---------------------------------------------------------------------------
+  describe "GET /admin/users/new", :unit do
+    it "returns 200" do
+      get new_admin_user_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/users (create)
+  # ---------------------------------------------------------------------------
+  describe "POST /admin/users", :unit do
+    let(:valid_params) do
+      {
+        user: {
+          name: "New User",
+          email: "newuser-#{SecureRandom.hex(4)}@example.com",
+          role: "user"
+        }
+      }
+    end
+
+    context "with valid params (no password supplied)" do
+      it "creates a new user" do
+        expect { post admin_users_path, params: valid_params }
+          .to change(User, :count).by(1)
+      end
+
+      it "redirects to user list after creation" do
+        post admin_users_path, params: valid_params
+        expect(response).to redirect_to(admin_users_path)
+      end
+
+      it "exposes the generated temp password in the flash" do
+        post admin_users_path, params: valid_params
+        expect(flash[:notice]).to be_present
+        expect(flash[:notice]).to include("Temporary password:")
+      end
+
+      it "generated password satisfies User model complexity requirements" do
+        post admin_users_path, params: valid_params
+        # Extract the password from flash
+        password_match = flash[:notice].match(/Temporary password: (\S+)/)
+        expect(password_match).not_to be_nil
+
+        generated_password = password_match[1]
+        expect(generated_password.length).to be >= User::PASSWORD_MIN_LENGTH
+        expect(generated_password).to match(/[A-Z]/)
+        expect(generated_password).to match(/[a-z]/)
+        expect(generated_password).to match(/\d/)
+        expect(generated_password).to match(/[@$!%*?&]/)
+      end
+    end
+
+    context "with an explicit password supplied" do
+      it "creates the user with the provided password" do
+        params = valid_params.deep_merge(user: { password: "ExplicitPass1!" })
+        expect { post admin_users_path, params: params }
+          .to change(User, :count).by(1)
+      end
+    end
+
+    context "with invalid params (missing email)" do
+      it "does not create a user" do
+        expect {
+          post admin_users_path, params: { user: { name: "Bad", role: "user" } }
+        }.not_to change(User, :count)
+      end
+
+      it "renders the new form (unprocessable content)" do
+        post admin_users_path, params: { user: { name: "Bad", role: "user" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "with forged role escalation from a non-admin (impossible when gated, but test anyway)" do
+      # Admin IS allowed to create another admin — strong params must not strip
+      # the role attribute for admin callers
+      it "allows admin to create an admin-role user" do
+        params = valid_params.deep_merge(user: { role: "admin" })
+        post admin_users_path, params: params
+        expect(User.last.role).to eq("admin")
+      end
+    end
+
+    context "with an invalid role value" do
+      it "does not create a user when role is not in the allowed list" do
+        params = valid_params.deep_merge(user: { role: "superadmin" })
+        expect {
+          post admin_users_path, params: params
+        }.not_to change(User, :count)
+      end
+    end
+
+    context "with forbidden params (session_token, password_digest, locked_at, failed_login_attempts)" do
+      it "ignores forged session_token" do
+        forged_token = "forged_token_abc123"
+        post admin_users_path, params: valid_params.deep_merge(
+          user: { session_token: forged_token }
+        )
+        expect(User.last&.session_token).not_to eq(forged_token)
+      end
+
+      it "ignores forged locked_at to backdoor-lock a user" do
+        post admin_users_path, params: valid_params.deep_merge(
+          user: { locked_at: 1.hour.ago.iso8601 }
+        )
+        expect(User.last&.locked_at).to be_nil
+      end
+
+      it "ignores forged failed_login_attempts" do
+        post admin_users_path, params: valid_params.deep_merge(
+          user: { failed_login_attempts: 99 }
+        )
+        expect(User.last&.failed_login_attempts).to eq(0)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/users/:id/edit
+  # ---------------------------------------------------------------------------
+  describe "GET /admin/users/:id/edit", :unit do
+    it "returns 200 for an existing user" do
+      get edit_admin_user_path(other_user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 404 for a non-existent user" do
+      get edit_admin_user_path(id: 999_999)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PATCH /admin/users/:id (update)
+  # ---------------------------------------------------------------------------
+  describe "PATCH /admin/users/:id", :unit do
+    it "updates the user's name" do
+      patch admin_user_path(other_user), params: { user: { name: "Updated Name" } }
+      expect(other_user.reload.name).to eq("Updated Name")
+    end
+
+    it "redirects to users list after successful update" do
+      patch admin_user_path(other_user), params: { user: { name: "Updated Name" } }
+      expect(response).to redirect_to(admin_users_path)
+    end
+
+    it "does not permit updating session_token via mass assignment" do
+      original_token = other_user.session_token
+      patch admin_user_path(other_user), params: {
+        user: { session_token: "evil_token", name: "Same" }
+      }
+      expect(other_user.reload.session_token).to eq(original_token)
+    end
+
+    it "does not permit updating locked_at via mass assignment" do
+      patch admin_user_path(other_user), params: {
+        user: { locked_at: 1.day.ago.iso8601, name: "Same" }
+      }
+      expect(other_user.reload.locked_at).to be_nil
+    end
+
+    it "renders edit form with 422 when params are invalid" do
+      patch admin_user_path(other_user), params: { user: { name: "" } }
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DELETE /admin/users/:id (destroy)
+  # ---------------------------------------------------------------------------
+  describe "DELETE /admin/users/:id", :unit do
+    it "destroys a regular user with no associated data" do
+      target = create(:user, email: "target-#{SecureRandom.hex(4)}@example.com", password: password)
+      expect { delete admin_user_path(target) }
+        .to change(User, :count).by(-1)
+    end
+
+    it "redirects to user list after successful destroy" do
+      target = create(:user, email: "target2-#{SecureRandom.hex(4)}@example.com", password: password)
+      delete admin_user_path(target)
+      expect(response).to redirect_to(admin_users_path)
+    end
+
+    context "self-destroy prevention" do
+      it "prevents the admin from deleting themselves" do
+        expect { delete admin_user_path(admin) }
+          .not_to change(User, :count)
+      end
+
+      it "redirects with an alert when attempting self-destroy" do
+        delete admin_user_path(admin)
+        expect(response).to redirect_to(admin_users_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "last-admin protection" do
+      it "prevents destroying the last admin" do
+        # admin is the only admin; other_user is :user role
+        expect { delete admin_user_path(other_user) }.not_to change { User.admin.count }
+        # other_user is not admin so count wouldn't change anyway — test the REAL last-admin case:
+        # Create a second admin, then make admin the only one by deleting second
+        second_admin = create(:user, :admin,
+          email: "second-admin-#{SecureRandom.hex(4)}@example.com",
+          password: password)
+        # Now both admin and second_admin exist as admins
+        # Delete second_admin — should succeed (admin remains)
+        expect { delete admin_user_path(second_admin) }.to change(User.where(role: :admin), :count).by(-1)
+      end
+
+      it "blocks destroying the only remaining admin" do
+        # admin is the sole admin; attempt to delete them via a second admin session
+        second_admin = create(:user, :admin,
+          email: "second-admin2-#{SecureRandom.hex(4)}@example.com",
+          password: password)
+        # Sign in as second_admin and try to delete the (now) last-remaining admin
+        sign_in_as(second_admin, password: password)
+        # Make admin the last admin by having no other admins first — delete second_admin itself?
+        # Actually: sign in as second_admin and attempt to delete admin (only one left after second would be gone)
+        # Simpler: try to delete admin while second_admin is signed in (2 admins exist → delete admin is fine)
+        # To test "last admin protection": sign in as second_admin, then delete second_admin first
+        #   → now admin is sole admin; sign back in as admin and attempt delete → blocked
+
+        # Let's just test that when there's only ONE admin in the DB and we try to delete
+        # a DIFFERENT user who is NOT admin — that's fine. The real guard is:
+        # "if after destroy there would be zero admins, block it."
+        #
+        # Actually the guard is: user being destroyed is admin AND no OTHER admin exists.
+        # Sign in as second_admin, try to delete admin (second_admin = one admin remains → allowed).
+        # Sign in as admin, try to delete second_admin (admin = one admin remains → allowed).
+        # BUT: if admin is sole admin and tries to delete themselves → blocked by self-destroy.
+        # If second_admin is sole admin and tries to delete themselves → self-destroy guard catches it.
+        #
+        # The last-admin guard fires when: target is admin AND deleting them would leave zero admins.
+        # i.e., target.admin? && User.admin.where.not(id: target.id).none?
+        #
+        # Setup: only second_admin exists as admin (delete admin from DB directly)
+        admin.update_column(:role, 0)  # demote to :user role
+        expect { delete admin_user_path(second_admin) }.not_to change(User, :count)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "user with associated data" do
+      it "rejects destroy when user has associated expenses (restrict_with_exception)" do
+        category = Category.first || create(:category)
+        expense = create(:expense, user: other_user, category: category)
+        expect(expense).to be_persisted
+
+        expect { delete admin_user_path(other_user) }.not_to change(User, :count)
+        expect(response).to redirect_to(admin_users_path)
+        expect(flash[:alert]).to include("cannot be deleted")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/users/:id/lock
+  # ---------------------------------------------------------------------------
+  describe "POST /admin/users/:id/lock", :unit do
+    it "locks an unlocked user" do
+      expect(other_user.locked_at).to be_nil
+      post lock_admin_user_path(other_user)
+      expect(other_user.reload.locked_at).to be_present
+    end
+
+    it "redirects after locking" do
+      post lock_admin_user_path(other_user)
+      expect(response).to redirect_to(admin_users_path)
+    end
+
+    it "is idempotent — locking an already-locked user is a no-op / succeeds" do
+      other_user.lock_account!
+      expect { post lock_admin_user_path(other_user) }.not_to raise_error
+      expect(response).to redirect_to(admin_users_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/users/:id/unlock
+  # ---------------------------------------------------------------------------
+  describe "POST /admin/users/:id/unlock", :unit do
+    before { other_user.lock_account! }
+
+    it "unlocks a locked user" do
+      post unlock_admin_user_path(other_user)
+      expect(other_user.reload.locked_at).to be_nil
+    end
+
+    it "resets failed_login_attempts on unlock" do
+      other_user.update_column(:failed_login_attempts, 5)
+      post unlock_admin_user_path(other_user)
+      expect(other_user.reload.failed_login_attempts).to eq(0)
+    end
+
+    it "redirects after unlocking" do
+      post unlock_admin_user_path(other_user)
+      expect(response).to redirect_to(admin_users_path)
+    end
+
+    it "is idempotent — unlocking an already-unlocked user succeeds" do
+      other_user.unlock_account!
+      expect { post unlock_admin_user_path(other_user) }.not_to raise_error
+      expect(response).to redirect_to(admin_users_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /admin/users/:id/reset_password
+  # ---------------------------------------------------------------------------
+  describe "POST /admin/users/:id/reset_password", :unit do
+    it "updates the user's password" do
+      old_digest = other_user.password_digest
+      post reset_password_admin_user_path(other_user)
+      expect(other_user.reload.password_digest).not_to eq(old_digest)
+    end
+
+    it "exposes the new password ONCE in the flash" do
+      post reset_password_admin_user_path(other_user)
+      expect(flash[:notice]).to include("New password:")
+    end
+
+    it "redirects after resetting" do
+      post reset_password_admin_user_path(other_user)
+      expect(response).to redirect_to(admin_users_path)
+    end
+
+    it "generated password satisfies complexity requirements" do
+      post reset_password_admin_user_path(other_user)
+      password_match = flash[:notice].match(/New password: (\S+)/)
+      expect(password_match).not_to be_nil
+      new_pass = password_match[1]
+      expect(new_pass.length).to be >= User::PASSWORD_MIN_LENGTH
+      expect(new_pass).to match(/[A-Z]/)
+      expect(new_pass).to match(/[a-z]/)
+      expect(new_pass).to match(/\d/)
+      expect(new_pass).to match(/[@$!%*?&]/)
+    end
+
+    it "allows the user to log in with the new password" do
+      post reset_password_admin_user_path(other_user)
+      new_pass = flash[:notice].match(/New password: (\S+)/)[1]
+
+      sign_in_as(other_user, password: new_pass)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
PR 13a of 14. Backend-only admin user management. Styling lands in PR 13b.

**Added:** Admin::UsersController (155 LOC) with index, new, create, edit, update, destroy, lock, unlock, reset_password. 50-example request spec covering auth gating, forged params, self/last-admin destroy protection, lock/unlock, reset_password round-trip.

**Security-critical design:**
- Strong params permit only :name, :email, :role, :password, :password_confirmation. Never :session_token, :password_digest, :locked_at, :failed_login_attempts.
- Role whitelist: validate_role! raises ActionController::BadRequest if role not in User.roles.keys (user / admin). Prevents enum-coercion escalation.
- Self-destroy and last-admin destroy both blocked with clear error messages.
- dependent: :restrict_with_exception on User has_many surfaces a friendly error when data is tied to the user.
- **Password generation** uses SecureRandom (CSPRNG) — the initial Array#sample approach was a security blocker caught in review.
- **One-time password display** uses session[:one_time_password] (encrypted cookie) instead of flash[:notice] so credentials never appear in Rails logs / error tracker breadcrumbs. The index view reads and deletes the session key on first render.

**Review chain:**
1. tdd-feature-developer (Sonnet) — initial 8 actions + 50 specs.
2. Security+backend review (Sonnet): REQUEST-CHANGES → 2 critical blockers (CSPRNG + flash leak) + non-blocking items. Both blockers applied.
3. Codex requested below.

**Views:** minimal scaffold only — no Tailwind, no Stimulus. PR 13b polishes with the teal/amber palette.

**Verification:** 8988 unit examples, 0 failures. Rubocop + brakeman clean.