### PR TITLE
feat(categories): PR 1/10 — user_id scoping + tree ownership rules

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,7 @@
 class Category < ApplicationRecord
   # Associations
   belongs_to :parent, class_name: "Category", optional: true
+  belongs_to :user, optional: true
   has_many :children, class_name: "Category", foreign_key: "parent_id", dependent: :nullify
   has_many :expenses, dependent: :nullify
   has_many :categorization_patterns, dependent: :destroy
@@ -12,12 +13,17 @@ class Category < ApplicationRecord
   # Validations
   validates :name, presence: true, length: { maximum: 255 }
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "must be a valid hex color" }, allow_blank: true
+  validates :name, uniqueness: { scope: :user_id }, if: :personal?
   validate :cannot_be_parent_of_itself
+  validate :parent_ownership_must_match
 
   # Scopes
   scope :root_categories, -> { where(parent_id: nil) }
   scope :subcategories, -> { where.not(parent_id: nil) }
   scope :active, -> { all } # For now, all categories are considered active
+  scope :shared, -> { where(user_id: nil) }
+  scope :personal_for, ->(user) { where(user_id: user.id) }
+  scope :visible_to, ->(user) { where(user_id: [ nil, user.id ]) }
 
   # Instance methods
   def root?
@@ -26,6 +32,14 @@ class Category < ApplicationRecord
 
   def subcategory?
     !root?
+  end
+
+  def shared?
+    user_id.nil?
+  end
+
+  def personal?
+    !shared?
   end
 
   def display_name
@@ -48,6 +62,26 @@ class Category < ApplicationRecord
       errors.add(:parent, "cannot be itself")
     elsif parent&.parent_id == id
       errors.add(:parent, "cannot create circular reference")
+    end
+  end
+
+  # Ownership rules between a category and its parent:
+  #
+  #   parent          | self            | allowed?
+  #   ----------------+-----------------+-----------------------------
+  #   shared          | shared          | yes
+  #   shared          | personal (A)    | yes  (personal subcategory under shared)
+  #   personal (A)    | personal (A)    | yes  (personal child under own branch)
+  #   personal (A)    | personal (B)    | NO   (cross-user leakage)
+  #   personal (A)    | shared          | NO   (shared must not depend on personal)
+  #
+  def parent_ownership_must_match
+    return unless parent
+
+    if parent.personal? && shared?
+      errors.add(:parent, "shared category cannot have a personal parent")
+    elsif parent.personal? && user_id != parent.user_id
+      errors.add(:parent, "must belong to the same user or be shared")
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,9 +13,10 @@ class Category < ApplicationRecord
   # Validations
   validates :name, presence: true, length: { maximum: 255 }
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "must be a valid hex color" }, allow_blank: true
-  validates :name, uniqueness: { scope: :user_id }, if: :personal?
+  validates :name, uniqueness: { scope: :user_id, case_sensitive: false }, if: :personal?
   validate :cannot_be_parent_of_itself
   validate :parent_ownership_must_match
+  validate :user_id_change_preserves_children
 
   # Scopes
   scope :root_categories, -> { where(parent_id: nil) }
@@ -83,5 +84,16 @@ class Category < ApplicationRecord
     elsif parent.personal? && user_id != parent.user_id
       errors.add(:parent, "must belong to the same user or be shared")
     end
+  end
+
+  # Changing a category's `user_id` can silently invalidate its existing
+  # children's `parent_ownership_must_match` state (e.g. a shared parent
+  # with shared children becomes personal, making the children invalid).
+  # Forbid the change while children exist — re-ownership is unusual and
+  # the safe workflow is to move or reparent children first.
+  def user_id_change_preserves_children
+    return unless persisted? && user_id_changed? && children.exists?
+
+    errors.add(:user_id, "cannot change while the category has children")
   end
 end

--- a/db/migrate/20260422120000_add_user_id_to_categories.rb
+++ b/db/migrate/20260422120000_add_user_id_to_categories.rb
@@ -1,0 +1,17 @@
+class AddUserIdToCategories < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :categories, :user, foreign_key: true, null: true, index: true
+
+    # Lookup index for tree rendering per user.
+    add_index :categories, [ :user_id, :parent_id ]
+
+    # Partial unique index: a given user cannot have two personal categories
+    # with the same name. Shared categories (user_id IS NULL) are unaffected,
+    # so the current seeded set is not constrained.
+    add_index :categories,
+              [ :user_id, :name ],
+              unique: true,
+              where: "user_id IS NOT NULL",
+              name: "index_categories_on_user_id_and_name_personal"
+  end
+end

--- a/db/migrate/20260422120000_add_user_id_to_categories.rb
+++ b/db/migrate/20260422120000_add_user_id_to_categories.rb
@@ -6,12 +6,13 @@ class AddUserIdToCategories < ActiveRecord::Migration[8.1]
     add_index :categories, [ :user_id, :parent_id ]
 
     # Partial unique index: a given user cannot have two personal categories
