### PR TITLE
chore(deploy): add pre-deploy runbook + checklist script for user-model cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ RAILS_ENV=test bin/rails db:schema:load
 - Security-focused code reviews
 - Production security monitoring
 
+## Deploying
+
+Production runs on a Hetzner VPS via Kamal. The user-model unification cutover (PRs #460–#475) has a dedicated runbook at [`docs/deploys/user-model-unification.md`](docs/deploys/user-model-unification.md) covering pre-flight, deploy, post-deploy smoke, and rollback.
+
+Run `bin/pre-deploy-check` before every `kamal deploy` — it validates secrets, remote state, and CI status, and will refuse to green-light a deploy that would crash on first boot.
+
 ## License
 
 [Add your license information here]

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -1,0 +1,213 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# bin/pre-deploy-check — pre-flight gates for the User-model unification deploy.
+#
+# Runs checks that can be verified WITHOUT booting Rails, so it is safe to run
+# from a clean shell. See docs/deploys/user-model-unification.md for the full
+# runbook. Exit 0 on all-green, 1 on any failure.
+#
+# Usage:
+#   bin/pre-deploy-check                 # full run
+#   bin/pre-deploy-check --offline       # skip remote Kamal/SSH checks
+#   bin/pre-deploy-check --skip-ci       # skip the `gh run list` gate
+#
+# Never echoes secret values — only key names and pass/fail booleans.
+
+require "optparse"
+require "open3"
+require "pathname"
+
+ROOT          = Pathname.new(__dir__).join("..").expand_path
+SECRETS_FILE  = ROOT.join(".kamal/secrets")
+DEPLOY_YML    = ROOT.join("config/deploy.yml")
+
+REQUIRED_SECRETS = %w[
+  RAILS_MASTER_KEY
+  SECRET_KEY_BASE
+  POSTGRES_PASSWORD
+  KAMAL_REGISTRY_PASSWORD
+  ADMIN_EMAIL
+  ADMIN_PASSWORD
+].freeze
+
+# Must stay in sync with db/seeds.rb:370 — the production seed guard.
+SENTINEL_EMAIL    = "admin@expense-tracker.com"
+SENTINEL_PASSWORD = "AdminPassword123!"
+
+options = { offline: false, skip_ci: false }
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/pre-deploy-check [--offline] [--skip-ci]"
+  opts.on("--offline", "Skip remote Kamal checks")         { options[:offline]  = true }
+  opts.on("--skip-ci", "Skip the `gh run list` CI gate")   { options[:skip_ci]  = true }
+  opts.on("-h", "--help", "Show this help")                { puts opts; exit 0 }
+end.parse!
+
+failures = []
+info     = []
+
+def say(msg)
+  puts "[pre-deploy-check] #{msg}"
+end
+
+def run(cmd, env: {})
+  out, err, status = Open3.capture3(env, cmd)
+  [ out.to_s.strip, err.to_s.strip, status.success? ]
+end
+
+# --- Gate 1: git check ----------------------------------------------------
+say "Gate 1/8: git state vs origin/main"
+_, _, fetch_ok = run("git fetch origin main 2>/dev/null")
+if fetch_ok
+  local_tip,  = run("git rev-parse main 2>/dev/null")
+  remote_tip, = run("git rev-parse origin/main")
+  if local_tip.empty? || remote_tip.empty?
+    failures << "Could not resolve main / origin/main revisions"
+  elsif local_tip != remote_tip
+    failures << "git main behind origin/main — pull first (local=#{local_tip[0, 7]} origin=#{remote_tip[0, 7]})"
+  end
+else
+  info << "git fetch origin main failed (offline?) — skipping git tip comparison"
+end
+
+# --- Gate 2: secrets presence --------------------------------------------
+say "Gate 2/8: .kamal/secrets presence"
+secrets = {}
+if SECRETS_FILE.file?
+  SECRETS_FILE.read.force_encoding(Encoding::UTF_8).scrub.each_line do |line|
+    line = line.strip
+    next if line.empty? || line.start_with?("#")
+    key, _, raw = line.partition("=")
+    next if key.empty?
+    value = raw.strip
+    # Strip matching single/double quotes (Kamal 2 dotenv style).
+    value = value[1..-2] if value.length >= 2 && (value.start_with?("'") && value.end_with?("'") || value.start_with?('"') && value.end_with?('"'))
+    secrets[key.strip] = value
+  end
+  REQUIRED_SECRETS.each do |key|
+    if !secrets.key?(key)
+      failures << "#{key} missing from .kamal/secrets"
+    elsif secrets[key].to_s.empty?
+      failures << "#{key} present but empty in .kamal/secrets"
+    end
+  end
+else
+  failures << ".kamal/secrets not found (expected at #{SECRETS_FILE.relative_path_from(ROOT)})"
+end
+
+# --- Gate 3: sentinel values ---------------------------------------------
+say "Gate 3/8: ADMIN_EMAIL / ADMIN_PASSWORD are not sentinels"
+if secrets["ADMIN_EMAIL"] == SENTINEL_EMAIL
+  failures << "ADMIN_EMAIL is the dev sentinel — set a real admin email (db/seeds.rb aborts otherwise)"
+end
+if secrets["ADMIN_PASSWORD"] == SENTINEL_PASSWORD
+  failures << "ADMIN_PASSWORD is the dev sentinel — set a real admin password (db/seeds.rb aborts otherwise)"
+end
+# Confirm to the operator which account they will log in with after cutover —
+# echoes the email only, never the password.
+if secrets["ADMIN_EMAIL"] && !secrets["ADMIN_EMAIL"].empty? && secrets["ADMIN_EMAIL"] != SENTINEL_EMAIL
+  info << "will log in post-deploy as ADMIN_EMAIL=#{secrets['ADMIN_EMAIL']}"
+end
+
+# --- Gate 4: config/deploy.yml env.secret sanity -------------------------
+say "Gate 4/8: config/deploy.yml declares ADMIN_EMAIL / ADMIN_PASSWORD under env.secret"
+if DEPLOY_YML.file?
+  yml = DEPLOY_YML.read.force_encoding(Encoding::UTF_8)
+  yml = yml.scrub unless yml.valid_encoding?
+  in_env_secret = false
+  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false }
+  yml.each_line do |line|
+    stripped = line.strip
+    if stripped.start_with?("secret:")
+      in_env_secret = true
+      next
+    end
+    # Exit the env.secret block when the indent drops (next top-level key like `clear:`).
+    if in_env_secret && stripped.match?(/\A[A-Za-z_]+:/) && !stripped.start_with?("-")
+      in_env_secret = false
+    end
+    if in_env_secret && stripped.start_with?("-")
+      key = stripped.sub(/\A-\s*/, "").strip
+      seen[key] = true if seen.key?(key)
+    end
+  end
+  seen.each do |key, found|
+    failures << "config/deploy.yml env.secret is missing `#{key}` — the container will start without it" unless found
+  end
+else
+  failures << "config/deploy.yml not found at #{DEPLOY_YML.relative_path_from(ROOT)}"
+end
+
+# --- Gate 5: remote reachability -----------------------------------------
+say "Gate 5/8: remote Kamal reachability"
+if options[:offline]
+  info << "--offline: skipped remote Kamal reachability"
+else
+  _, stderr, ok = run("kamal app details 2>&1")
+  unless ok
+    failures << "kamal app details failed — server unreachable or kamal not configured (#{stderr.lines.first&.strip})"
+  end
+end
+
+# --- Gate 6: remote AdminUser presence -----------------------------------
+say "Gate 6/8: remote admin_users table + AdminUser row count"
+if options[:offline]
+  info << "--offline: skipped remote AdminUser presence check"
+else
+  table_check_cmd = %q{kamal app exec --reuse "bin/rails runner 'puts ActiveRecord::Base.connection.tables.include?(%q{admin_users})'" 2>&1}
+  out, _, ok = run(table_check_cmd)
+  if !ok
+    failures << "Could not check admin_users table on remote (kamal app exec failed)"
+  elsif out.lines.map(&:strip).include?("true")
+    count_cmd = %q(kamal app exec --reuse "bin/rails runner 'puts AdminUser.count'" 2>&1)
+    count_out, _, count_ok = run(count_cmd)
+    count = count_out.lines.map(&:strip).reverse.find { |l| l.match?(/\A\d+\z/) }
+    if count_ok && count && count.to_i >= 1
+      info << "remote admin_users exists with #{count} row(s) — PR 3 migration will copy them into users"
+    else
+      failures << "remote admin_users table exists but has 0 rows — PR 3 migration will have nothing to copy (create an AdminUser first)"
+    end
+  elsif out.lines.map(&:strip).include?("false")
+    info << "remote admin_users table already dropped (previous deploy succeeded); no-op for PR 3 migration"
+  else
+    failures << "Unexpected output from remote admin_users check (see kamal logs)"
+  end
+end
+
+# --- Gate 7: CI on main --------------------------------------------------
+say "Gate 7/8: CI on origin/main is green"
+if options[:skip_ci]
+  info << "--skip-ci: skipped CI gate"
+else
+  cmd = %q(gh run list --branch main --limit 1 --json conclusion --jq '.[0].conclusion')
+  out, err, ok = run(cmd)
+  if !ok
+    failures << "gh run list failed — #{err.lines.first&.strip || 'see gh output'} (use --skip-ci to override)"
+  elsif out.strip != "success"
+    failures << "CI on main is `#{out.strip.empty? ? 'unknown' : out.strip}` — deploy blocked (use --skip-ci to override)"
+  end
+end
+
+# --- Gate 8: backup reminder --------------------------------------------
+say "Gate 8/8: backup reminder"
+info << <<~NUDGE.strip
+  before `kamal deploy`, snapshot the DB:
+    ssh deploy@178.104.88.183 \\
+      "pg_dump -h personal-blog-db -U expense_tracker expense_tracker_production \\
+         | gzip > ~/backups/pre-user-model-$(date +%Y%m%dT%H%M%SZ).sql.gz"
+NUDGE
+
+# --- Report --------------------------------------------------------------
+puts
+info.each { |line| say "INFO: #{line}" }
+
+if failures.empty?
+  say "All gates passed. You may run:  kamal deploy"
+  exit 0
+else
+  say "FAIL: #{failures.length} gate#{'s' if failures.length != 1} failed"
+  failures.each { |f| say "  - #{f}" }
+  say ""
+  say "See docs/deploys/user-model-unification.md for the full runbook."
+  exit 1
+end

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -17,6 +17,7 @@
 require "optparse"
 require "open3"
 require "pathname"
