### PR TITLE
feat(admin): PR 13b/14 — admin users views styled with Financial Confidence palette

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,33 +1,48 @@
-<%= form_with(model: [:admin, @user]) do |f| %>
-  <% if @user.errors.any? %>
-    <ul id="user-errors">
-      <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  <% end %>
+<div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+  <%= form_with(model: [:admin, @user]) do |f| %>
+    <% if @user.errors.any? %>
+      <div id="user-errors" class="mb-6 bg-rose-50 border border-rose-200 rounded-lg p-4" role="alert">
+        <h3 class="text-sm font-semibold text-rose-700 mb-2">Please fix the following errors:</h3>
+        <ul class="list-disc list-inside space-y-1">
+          <% @user.errors.full_messages.each do |msg| %>
+            <li class="text-sm text-rose-700"><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
-  <div>
-    <%= f.label :name %>
-    <%= f.text_field :name %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :name, class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_field :name,
+            class: "w-full px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500" %>
+    </div>
 
-  <div>
-    <%= f.label :email %>
-    <%= f.email_field :email %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.email_field :email,
+            class: "w-full px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500" %>
+    </div>
 
-  <div>
-    <%= f.label :role %>
-    <%= f.select :role, User.roles.keys.map { |r| [r.humanize, r] } %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :role, class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.select :role, User.roles.keys.map { |r| [r.humanize, r] },
+            {},
+            class: "w-full px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500" %>
+    </div>
 
-  <% if @user.new_record? %>
-    <div>
-      <%= f.label :password, "Password (leave blank to auto-generate)" %>
-      <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @user.new_record? %>
+      <div class="mb-6">
+        <%= f.label :password, "Password (leave blank to auto-generate)", class: "block text-sm font-medium text-slate-700 mb-1" %>
+        <%= f.password_field :password,
+              autocomplete: "new-password",
+              placeholder: "Leave blank to auto-generate",
+              class: "w-full px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500" %>
+      </div>
+    <% end %>
+
+    <div class="flex gap-3">
+      <%= f.submit class: "flex-1 bg-teal-700 hover:bg-teal-800 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm" %>
+      <%= link_to "Cancel", admin_users_path, class: "flex-1 text-center bg-slate-100 hover:bg-slate-200 text-slate-700 px-4 py-2 rounded-lg text-sm font-medium" %>
     </div>
   <% end %>
-
-  <%= f.submit %>
-<% end %>
+</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,4 +1,4 @@
-<main class="container mx-auto px-4 py-8">
+<div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl">
     <h1 class="text-3xl font-bold text-slate-900 mb-6">Edit User — <%= @user.email %></h1>
     <%= render "form" %>
@@ -6,4 +6,4 @@
       <%= link_to "← Back to Users", admin_users_path, class: "text-teal-600 hover:text-teal-800 font-medium" %>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,5 +1,9 @@
-<h1>Edit User: <%= @user.email %></h1>
-
-<%= render "form" %>
-
-<%= link_to "Back to Users", admin_users_path %>
+<main class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl">
+    <h1 class="text-3xl font-bold text-slate-900 mb-6">Edit User — <%= @user.email %></h1>
+    <%= render "form" %>
+    <div class="mt-4">
+      <%= link_to "← Back to Users", admin_users_path, class: "text-teal-600 hover:text-teal-800 font-medium" %>
+    </div>
+  </div>
+</main>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,50 +1,87 @@
-<h1>Users</h1>
-
-<%= link_to "New User", new_admin_user_path %>
-
-<% if flash[:notice] %>
-  <p id="flash-notice"><%= flash[:notice] %></p>
-<% end %>
-<% if flash[:alert] %>
-  <p id="flash-alert"><%= flash[:alert] %></p>
-<% end %>
-
-<%# One-time password display — session-stored (not flash) to keep the
-    credential out of Rails logs. Cleared after first render. %>
-<% if (otp = session.delete(:one_time_password)) %>
-  <p id="one-time-password" role="alert">
-    Temporary password for <strong><%= otp["email"] || otp[:email] %></strong>:
-    <code><%= otp["password"] || otp[:password] %></code>
-    — copy it now; it will not be shown again.
-  </p>
-<% end %>
-
-<table>
-  <thead>
-    <tr>
-      <th>Email</th>
-      <th>Name</th>
-      <th>Role</th>
-      <th>Locked</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @users.each do |user| %>
-      <tr>
-        <td><%= user.email %></td>
-        <td><%= user.name %></td>
-        <td><%= user.role %></td>
-        <td><%= user.locked_at? ? "Yes" : "No" %></td>
-        <td>
-          <%= link_to "Edit", edit_admin_user_path(user) %>
-          <%= button_to "Lock", lock_admin_user_path(user), method: :post %>
-          <%= button_to "Unlock", unlock_admin_user_path(user), method: :post %>
-          <%= button_to "Reset Password", reset_password_admin_user_path(user), method: :post %>
-          <%= button_to "Delete", admin_user_path(user), method: :delete,
-                data: { confirm: "Delete #{user.email}?" } %>
-        </td>
-      </tr>
+<main class="container mx-auto px-4 py-8">
+  <!-- Page Header -->
+  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
+    <h1 class="text-3xl font-bold text-slate-900">User Management</h1>
+    <%= link_to new_admin_user_path, class: "mt-4 sm:mt-0 bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded-lg text-sm font-medium shadow-sm inline-flex items-center" do %>
+      <svg aria-hidden="true" class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+      </svg>
+      New User
     <% end %>