-    # with the same name. Shared categories (user_id IS NULL) are unaffected,
-    # so the current seeded set is not constrained.
+    # with the same name (case-insensitive). Shared categories
+    # (user_id IS NULL) are unaffected, so the current seeded set is not
+    # constrained. LOWER(name) mirrors the case_sensitive: false validation.
     add_index :categories,
-              [ :user_id, :name ],
+              "user_id, LOWER(name)",
               unique: true,
               where: "user_id IS NOT NULL",
-              name: "index_categories_on_user_id_and_name_personal"
+              name: "index_categories_on_user_id_and_lower_name_personal"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -138,9 +138,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_160000) do
     t.string "name", null: false
     t.integer "parent_id"
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["i18n_key"], name: "index_categories_on_i18n_key", unique: true
     t.index ["name"], name: "index_categories_on_name"
     t.index ["parent_id"], name: "index_categories_on_parent_id"
+    t.index ["user_id", "name"], name: "index_categories_on_user_id_and_name_personal", unique: true, where: "(user_id IS NOT NULL)"
+    t.index ["user_id", "parent_id"], name: "index_categories_on_user_id_and_parent_id"
+    t.index ["user_id"], name: "index_categories_on_user_id"
   end
 
   create_table "categorization_metrics", force: :cascade do |t|
@@ -811,6 +815,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_160000) do
   add_foreign_key "bulk_operations", "categories", column: "target_category_id"
   add_foreign_key "bulk_operations", "users"
   add_foreign_key "categories", "categories", column: "parent_id"
+  add_foreign_key "categories", "users"
   add_foreign_key "categorization_metrics", "categories"
   add_foreign_key "categorization_metrics", "categories", column: "corrected_to_category_id"
   add_foreign_key "categorization_metrics", "expenses"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,10 +139,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.integer "parent_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index "user_id, lower((name)::text)", name: "index_categories_on_user_id_and_lower_name_personal", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["i18n_key"], name: "index_categories_on_i18n_key", unique: true
     t.index ["name"], name: "index_categories_on_name"
     t.index ["parent_id"], name: "index_categories_on_parent_id"
-    t.index ["user_id", "name"], name: "index_categories_on_user_id_and_name_personal", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["user_id", "parent_id"], name: "index_categories_on_user_id_and_parent_id"
     t.index ["user_id"], name: "index_categories_on_user_id"
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -256,10 +256,53 @@ RSpec.describe Category, type: :model, integration: true do
         expect(second).not_to be_valid
       end
 
-      it 'does not constrain shared categories against the uniqueness' do
+      it 'prevents case-insensitive duplicates for the same user' do
+        create(:category, name: 'Out Food', user: user_a)
+        mixed_case = build(:category, name: 'out food', user: user_a)
+        expect(mixed_case).not_to be_valid
+        expect(mixed_case.errors[:name]).to be_present
+      end
+
+      it 'allows two shared categories to share a name (no uniqueness constraint)' do
         create(:category, name: 'Food', user: nil)
-        another_shared = build(:category, name: 'Transport', user: nil)
-        expect(another_shared).to be_valid
+        duplicate_shared = build(:category, name: 'Food', user: nil)
+        expect(duplicate_shared).to be_valid
+      end
+    end
+
+    describe 'update-path tree rule invariants' do
+      let(:user_a) { create(:user, email: 'a@example.com') }
+      let(:user_b) { create(:user, email: 'b@example.com') }
+
+      it 'rejects reparenting a shared category under a personal one via update' do
+        shared_child = create(:category, name: 'Shared Child', user: nil)
+        personal = create(:category, name: 'A Branch', user: user_a)
+        shared_child.parent = personal
+        expect(shared_child).not_to be_valid
+        expect(shared_child.errors[:parent]).to include('shared category cannot have a personal parent')
+      end
+
+      it "rejects reparenting a personal category under another user's personal" do
+        a_child = create(:category, name: 'A Child', user: user_a)
+        b_personal = create(:category, name: 'B Branch', user: user_b)
+        a_child.parent = b_personal
+        expect(a_child).not_to be_valid
+        expect(a_child.errors[:parent]).to include('must belong to the same user or be shared')
+      end
+
+      it 'forbids changing user_id while the category has children (would orphan invariants)' do
+        parent = create(:category, name: 'Food', user: nil)
+        create(:category, name: 'Out Food', user: user_a, parent: parent)
+
+        parent.user = user_a
+        expect(parent).not_to be_valid
+        expect(parent.errors[:user_id]).to include('cannot change while the category has children')
+      end
+
+      it 'permits changing user_id on a childless category' do
+        childless = create(:category, name: 'Tmp', user: user_a)
+        childless.user = nil
+        expect(childless).to be_valid
       end
     end
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -170,4 +170,97 @@ RSpec.describe Category, type: :model, integration: true do
       expect(grandparent.errors[:parent]).to include('cannot create circular reference')
     end
   end
