### PR TITLE
test(pattern_learner): un-quarantine perf spec with stable 200ms threshold

### DIFF
--- a/spec/services/categorization/pattern_learner_spec.rb
+++ b/spec/services/categorization/pattern_learner_spec.rb
@@ -163,16 +163,12 @@ RSpec.describe Services::Categorization::PatternLearner do
     end
 
     context "performance" do
-      # TODO(PER-196): re-enable once the timing threshold is stabilized across
-      # CI runners. Consistently exceeds 100ms under shared-runner load despite
-      # the 10ms spec target; pre-existing flake, not caused by PR 7 (user_id
-      # is not written by PatternLearner).
-      xit "completes within 10ms for single correction" do
+      it "completes within 200ms for single correction" do
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         learner.learn_from_correction(expense, food_category)
         duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
 
-        expect(duration_ms).to be < 100  # Updated for enhanced pattern learning with database operations
+        expect(duration_ms).to be < 200
       end
     end
   end


### PR DESCRIPTION
## Summary

- Un-quarantines the flaky `PatternLearner#learn_from_correction` performance spec that was disabled with `xit` in PR 7.
- Raises the threshold to a stable `< 200ms` (was `< 100ms`, flaking at 110ms on shared CI runners).
- Fixes the stale description (said "within 10ms" while the expectation had already drifted to 100ms).
- Removes the `TODO(PER-196)` comment since this PR tracks it.

If we later want a tighter guarantee, the correct path is to profile and optimize `PatternLearner#learn_from_correction` rather than keep chasing the threshold.

Tracking: #481

## Test plan

- [ ] CI green on `spec/services/categorization/pattern_learner_spec.rb`
- [ ] Performance context no longer skipped (visible in rspec output)
- [ ] No RuboCop/Brakeman regressions from the pre-commit hook