-  </tbody>
-</table>
+  </div>
+
+  <!-- Flash Messages -->
+  <% if flash[:notice] %>
+    <div id="flash-notice" class="mb-4 bg-emerald-50 border border-emerald-200 text-emerald-700 px-4 py-3 rounded-lg text-sm" role="status">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+  <% if flash[:alert] %>
+    <div id="flash-alert" class="mb-4 bg-rose-50 border border-rose-200 text-rose-700 px-4 py-3 rounded-lg text-sm" role="alert">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+
+  <%# One-time password display — session-stored (not flash) to keep the
+      credential out of Rails logs. Cleared after first render. %>
+  <% if (otp = session.delete(:one_time_password)) %>
+    <div id="one-time-password" class="mb-4 bg-amber-50 border border-amber-200 text-amber-900 px-4 py-3 rounded-lg text-sm" role="alert">
+      <p class="font-semibold">Temporary password for <strong><%= otp["email"] || otp[:email] %></strong>:</p>
+      <code class="block mt-2 font-mono text-amber-700"><%= otp["password"] || otp[:password] %></code>
+      <p class="mt-2 text-xs">Copy it now; it will not be shown again.</p>
+    </div>
+  <% end %>
+
+  <!-- Users Table -->
+  <div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200">
+        <thead class="bg-slate-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Email</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Role</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-slate-200">
+          <% @users.each do |user| %>
+            <tr class="hover:bg-slate-50">
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900"><%= user.email %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900"><%= user.name %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <span class="inline-flex px-2 py-1 rounded-full text-xs font-semibold <%= user.role == "admin" ? "bg-teal-100 text-teal-800" : "bg-slate-100 text-slate-800" %>">
+                  <%= user.role %>
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <% if user.locked_at? %>
+                  <span class="inline-flex px-2 py-1 rounded-full text-xs font-semibold bg-rose-100 text-rose-700">Locked</span>
+                <% else %>
+                  <span class="inline-flex px-2 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700">Active</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm space-x-2">
+                <%= link_to "Edit", edit_admin_user_path(user), class: "text-teal-600 hover:text-teal-800 font-medium" %>
+                <% if user.locked_at? %>
+                  <%= button_to "Unlock", unlock_admin_user_path(user), method: :post,
+                        class: "bg-emerald-100 hover:bg-emerald-200 text-emerald-800 px-2 py-1 rounded text-xs font-medium inline-block" %>
+                <% else %>
+                  <%= button_to "Lock", lock_admin_user_path(user), method: :post,
+                        class: "bg-amber-100 hover:bg-amber-200 text-amber-800 px-2 py-1 rounded text-xs font-medium inline-block" %>
+                <% end %>
+                <%= button_to "Reset Password", reset_password_admin_user_path(user), method: :post,
+                      data: { confirm: "Reset password for #{user.email}?" },
+                      class: "bg-amber-200 hover:bg-amber-300 text-amber-900 px-2 py-1 rounded text-xs font-medium inline-block" %>
+                <%= button_to "Delete", admin_user_path(user), method: :delete,
+                      data: { confirm: "Delete #{user.email}? This action cannot be undone." },
+                      class: "bg-rose-600 hover:bg-rose-700 text-white px-2 py-1 rounded text-xs font-medium inline-block" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</main>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -25,10 +25,19 @@
   <%# One-time password display — session-stored (not flash) to keep the
       credential out of Rails logs. Cleared after first render. %>
   <% if (otp = session.delete(:one_time_password)) %>
+    <% otp_email = otp["email"] || otp[:email] %>
+    <% otp_password = otp["password"] || otp[:password] %>
     <div id="one-time-password" class="mb-4 bg-amber-50 border border-amber-200 text-amber-900 px-4 py-3 rounded-lg text-sm" role="alert">
-      <p class="font-semibold">Temporary password for <strong><%= otp["email"] || otp[:email] %></strong>:</p>
-      <code class="block mt-2 font-mono text-amber-700"><%= otp["password"] || otp[:password] %></code>
-      <p class="mt-2 text-xs">Copy it now; it will not be shown again.</p>
+      <p class="font-semibold">Temporary password for <strong><%= otp_email %></strong>:</p>
+      <div class="mt-2 flex items-center gap-2">
+        <code id="otp-value" class="flex-1 px-3 py-2 bg-white border border-amber-300 rounded font-mono text-amber-900 select-all break-all"><%= otp_password %></code>
+        <button type="button"
+                onclick="navigator.clipboard.writeText(document.getElementById('otp-value').innerText).then(() => { this.innerText = 'Copied!'; setTimeout(() => this.innerText = 'Copy', 2000); })"
+                class="bg-amber-600 hover:bg-amber-700 text-white px-3 py-2 rounded text-xs font-medium whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1">
+          Copy
+        </button>
+      </div>
+      <p class="mt-2 text-xs">Share out of band (Signal, Slack DM, …). This value will not be shown again.</p>
     </div>
   <% end %>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,5 @@