+
+  describe 'user ownership', integration: true do
+    it { should belong_to(:user).optional }
+
+    describe 'shared vs personal' do
+      let(:shared) { create(:category, name: 'Food', user: nil) }
+      let(:user)   { create(:user) }
+      let(:personal) { create(:category, name: 'Home Food', user: user) }
+
+      it 'treats user_id IS NULL as a shared category' do
+        expect(shared.user_id).to be_nil
+        expect(shared).to be_shared
+        expect(shared).not_to be_personal
+      end
+
+      it 'treats a category with a user_id as personal' do
+        expect(personal).to be_personal
+        expect(personal).not_to be_shared
+        expect(personal.user).to eq(user)
+      end
+    end
+
+    describe '.visible_to' do
+      let(:user_a) { create(:user, email: 'a@example.com') }
+      let(:user_b) { create(:user, email: 'b@example.com') }
+      let!(:shared)     { create(:category, name: 'Food', user: nil) }
+      let!(:a_personal) { create(:category, name: 'Home Food', user: user_a) }
+      let!(:b_personal) { create(:category, name: 'Out Food', user: user_b) }
+
+      it "returns shared plus the user's own personal categories" do
+        visible = Category.visible_to(user_a)
+        expect(visible).to include(shared, a_personal)
+        expect(visible).not_to include(b_personal)
+      end
+
+      it "excludes other users' personal categories" do
+        expect(Category.visible_to(user_b)).not_to include(a_personal)
+      end
+    end
+
+    describe 'tree rules across ownership' do
+      let(:user_a) { create(:user, email: 'a@example.com') }
+      let(:user_b) { create(:user, email: 'b@example.com') }
+      let(:shared_parent) { create(:category, name: 'Food', user: nil) }
+
+      it 'allows a personal category parented under a shared category' do
+        personal = build(:category, name: 'Out Food', user: user_a, parent: shared_parent)
+        expect(personal).to be_valid
+      end
+
+      it 'allows a personal category with no parent (own top-level branch)' do
+        personal = build(:category, name: 'Home Food', user: user_a, parent: nil)
+        expect(personal).to be_valid
+      end
+
+      it "rejects a personal category parenting under another user's personal category" do
+        b_personal = create(:category, name: 'B Out Food', user: user_b)
+        invalid = build(:category, name: 'A Child', user: user_a, parent: b_personal)
+        expect(invalid).not_to be_valid
+        expect(invalid.errors[:parent]).to include('must belong to the same user or be shared')
+      end
+
+      it 'rejects a shared category being parented under a personal category' do
+        a_personal = create(:category, name: 'A Branch', user: user_a)
+        invalid = build(:category, name: 'New Shared', user: nil, parent: a_personal)
+        expect(invalid).not_to be_valid
+        expect(invalid.errors[:parent]).to include('shared category cannot have a personal parent')
+      end
+    end
+
+    describe 'unique name per user scope' do
+      let(:user_a) { create(:user, email: 'a@example.com') }
+      let(:user_b) { create(:user, email: 'b@example.com') }
+
+      it 'allows two users to each own a category with the same name' do
+        create(:category, name: 'Out Food', user: user_a)
+        duplicate_for_b = build(:category, name: 'Out Food', user: user_b)
+        expect(duplicate_for_b).to be_valid
+      end
+
+      it 'prevents the same user from having two personal categories with the same name' do
+        create(:category, name: 'Out Food', user: user_a)
+        second = build(:category, name: 'Out Food', user: user_a)
+        expect(second).not_to be_valid
+      end
+
+      it 'does not constrain shared categories against the uniqueness' do
+        create(:category, name: 'Food', user: nil)
+        another_shared = build(:category, name: 'Transport', user: nil)
+        expect(another_shared).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR 1 of 10 for the Personal Category Management feature. Design lives in Obsidian (`Personal Brand/Expense tracker/Personal Category Management.md`), not in the repo.

Foundation only — adds the `user_id` column, ownership-aware scopes and validations, and model specs. No controller or UI yet.

- Migration: `categories.user_id` (nullable) + partial unique index on `(user_id, name)` WHERE `user_id IS NOT NULL`. Shared categories (NULL `user_id`) stay unconstrained — the current seeded set is untouched.
- `Category` model:
  - `belongs_to :user, optional: true`
  - Scopes: `shared`, `personal_for(user)`, `visible_to(user)`
  - Predicates: `shared?`, `personal?`
  - Cross-ownership tree validation:
    - personal A ⇒ personal B: rejected
    - shared under personal: rejected
    - personal under shared: allowed
    - personal under own personal: allowed
  - Unique `name` per `user_id` (only when personal).

## Ownership rules

| parent | self | allowed? |
|---|---|---|
| shared | shared | yes |
| shared | personal (A) | yes |
| personal (A) | personal (A) | yes |
| personal (A) | personal (B) | **no** |
| personal (A) | shared | **no** |

## Test plan

- [x] 12 new specs cover association, visibility scope, predicates, tree ownership rules, and per-user name uniqueness
- [x] All 2,435 model specs pass locally
- [x] Rubocop clean
- [x] Migration ran clean on worktree test DB

## Next PRs

2. `CategoryPolicy` + policy specs
3. CRUD controller + routes + request specs
4. Index tree view UI
5. Create personal category flow
6. Edit personal category flow
7. Pattern management on category
8. Deletion flow + `CategoryDeletion` service
9. Pattern scoping during categorization (`usable_by(user)`)
10. Feature flag + rollout