### PR TITLE
fix(ui): redirect /favicon.ico to /icon.svg

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,18 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Browsers auto-request /favicon.ico regardless of the <link rel="icon"> tags
-  # in the layout. Redirect to the SVG tile (Financial Confidence palette,
-  # rounded-square bar chart) — modern browsers accept SVG favicons and cache
-  # the 301 aggressively, so the redirect costs effectively nothing after the
-  # first request per client.
-  get "/favicon.ico", to: redirect("/icon.svg", status: 301)
+  # in the layout, and Safari / iOS Safari do not reliably accept SVG at the
+  # /favicon.ico endpoint (only the explicit <link rel="icon" type="image/svg">
+  # path). Redirect to the PNG rendition so every browser resolves correctly.
+  # 301 is safe: the target is the stable 512x512 teal bar-chart PNG.
+  get "/favicon.ico", to: redirect("/icon.png", status: 301)
+
+  # iOS and macOS Safari also probe /apple-touch-icon.png (and the
+  # -precomposed variant) even when an apple-touch-icon <link> is declared.
+  # Redirect both so the 404s in the server log go away and the tab/home-screen
+  # icons resolve on the first try.
+  get "/apple-touch-icon.png", to: redirect("/icon.png", status: 301)
+  get "/apple-touch-icon-precomposed.png", to: redirect("/icon.png", status: 301)
 
   # End-user authentication (parallel to /admin/login during migration)
   get "login", to: "sessions#new", as: :login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  # Browsers auto-request /favicon.ico regardless of the <link rel="icon"> tags
+  # in the layout. Redirect to the SVG tile (Financial Confidence palette,
+  # rounded-square bar chart) — modern browsers accept SVG favicons and cache
+  # the 301 aggressively, so the redirect costs effectively nothing after the
+  # first request per client.
+  get "/favicon.ico", to: redirect("/icon.svg", status: 301)
+
   # End-user authentication (parallel to /admin/login during migration)
   get "login", to: "sessions#new", as: :login
   post "login", to: "sessions#create"

--- a/spec/requests/favicon_spec.rb
+++ b/spec/requests/favicon_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Browsers auto-request `/favicon.ico` regardless of the <link rel="icon">
+# tags in the layout. Before the redirect in config/routes.rb, that request
+# 404'd — which kept stale red-dot favicons pinned in browser caches long
+# after the teal bar-chart replacement shipped. Keep this test green so the
+# redirect doesn't silently regress during a routes refactor.
+RSpec.describe "favicon", type: :request do
+  describe "GET /favicon.ico", :unit do
+    it "redirects to /icon.svg with a 301 (Moved Permanently)" do
+      get "/favicon.ico"
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with("/icon.svg")
+    end
+  end
+end

--- a/spec/requests/favicon_spec.rb
+++ b/spec/requests/favicon_spec.rb
@@ -2,17 +2,33 @@
 
 require "rails_helper"
 
-# Browsers auto-request `/favicon.ico` regardless of the <link rel="icon">
-# tags in the layout. Before the redirect in config/routes.rb, that request
-# 404'd — which kept stale red-dot favicons pinned in browser caches long
-# after the teal bar-chart replacement shipped. Keep this test green so the
-# redirect doesn't silently regress during a routes refactor.
+# Browsers auto-request `/favicon.ico` and (on Safari/iOS) `/apple-touch-icon*.png`
+# regardless of the <link rel="icon"> tags in the layout. Before the redirects
+# in config/routes.rb, those requests 404'd — which kept stale red-dot favicons
+# pinned in browser caches long after the teal bar-chart replacement shipped.
+# Keep these tests green so a future routes refactor doesn't silently regress.
 RSpec.describe "favicon", type: :request do
   describe "GET /favicon.ico", :unit do
-    it "redirects to /icon.svg with a 301 (Moved Permanently)" do
+    it "redirects to /icon.png with a 301 (Moved Permanently)" do
       get "/favicon.ico"
       expect(response).to have_http_status(:moved_permanently)
-      expect(response.location).to end_with("/icon.svg")
+      expect(response.location).to end_with("/icon.png")
+    end
+  end
+
+  describe "GET /apple-touch-icon.png", :unit do
+    it "redirects to /icon.png with a 301" do
+      get "/apple-touch-icon.png"
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with("/icon.png")
+    end
+  end
+
+  describe "GET /apple-touch-icon-precomposed.png", :unit do
+    it "redirects to /icon.png with a 301" do
+      get "/apple-touch-icon-precomposed.png"
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with("/icon.png")
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the chronic `/favicon.ico` 404 on prod. Browsers request `/favicon.ico` by default regardless of the `<link rel="icon">` tags in the layout; before this, they got a 404 and kept the previously-cached favicon (which for pre-#458 visitors was the Rails boilerplate red circle).

Adds a 301 redirect to `/icon.svg` (the teal bar-chart tile). Modern browsers accept SVG favicons and aggressively cache 301s.

## Test plan

- [x] `bin/rails routes | grep favicon` — shows `GET /favicon.ico redirect(301, /icon.svg)`
- [x] New `spec/requests/favicon_spec.rb` passes on isolated test DB
- [ ] CI green
- [ ] Post-merge: `curl -sI https://expense-tracker.estebansoto.dev/favicon.ico` returns `HTTP/2 301` with `location: /icon.svg`