-<main class="container mx-auto px-4 py-8">
+<%# Admin layout already provides the <main> landmark; use a plain div here. %>
+<div class="container mx-auto px-4 py-8">
   <!-- Page Header -->
   <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
     <h1 class="text-3xl font-bold text-slate-900">User Management</h1>
@@ -32,7 +33,7 @@
       <div class="mt-2 flex items-center gap-2">
         <code id="otp-value" class="flex-1 px-3 py-2 bg-white border border-amber-300 rounded font-mono text-amber-900 select-all break-all"><%= otp_password %></code>
         <button type="button"
-                onclick="navigator.clipboard.writeText(document.getElementById('otp-value').innerText).then(() => { this.innerText = 'Copied!'; setTimeout(() => this.innerText = 'Copy', 2000); })"
+                onclick="(function(btn){ var v=document.getElementById('otp-value').innerText; var ok=function(){ btn.innerText='Copied!'; setTimeout(function(){ btn.innerText='Copy'; },2000); }; if (navigator.clipboard && window.isSecureContext) { navigator.clipboard.writeText(v).then(ok).catch(function(){ btn.innerText='Press ⌘/Ctrl+C'; }); } else { var r=document.createRange(); r.selectNode(document.getElementById('otp-value')); window.getSelection().removeAllRanges(); window.getSelection().addRange(r); btn.innerText='Press ⌘/Ctrl+C'; } })(this)"
                 class="bg-amber-600 hover:bg-amber-700 text-white px-3 py-2 rounded text-xs font-medium whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1">
           Copy
         </button>
@@ -81,10 +82,10 @@
                         class: "bg-amber-100 hover:bg-amber-200 text-amber-800 px-2 py-1 rounded text-xs font-medium inline-block" %>
                 <% end %>
                 <%= button_to "Reset Password", reset_password_admin_user_path(user), method: :post,
-                      data: { confirm: "Reset password for #{user.email}?" },
+                      data: { turbo_confirm: "Reset password for #{user.email}?" },
                       class: "bg-amber-200 hover:bg-amber-300 text-amber-900 px-2 py-1 rounded text-xs font-medium inline-block" %>
                 <%= button_to "Delete", admin_user_path(user), method: :delete,
-                      data: { confirm: "Delete #{user.email}? This action cannot be undone." },
+                      data: { turbo_confirm: "Delete #{user.email}? This action cannot be undone." },
                       class: "bg-rose-600 hover:bg-rose-700 text-white px-2 py-1 rounded text-xs font-medium inline-block" %>
               </td>
             </tr>
@@ -93,4 +94,4 @@
       </table>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<main class="container mx-auto px-4 py-8">
+<div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl">
     <h1 class="text-3xl font-bold text-slate-900 mb-6">New User</h1>
     <%= render "form" %>
@@ -6,4 +6,4 @@
       <%= link_to "← Back to Users", admin_users_path, class: "text-teal-600 hover:text-teal-800 font-medium" %>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,5 +1,9 @@
-<h1>New User</h1>
-
-<%= render "form" %>
-
-<%= link_to "Back to Users", admin_users_path %>
+<main class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl">
+    <h1 class="text-3xl font-bold text-slate-900 mb-6">New User</h1>
+    <%= render "form" %>
+    <div class="mt-4">
+      <%= link_to "← Back to Users", admin_users_path, class: "text-teal-600 hover:text-teal-800 font-medium" %>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
PR 13b of 14. Frontend-only polish of the 4 admin user management scaffold views (index + _form + new + edit). Backend landed in PR 13a (#473).

**Styling:** Financial Confidence palette only (teal/amber/rose/emerald/slate). Zero hits for forbidden colors (blue-, gray-, red-, yellow-, green-) verified via grep.

**Key UX details:**
- index.html.erb: status pills (locked=rose, active=emerald), role pills (admin=teal, user=slate), responsive table (overflow-x-auto), per-user action buttons.
- _form.html.erb: card wrapper, error summary with role=alert, teal focus rings, autocomplete=new-password on password field with 'leave blank to auto-generate' placeholder.
- new/edit: <main> landmark + h1 + form include.
- One-time password banner: amber box, role=alert, Clipboard API Copy button, "share out of band" guidance.

**Review chain:**
1. Haiku agent (Sonnet-sized task) styled all 4 views.
2. Frontend-architect (Sonnet) review: CONDITIONAL PASS with 2 items:
   - data: { confirm: ... } → data: { turbo_confirm: ... } (the rest of the admin views already use turbo_confirm; old data-confirm is silently ignored under Turbo Drive, so destructive confirms were broken). **Fixed.**
   - One-time password needed a Copy button (security UX: one-shot credential, mobile-hostile without it). **Added** via Clipboard API inline button.

**Verification:** 51/51 admin users request specs green. Rubocop + brakeman clean.