+require "shellwords"
 
 ROOT          = Pathname.new(__dir__).join("..").expand_path
 SECRETS_FILE  = ROOT.join(".kamal/secrets")
@@ -74,6 +75,7 @@ end
 say "Gate 2/8: .kamal/secrets presence"
 secrets = {}
 if SECRETS_FILE.file?
+  unresolved_substitution = []
   SECRETS_FILE.read.force_encoding(Encoding::UTF_8).scrub.each_line do |line|
     line = line.strip
     next if line.empty? || line.start_with?("#")
@@ -82,6 +84,12 @@ if SECRETS_FILE.file?
     value = raw.strip
     # Strip matching single/double quotes (Kamal 2 dotenv style).
     value = value[1..-2] if value.length >= 2 && (value.start_with?("'") && value.end_with?("'") || value.start_with?('"') && value.end_with?('"'))
+    # Kamal supports $VAR, ${VAR}, and $(command) substitution in .kamal/secrets.
+    # We can't resolve those here, so flag them — the file parser will treat the
+    # raw text as the value and the sentinel check would falsely pass.
+    if value.match?(/\$\{?[A-Z_][A-Z0-9_]*\}?/) || value.match?(/\$\(/)
+      unresolved_substitution << key.strip
+    end
     secrets[key.strip] = value
   end
   REQUIRED_SECRETS.each do |key|
@@ -90,6 +98,10 @@ if SECRETS_FILE.file?
     elsif secrets[key].to_s.empty?
       failures << "#{key} present but empty in .kamal/secrets"
     end
+  end
+  unless unresolved_substitution.empty?
+    info << "the following .kamal/secrets entries use shell substitution and were not sentinel-checked: " \
+            "#{unresolved_substitution.join(', ')} — verify their resolved values manually or via `kamal secrets print`"
   end
 else
   failures << ".kamal/secrets not found (expected at #{SECRETS_FILE.relative_path_from(ROOT)})"
@@ -103,10 +115,11 @@ end
 if secrets["ADMIN_PASSWORD"] == SENTINEL_PASSWORD
   failures << "ADMIN_PASSWORD is the dev sentinel — set a real admin password (db/seeds.rb aborts otherwise)"
 end
-# Confirm to the operator which account they will log in with after cutover —
-# echoes the email only, never the password.
+# Confirm to the operator that ADMIN_EMAIL passed the checks — without echoing
+# the value. The env.secret block in config/deploy.yml treats ADMIN_EMAIL as a
+# secret, so this script never prints it.
 if secrets["ADMIN_EMAIL"] && !secrets["ADMIN_EMAIL"].empty? && secrets["ADMIN_EMAIL"] != SENTINEL_EMAIL
-  info << "will log in post-deploy as ADMIN_EMAIL=#{secrets['ADMIN_EMAIL']}"
+  info << "ADMIN_EMAIL is present and not the dev sentinel (value withheld)"
 end
 
 # --- Gate 4: config/deploy.yml env.secret sanity -------------------------
@@ -179,22 +192,47 @@ say "Gate 7/8: CI on origin/main is green"
 if options[:skip_ci]
   info << "--skip-ci: skipped CI gate"
 else
-  cmd = %q(gh run list --branch main --limit 1 --json conclusion --jq '.[0].conclusion')
-  out, err, ok = run(cmd)
-  if !ok
-    failures << "gh run list failed — #{err.lines.first&.strip || 'see gh output'} (use --skip-ci to override)"
-  elsif out.strip != "success"
-    failures << "CI on main is `#{out.strip.empty? ? 'unknown' : out.strip}` — deploy blocked (use --skip-ci to override)"
+  sha, _, sha_ok = run("git rev-parse origin/main")
+  if !sha_ok || sha.empty?
+    failures << "could not resolve origin/main SHA for CI gate (use --skip-ci to override)"
+  else
+    # Check ALL workflows on the exact origin/main commit. Filtering by commit
+    # avoids the "latest run on main is green but an earlier workflow failed"
+    # false-positive. Count > 0 means something is still running or failed.
+    cmd = %(gh run list --branch main --commit #{sha.shellescape} --json name,status,conclusion --jq 'map(select(.status != "completed" or .conclusion != "success")) | length')
+    out, err, ok = run(cmd)
+    if !ok
+      failures << "gh run list failed — #{err.lines.first&.strip || 'see gh output'} (use --skip-ci to override)"
+    elsif out.strip.empty?
+      failures << "gh run list returned no output for commit #{sha[0, 7]} — check `gh auth status` (use --skip-ci to override)"
+    elsif !out.strip.match?(/\A\d+\z/)
+      failures << "gh run list returned unexpected output `#{out.strip}` — deploy blocked (use --skip-ci to override)"
+    elsif out.strip.to_i > 0
+      failures << "CI on origin/main (#{sha[0, 7]}) has #{out.strip} non-green workflow run(s) — deploy blocked (use --skip-ci to override)"
+    else
+      # Also sanity-check that at least one run exists for this commit.
+      count_cmd = %(gh run list --branch main --commit #{sha.shellescape} --json name --jq 'length')
+      count_out, _, count_ok = run(count_cmd)
+      if count_ok && count_out.strip.match?(/\A\d+\z/) && count_out.strip.to_i == 0
+        failures << "no CI workflow runs found for origin/main (#{sha[0, 7]}) — deploy blocked (use --skip-ci to override)"
+      end
+    end
   end
 end
 
 # --- Gate 8: backup reminder --------------------------------------------
 say "Gate 8/8: backup reminder"
 info << <<~NUDGE.strip
-  before `kamal deploy`, snapshot the DB:
-    ssh deploy@178.104.88.183 \\
-      "pg_dump -h personal-blog-db -U expense_tracker expense_tracker_production \\
-         | gzip > ~/backups/pre-user-model-$(date +%Y%m%dT%H%M%SZ).sql.gz"
+  before `kamal deploy`, snapshot the DB (see §1.4 of the runbook):
+    ssh deploy@178.104.88.183 'bash -s' <<'EOF'
+    mkdir -p ~/backups
+    TS=$(date +%Y%m%dT%H%M%SZ)
+    PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \\
+      -h personal-blog-db -U expense_tracker \\
+      --format=custom --no-owner --no-acl \\
+      -f ~/backups/pre-user-model-${TS}.dump \\
+      expense_tracker_production
+    EOF
 NUDGE
 
 # --- Report --------------------------------------------------------------

--- a/docs/deploys/user-model-unification.md
+++ b/docs/deploys/user-model-unification.md
@@ -4,7 +4,7 @@ One-time runbook for the 14-PR User-model unification deploy (PRs #460–#475, m
 
 Three risk surfaces you're dealing with:
 
-1. **First-boot data migration.** `db/migrate/20260421130100_create_default_user_from_admin_users.rb` reads `admin_users` rows and creates `User` rows. PR 14's `drop_admin_users_table` runs later in the same batch — the drop is safe because rows are already copied, but the first deploy MUST have at least one `admin_users` row when migrations start.
+1. **First-boot data migration.** `db/migrate/20260420130000_create_default_user_from_admin_users.rb` reads `admin_users` rows and creates `User` rows. PR 14's `drop_admin_users_table` (`db/migrate/20260421160000_drop_admin_users_table.rb`) runs later in the same batch — the drop is safe because rows are already copied, but the first deploy MUST have at least one `admin_users` row when migrations start.
 2. **Session-cookie cutover.** Every existing admin cookie becomes invalid at cutover. Log in again at `/login` — there is no more `/admin/login`.
 3. **Env-var dependency.** `db/seeds.rb` now creates a `User` (not `AdminUser`) and `abort`s in production if `ADMIN_EMAIL` or `ADMIN_PASSWORD` match the dev sentinels. `config/deploy.yml` already declares both as `env.secret`, so `.kamal/secrets` on the workstation must have real values.
 
@@ -27,11 +27,14 @@ git log --oneline origin/main -1   # expect: d727375 feat(cleanup): PR 14/14 ...
 ### 1.2 Verify CI on main
 
 ```bash
-gh run list --branch main --limit 1 --json conclusion,status \
-  --jq '.[0] | select(.conclusion != "success") | "CI NOT green — abort"'
+# Check ALL workflows on the current origin/main commit, not just the latest run.
+SHA=$(git rev-parse origin/main)
+gh run list --branch main --commit "$SHA" --json name,status,conclusion \
+  --jq 'map(select(.status != "completed" or .conclusion != "success"))
+        | if length == 0 then "green" else "CI NOT green — abort" end'
 ```
 
-No output = green. Any output means abort.
+`green` = proceed. Anything else means abort.
 
 ### 1.3 Run the pre-flight script
 
@@ -57,26 +60,33 @@ Flags:
 
 ### 1.4 Snapshot the DB (critical — rollback depends on it)
 
-Preferred: run from the Hetzner box directly.
+Preferred: run from the Hetzner box directly. Use `--format=custom` so rollback can use `pg_restore --clean --if-exists` (plain-SQL restores can fail with "relation already exists" after the schema change).
 
 ```bash
-ssh deploy@178.104.88.183 \
-  "pg_dump -h personal-blog-db -U expense_tracker expense_tracker_production \
-     | gzip > ~/backups/pre-user-model-$(date +%Y%m%dT%H%M%SZ).sql.gz"
+ssh deploy@178.104.88.183 'bash -s' <<'EOF'
+mkdir -p ~/backups
+TS=$(date +%Y%m%dT%H%M%SZ)
+PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
+  -h personal-blog-db -U expense_tracker \
+  --format=custom --no-owner --no-acl \
+  -f ~/backups/pre-user-model-${TS}.dump \
+  expense_tracker_production
+ls -lh ~/backups/pre-user-model-${TS}.dump
+EOF
 ```
 
-Alternative via Kamal (piped through the app container):
+`POSTGRES_PASSWORD` must be exported in the `deploy` user's shell on the Hetzner box, or replace the inline `PGPASSWORD="$POSTGRES_PASSWORD"` with `PGPASSWORD='...'` once.
+
+Alternative via Kamal (piped through the app container — also custom format):
 
 ```bash
 kamal app exec --reuse \
-  "bash -c 'pg_dump -h \$POSTGRES_HOST -U \$POSTGRES_USER expense_tracker_production' \
-  > /rails/storage/backups/pre-user-model.sql"
-```
-
-Verify the file exists and is non-empty:
-
-```bash
-ssh deploy@178.104.88.183 "ls -lh ~/backups/pre-user-model-*.sql.gz | tail -1"
+  "bash -c 'mkdir -p /rails/storage/backups && \
+    PGPASSWORD=\$POSTGRES_PASSWORD pg_dump \
+      -h \$POSTGRES_HOST -U \$POSTGRES_USER \
+      --format=custom --no-owner --no-acl \
+      -f /rails/storage/backups/pre-user-model.dump \
+      expense_tracker_production'"
 ```
 
 Write the timestamped path somewhere you can find it — you'll need it for rollback (§4).
@@ -138,13 +148,15 @@ kamal deploy
 # Health endpoint
 curl -fsS https://expense-tracker.estebansoto.dev/up && echo "OK: /up"
 
-# Schema sanity — runs inside the just-deployed container
+# Schema sanity — runs inside the just-deployed container.
+# Uses `User.admin` (singular) because Rails auto-generates scope names from
+# the enum value (`enum :role, { user: 0, admin: 1 }` in app/models/user.rb).
 kamal app exec --reuse "bin/rails runner '
   fail unless User.count > 0
-  fail unless User.admins.count > 0
+  fail unless User.admin.count > 0
   fail if ActiveRecord::Base.connection.tables.include?(\"admin_users\")
   fail unless ActiveRecord::Base.connection.columns(:expenses).map(&:name).include?(\"user_id\")
-  puts %Q{users=#{User.count} admins=#{User.admins.count} admin_users_dropped=true expenses.user_id=present}
+  puts %Q{users=#{User.count} admins=#{User.admin.count} admin_users_dropped=true expenses.user_id=present}
 '"
 ```
 
@@ -169,13 +181,13 @@ Three cases. Pick the one that matches the failure.
 
 ### 4.1 Code rollback, schema intact
 
-Deploy introduced a bug but the User-model schema is fine.
+Deploy introduced a bug but the User-model schema is fine AND the rollback target is a post-unification image (i.e. one of PRs #460–#475 or later).
 
 ```bash
 kamal rollback <previous-image-tag>
 ```
 
-`.kamal/hooks/pre-deploy` will BLOCK this because the old image is behind the current schema. Override with `kamal deploy --skip-hooks` ONLY if you also restore the DB (case 4.2).
+⚠️ **Do not code-only rollback to a pre-unification image after the schema cutover.** `.kamal/hooks/pre-deploy` checks `db:migrate:status` inside the *currently running* container (see `.kamal/hooks/pre-deploy:15`), so after a successful cutover the hook can pass even though the rollback image would crash against the migrated schema. Rolling back across the unification boundary requires a full DB restore — use case 4.2 instead, or roll forward with a fix.
 
 ### 4.2 Full rollback including schema
 
@@ -188,9 +200,13 @@ ssh deploy@178.104.88.183
 # Stop the app
 kamal app stop
 
-# Restore the DB (use the timestamped path from §1.4)
-gunzip -c ~/backups/pre-user-model-<timestamp>.sql.gz \
-  | psql -h personal-blog-db -U expense_tracker expense_tracker_production
+# Restore the DB (use the timestamped path from §1.4).
+# --clean --if-exists drops the unification-era tables/columns before restoring.
+PGPASSWORD="$POSTGRES_PASSWORD" pg_restore \
+  -h personal-blog-db -U expense_tracker \
+  --clean --if-exists --no-owner --no-acl \
+  -d expense_tracker_production \
+  ~/backups/pre-user-model-<timestamp>.dump
 
 # Rollback the image (back to local shell)
 exit

--- a/docs/deploys/user-model-unification.md
+++ b/docs/deploys/user-model-unification.md
@@ -1,0 +1,220 @@
+# Deploy Runbook — User-Model Unification Cutover
+
+One-time runbook for the 14-PR User-model unification deploy (PRs #460–#475, merged to `main` on 2026-04-21 at commit `d727375`). After this deploy ships and smokes green, this file can stay as a reference for future operators.
+
+Three risk surfaces you're dealing with:
+
+1. **First-boot data migration.** `db/migrate/20260421130100_create_default_user_from_admin_users.rb` reads `admin_users` rows and creates `User` rows. PR 14's `drop_admin_users_table` runs later in the same batch — the drop is safe because rows are already copied, but the first deploy MUST have at least one `admin_users` row when migrations start.
+2. **Session-cookie cutover.** Every existing admin cookie becomes invalid at cutover. Log in again at `/login` — there is no more `/admin/login`.
+3. **Env-var dependency.** `db/seeds.rb` now creates a `User` (not `AdminUser`) and `abort`s in production if `ADMIN_EMAIL` or `ADMIN_PASSWORD` match the dev sentinels. `config/deploy.yml` already declares both as `env.secret`, so `.kamal/secrets` on the workstation must have real values.
+
+Four sections below. Do them in order.
+
+---
+
+## 1. Pre-flight (T-minus)
+
+Run from the local workstation. Each step is copy-pasteable.
+
+### 1.1 Verify branch state
+
+```bash
+cd /Users/esoto/development/expense_tracker
+git fetch origin main
+git log --oneline origin/main -1   # expect: d727375 feat(cleanup): PR 14/14 ...
+```
+
+### 1.2 Verify CI on main
+
+```bash
+gh run list --branch main --limit 1 --json conclusion,status \
+  --jq '.[0] | select(.conclusion != "success") | "CI NOT green — abort"'
+```
+
+No output = green. Any output means abort.
+
+### 1.3 Run the pre-flight script
+
+```bash
+bin/pre-deploy-check
+```
+
+Gates it enforces (see `bin/pre-deploy-check` source for details):
+
+- `.kamal/secrets` has non-empty values for `RAILS_MASTER_KEY`, `SECRET_KEY_BASE`, `POSTGRES_PASSWORD`, `KAMAL_REGISTRY_PASSWORD`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`.
+- `ADMIN_EMAIL` is not the sentinel `admin@expense-tracker.com`.
+- `ADMIN_PASSWORD` is not the sentinel `AdminPassword123!`.
+- `config/deploy.yml`'s `env.secret` block lists both `ADMIN_EMAIL` and `ADMIN_PASSWORD` (guardrail against someone removing them).
+- **Remote reachability:** `kamal app details` succeeds (skippable via `--offline` if drafting the deploy offline).
+- **Remote `AdminUser` presence:** asks the running prod container whether `admin_users` exists and, if so, whether it has ≥ 1 row. Prints a clear info line for re-deploys where the table is already dropped.
+- `gh run list` says CI on `main` is green (skippable via `--skip-ci` for emergencies).
+- Prints the backup command from §1.4 as a friendly nudge.
+
+Flags:
+
+- `--offline` — skip remote Kamal/SSH checks.
+- `--skip-ci` — skip the `gh run list` gate. Only for genuine emergencies.
+
+### 1.4 Snapshot the DB (critical — rollback depends on it)
+
+Preferred: run from the Hetzner box directly.
+
+```bash
+ssh deploy@178.104.88.183 \
+  "pg_dump -h personal-blog-db -U expense_tracker expense_tracker_production \
+     | gzip > ~/backups/pre-user-model-$(date +%Y%m%dT%H%M%SZ).sql.gz"
+```
+
+Alternative via Kamal (piped through the app container):
+
+```bash
+kamal app exec --reuse \
+  "bash -c 'pg_dump -h \$POSTGRES_HOST -U \$POSTGRES_USER expense_tracker_production' \
+  > /rails/storage/backups/pre-user-model.sql"
+```
+
+Verify the file exists and is non-empty:
+
+```bash
+ssh deploy@178.104.88.183 "ls -lh ~/backups/pre-user-model-*.sql.gz | tail -1"
+```
+
+Write the timestamped path somewhere you can find it — you'll need it for rollback (§4).
+
+### 1.5 Baseline the current prod
+
+```bash
+curl -fsS https://expense-tracker.estebansoto.dev/up && echo OK
+```
+
+If this is already failing, stop here and fix the baseline first. Don't layer a new deploy on top of a broken one.
+
+---
+
+## 2. Deploy (T+0)
+
+One command, two terminals, eyes on the logs.
+
+**Terminal 2 (open this FIRST — live logs):**
+
+```bash
+kamal app logs -f
+```
+
+**Terminal 1 (deploy driver):**
+
+```bash
+kamal deploy
+```
+
+### Expected log sequence
+
+1. Docker image build + push to `ghcr.io/esoto/expense-tracker`.
+2. `.kamal/hooks/pre-deploy` runs — should PASS. The hook blocks on pending migrations *against the running image*. If it complains here, the new image's schema is behind the DB — abort and investigate.
+3. New container starts → `bin/docker-entrypoint` runs `bin/rails db:prepare`.
+4. The 14-PR migration batch runs. Expect `add_*_user_id`, `backfill_*`, `make_*_not_null` triplets to log short `migrated` lines. Backfills on `expenses` and `sync_metrics` may take 1–3s depending on row count. Final migration: `20260421160000_drop_admin_users_table`.
+5. Puma boots; Solid Queue supervisor + dispatcher start (`SOLID_QUEUE_IN_PUMA=true`).
+6. Orchestrator cache warm-up (~15s silent period — the `readiness_delay` in `config/deploy.yml`).
+7. kamal-proxy polls `/up` every 10s; cuts traffic to the new container once healthy.
+
+**Expected total deploy time:** 2–5 minutes. **Expected downtime:** ≤ 15s during container swap (kamal-proxy handles the cutover).
+
+### Red flags — abort and investigate
+
+- `ActiveRecord::MigrationError: Found N ... with NULL user_id but no admin User exists` — PR 3's migration didn't run or seeded nothing. Abort:
+  ```bash
+  kamal app exec --interactive --reuse "bin/rails console"
+  ```
+- `PG::UndefinedColumn` or `PG::DuplicateColumn` — schema drift. Rollback per §4.
+- Solid Queue connection-pool errors — unlikely, but verify `RAILS_MAX_THREADS: "8"` in `config/deploy.yml` hasn't been edited down.
+
+---
+
+## 3. Post-deploy smoke (T+1 — 5 minutes)
+
+### 3.1 Automated checks
+
+```bash
+# Health endpoint
+curl -fsS https://expense-tracker.estebansoto.dev/up && echo "OK: /up"
+
+# Schema sanity — runs inside the just-deployed container
+kamal app exec --reuse "bin/rails runner '
+  fail unless User.count > 0
+  fail unless User.admins.count > 0
+  fail if ActiveRecord::Base.connection.tables.include?(\"admin_users\")
+  fail unless ActiveRecord::Base.connection.columns(:expenses).map(&:name).include?(\"user_id\")
+  puts %Q{users=#{User.count} admins=#{User.admins.count} admin_users_dropped=true expenses.user_id=present}
+'"
+```
+
+### 3.2 Manual UI smoke (browser)
+
+1. Visit `https://expense-tracker.estebansoto.dev/` → should redirect to `/login`.
+2. Sign in with `ADMIN_EMAIL` / `ADMIN_PASSWORD` (values from `.kamal/secrets`).
+3. Visit `/admin/users` → see yourself listed; role column reads `admin`; status reads `Active`.
+4. Create a second user at `/admin/users/new` (role: user). Confirm the one-time password banner appears and the Copy button works.
+5. Open an incognito window; sign in as the new user; visit `/admin/users` → expect redirect with "Forbidden" flash.
+6. Back as admin: delete the test user.
+
+### 3.3 iPhone Shortcut smoke
+
+7. Open an existing Shortcut that hits `/api/v1/...` or `/api/webhooks/add_expense`. Run it. Confirm the expense lands in the feed — the token is now user-scoped but belongs to the default admin user (PR 11's backfill), so it should still work unchanged.
+
+---
+
+## 4. Rollback
+
+Three cases. Pick the one that matches the failure.
+
+### 4.1 Code rollback, schema intact
+
+Deploy introduced a bug but the User-model schema is fine.
+
+```bash
+kamal rollback <previous-image-tag>
+```
+
+`.kamal/hooks/pre-deploy` will BLOCK this because the old image is behind the current schema. Override with `kamal deploy --skip-hooks` ONLY if you also restore the DB (case 4.2).
+
+### 4.2 Full rollback including schema
+
+The migrations themselves broke something.
+
+```bash
+# On the Hetzner box, via ssh
+ssh deploy@178.104.88.183
+
+# Stop the app
+kamal app stop
+
+# Restore the DB (use the timestamped path from §1.4)
+gunzip -c ~/backups/pre-user-model-<timestamp>.sql.gz \
+  | psql -h personal-blog-db -U expense_tracker expense_tracker_production
+
+# Rollback the image (back to local shell)
+exit
+kamal rollback <previous-image-tag>
+kamal app start
+```
+
+Post-rollback: the DB has `admin_users` again, no `users` table, no `user_id` columns. All prior Shortcuts + admin logins work.
+
+### 4.3 Partial failure (migrations started, ran some, crashed)
+
+Rare but possible.
+
+- Each migration runs in its own transaction EXCEPT the ones with `disable_ddl_transaction!` (concurrent-index migrations from PRs 4–11). If one of those fails, the partial state is recoverable: re-run
+  ```bash
+  kamal app exec --reuse "bin/rails db:migrate"
+  ```
+  and it continues from where it left off.
+- If you can't make progress, restore from backup per §4.2.
+
+---
+
+## Note to self
+
+- After cutover, every existing browser cookie is invalidated. Log in again at `/login` (not `/admin/login`).
+- `kamal rollback` rolls the image only — the DB is NOT restored by rollback.
+- The backup file from §1.4 is the only path back to the old schema. Don't skip it.


### PR DESCRIPTION
## Summary

- New runbook at `docs/deploys/user-model-unification.md` — four sections (Pre-flight, Deploy, Post-deploy smoke, Rollback) with copy-pasteable commands for the Hetzner/Kamal cutover
- New executable Ruby script `bin/pre-deploy-check` — 8 gates validating secrets presence, sentinel rejection (mirrors `db/seeds.rb:370`), `config/deploy.yml` env.secret sanity, remote Kamal reachability, remote `admin_users`/User state, CI green, and a backup nudge. Flags: `--offline`, `--skip-ci`
- README gains a short "Deploying" section pointing at the runbook and the pre-flight script
- Never echoes secret values — only key names + pass/fail

## Test plan

- [x] `chmod +x bin/pre-deploy-check`
- [x] `ruby -c bin/pre-deploy-check` (Syntax OK)
- [x] `bundle exec rubocop bin/pre-deploy-check` (no offenses)
- [x] `bin/pre-deploy-check --offline --skip-ci` runs, exits 1 cleanly with human-readable failures (missing `.kamal/secrets` + git tip mismatch in the worktree)
- [x] `git diff --stat` shows only the 3 expected files
- [x] Pre-commit hook (rubocop + brakeman + rspec unit + rails-best-practices) passed on commit

## Context

Ships the one-time pre-deploy artifacts for the 14-PR User-model unification (PRs #460–#475, merged `d727375` on 2026-04-21). This PR is #15/15 of the cutover — runs before the first `kamal deploy` against the Hetzner VPS. Runbook owns rollback (DB snapshot required — `kamal rollback` does not restore the DB) and smoke steps (schema invariants + UI login + iPhone Shortcut).