### PR TITLE
fix(seeds): scope API token seeding to the admin user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,8 +105,7 @@ api_tokens = [
 
 created_tokens = []
 api_tokens.each do |token_data|
-  token = ApiToken.find_or_create_by!(name: token_data[:name]) do |t|
-    t.user = default_user
+  token = default_user.api_tokens.find_or_create_by!(name: token_data[:name]) do |t|
     t.expires_at = token_data[:expires_at]
     t.active = true
   end

--- a/spec/db/seeds_spec.rb
+++ b/spec/db/seeds_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "db/seeds.rb" do
+  let(:admin_email) { "seeds-spec-admin@example.com" }
+  let(:admin_password) { "SeedsSpecPass123!" }
+  let(:non_admin_email) { "seeds-spec-non-admin@example.com" }
+
+  around do |example|
+    original_admin_email = ENV["ADMIN_EMAIL"]
+    original_admin_password = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_EMAIL"] = admin_email
+    ENV["ADMIN_PASSWORD"] = admin_password
+    example.run
+  ensure
+    ENV["ADMIN_EMAIL"] = original_admin_email
+    ENV["ADMIN_PASSWORD"] = original_admin_password
+  end
+
+  def load_seeds
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    load Rails.root.join("db/seeds.rb")
+  ensure
+    $stdout = original_stdout
+  end
+
+  describe "ApiToken seeding" do
+    it "creates the admin's own token even when another user already owns a token with the same name" do
+      non_admin = User.create!(
+        email: non_admin_email,
+        name: "Non Admin",
+        password: "NonAdminPass123!",
+        role: :user
+      )
+      non_admin_token = non_admin.api_tokens.create!(
+        name: "iPhone Shortcuts",
+        active: true,
+        expires_at: 6.months.from_now
+      )
+
+      load_seeds
+
+      admin = User.find_by!(email: admin_email)
+      expect(admin.role).to eq("admin")
+
+      admin_token = admin.api_tokens.find_by(name: "iPhone Shortcuts")
+      expect(admin_token).to be_present
+      expect(admin_token.id).not_to eq(non_admin_token.id)
+
+      # The non-admin's token must remain untouched and still owned by them.
+      expect(non_admin.api_tokens.reload.find_by(name: "iPhone Shortcuts")).to eq(non_admin_token)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `ApiToken.find_or_create_by!(name:)` in [db/seeds.rb](db/seeds.rb) matched tokens across users by name. An existing token with the same name owned by a non-admin user would be reused instead of creating the admin's token.
- Scope the lookup through `default_user.api_tokens` so the seeded token is always owned by the admin.
- Add a regression spec in [spec/db/seeds_spec.rb](spec/db/seeds_spec.rb) that pre-creates a non-admin user with an "iPhone Shortcuts" token, runs the seed, and asserts the admin receives its own token (distinct from the non-admin's).

Follow-up from Codex's review of #477 (Low severity).

## Test plan
- [x] `bundle exec rspec spec/db/seeds_spec.rb` passes
- [x] `bundle exec rubocop db/seeds.rb spec/db/seeds_spec.rb` clean
- [x] Verified RED before the fix (admin had no token) and GREEN after (admin owns its own token, non-admin's token untouched)