### PR TITLE
feat(categories): PR 3/10 — CRUD controller, routes, barebones views

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,6 +2,21 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: %i[show edit update destroy]
   before_action :authorize_show!, only: %i[show]
   before_action :authorize_edit!, only: %i[edit update destroy]
+  before_action :scope_parent_id, only: %i[create update]
+
+  # Associations that block an "empty category" fast-path destroy in this PR.
+  # Anything touching a category's identity must be resolved by PR 8's
+  # CategoryDeletion service (reassign vs. orphan). This list mirrors the
+  # dependent: :destroy/:nullify associations on Category.
+  DELETE_BLOCKING_ASSOCIATIONS = %i[
+    expenses
+    children
+    categorization_patterns
+    composite_patterns
+    pattern_feedbacks
+    pattern_learning_events
+    user_category_preferences
+  ].freeze
 
   # GET /categories(.json)
   def index
@@ -58,10 +73,12 @@ class CategoriesController < ApplicationController
   # DELETE /categories/:id
   #
   # PR 3 ships a narrow destroy that only deletes *empty* personal categories
-  # (no expenses, no children, no patterns). The full reassign/orphan flow is
-  # the subject of PR 8 (CategoryDeletion service).
+  # — no expenses, no children, no patterns, no feedbacks/metrics/preferences.
+  # The full reassign/orphan flow is the subject of PR 8 (CategoryDeletion
+  # service); refusing a non-empty destroy here avoids silent cascade of
+  # dependent: :destroy associations.
   def destroy
-    if @category.expenses.exists? || @category.children.exists? || @category.categorization_patterns.exists?
+    if category_in_use?
       redirect_to category_path(@category),
                   alert: "This category is in use. Full deletion flow arrives in PR 8.",
                   status: :see_other
@@ -101,7 +118,27 @@ class CategoriesController < ApplicationController
     # user_id is intentionally NOT permitted. Ownership is forced to
     # current_user at create time and immutable thereafter (see Category
     # model's user_id_change_preserves_children validation).
-    params.require(:category).permit(:name, :description, :color, :parent_id, :i18n_key)
+    # i18n_key is not user-facing yet (used for shared category translation
+    # keys) — omit from permitted params until the admin UI lands.
+    params.require(:category).permit(:name, :description, :color, :parent_id)
+  end
+
+  # Reject parent_id values that point at categories the current user cannot
+  # see (other users' personal categories or nonexistent IDs) before they
+  # reach the model. Without this, the model validation fires and returns
+  # 422 — which leaks the existence of hidden categories via error message
+  # differences. Normalize to 404 (out-of-scope) instead.
+  def scope_parent_id
+    pid = params.dig(:category, :parent_id)
+    return if pid.blank?
+
+    unless CategoryPolicy.visible_scope(current_user).exists?(id: pid)
+      render_not_found
+    end
+  end
+
+  def category_in_use?
+    DELETE_BLOCKING_ASSOCIATIONS.any? { |assoc| @category.public_send(assoc).exists? }
   end
 
   def render_not_found

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,9 +1,14 @@
 class CategoriesController < ApplicationController
-  # GET /categories.json
+  before_action :set_category, only: %i[show edit update destroy]
+  before_action :authorize_show!, only: %i[show]
+  before_action :authorize_edit!, only: %i[edit update destroy]
+
+  # GET /categories(.json)
   def index
-    @categories = Category.order(:name)
+    @categories = CategoryPolicy.visible_scope(current_user).order(:name)
 
     respond_to do |format|
+      format.html
       format.json do
         render json: @categories.map { |category|
           {
@@ -14,7 +19,95 @@ class CategoriesController < ApplicationController
           }
         }
       end
-      format.html { redirect_to expenses_path }
+    end
+  end
+
+  # GET /categories/:id
+  def show
+  end
+
+  # GET /categories/new
+  def new
+    @category = Category.new(user: current_user)
+  end
+
+  # POST /categories
+  def create
+    @category = Category.new(category_params.merge(user: current_user))
+
+    if CategoryPolicy.new(current_user, @category).create? && @category.save
+      redirect_to category_path(@category), notice: "Category created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # GET /categories/:id/edit
+  def edit
+  end
+
+  # PATCH/PUT /categories/:id
+  def update
+    if @category.update(category_params)
+      redirect_to category_path(@category), notice: "Category updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /categories/:id
+  #
+  # PR 3 ships a narrow destroy that only deletes *empty* personal categories
+  # (no expenses, no children, no patterns). The full reassign/orphan flow is
+  # the subject of PR 8 (CategoryDeletion service).
+  def destroy
+    if @category.expenses.exists? || @category.children.exists? || @category.categorization_patterns.exists?
+      redirect_to category_path(@category),
+                  alert: "This category is in use. Full deletion flow arrives in PR 8.",
+                  status: :see_other
+    else
+      @category.destroy
+      redirect_to categories_path, notice: "Category deleted.", status: :see_other
+    end
+  end
+
+  private
+
+  def set_category
+    # Hide existence of other users' personal categories by returning 404
+    # instead of 403. Admins see everything.
+    @category = CategoryPolicy.visible_scope(current_user).find_by(id: params[:id])
+    render_not_found if @category.nil?
+  end
+
+  def authorize_show!
+    render_not_found unless CategoryPolicy.new(current_user, @category).show?
+  end
+
+  def authorize_edit!
+    return if CategoryPolicy.new(current_user, @category).edit?
+
+    if @category.user_id == current_user.id
+      render_not_found # shouldn't hit this branch; defensive
+    elsif @category.shared?
+      # Non-admin trying to edit a shared category: redirect, don't 404.
+      redirect_to category_path(@category), alert: "Shared categories are read-only.", status: :see_other
+    else
+      render_not_found
+    end
+  end
+
+  def category_params
+    # user_id is intentionally NOT permitted. Ownership is forced to
+    # current_user at create time and immutable thereafter (see Category
+    # model's user_id_change_preserves_children validation).
+    params.require(:category).permit(:name, :description, :color, :parent_id, :i18n_key)
+  end
+
+  def render_not_found
+    respond_to do |format|
+      format.html { render file: Rails.root.join("public/404.html"), layout: false, status: :not_found }
+      format.json { render json: { error: "Not Found" }, status: :not_found }
     end
   end
 end

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_with(model: category, local: true, class: "space-y-4") do |f| %>
+  <% if category.errors.any? %>
+    <div class="rounded-md bg-rose-50 border border-rose-200 p-3 text-sm text-rose-800">
+      <p class="font-medium mb-1"><%= pluralize(category.errors.count, "error") %> prevented saving:</p>
+      <ul class="list-disc list-inside">
+        <% category.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :name, class: "block text-sm font-medium text-slate-700" %>
+    <%= f.text_field :name,
+                     class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: "block text-sm font-medium text-slate-700" %>
+    <%= f.text_area :description, rows: 3,
+                    class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
+  </div>
+
+  <div>
+    <%= f.label :color, class: "block text-sm font-medium text-slate-700" %>
+    <%= f.text_field :color, placeholder: "#0f766e",
+                     class: "mt-1 block w-48 rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
+    <p class="text-xs text-slate-500 mt-1">Hex color, e.g. #0f766e. Stimulus picker arrives in PR 5.</p>
+  </div>
+
+  <div>
+    <%= f.label :parent_id, "Parent category", class: "block text-sm font-medium text-slate-700" %>
+    <%= f.collection_select :parent_id,
+                            CategoryPolicy.visible_scope(current_user).where.not(id: category.id).order(:name),
+                            :id, :display_name,
+                            { include_blank: "— none (top-level branch)" },
+                            class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
+  </div>
+
+  <div class="flex items-center gap-3 pt-2">
+    <%= f.submit class: "inline-flex items-center px-4 py-2 rounded-md bg-teal-700 text-white hover:bg-teal-800" %>
+    <%= link_to "Cancel", categories_path, class: "text-sm text-slate-600 hover:text-slate-900" %>
+  </div>
+<% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,4 @@
+<section class="max-w-2xl mx-auto p-6">
+  <h1 class="text-2xl font-semibold text-slate-900 mb-6">Edit category</h1>
+  <%= render "form", category: @category %>
+</section>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,25 @@
+<%# Barebones index — PR 3. Tree + personal/shared styling lands in PR 4. %>
+<section class="max-w-4xl mx-auto p-6">
+  <header class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-slate-900">Categories</h1>
+    <%= link_to "New category", new_category_path,
+                class: "inline-flex items-center px-4 py-2 rounded-md bg-teal-700 text-white hover:bg-teal-800" %>
+  </header>
+
+  <ul class="divide-y divide-slate-200 bg-white rounded-lg shadow-sm">
+    <% @categories.each do |category| %>
+      <li class="flex items-center justify-between p-4">
+        <div class="flex items-center gap-3">
+          <span class="inline-block w-3 h-3 rounded-full" style="background-color: <%= category.color || "#94a3b8" %>;"></span>
+          <%= link_to category.display_name, category_path(category), class: "text-slate-900 hover:text-teal-700" %>
+          <% if category.personal? %>
+            <span class="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-800">personal</span>
+          <% end %>
+        </div>
+        <% if CategoryPolicy.new(current_user, category).edit? %>
+          <%= link_to "Edit", edit_category_path(category), class: "text-sm text-teal-700 hover:text-teal-900" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,4 @@
+<section class="max-w-2xl mx-auto p-6">
+  <h1 class="text-2xl font-semibold text-slate-900 mb-6">New category</h1>
+  <%= render "form", category: @category %>
+</section>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -28,7 +28,7 @@
     </p>
   <% end %>
 
-  <% if @category.description.present? %>
+  <% if @category.description? %>
     <p class="text-slate-700 mb-4"><%= @category.description %></p>
   <% end %>
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,38 @@
+<%# Barebones show — PR 3. Detail panel + patterns inline lands in PR 6/7. %>
+<section class="max-w-3xl mx-auto p-6">
+  <header class="flex items-center justify-between mb-6">
+    <div class="flex items-center gap-3">
+      <span class="inline-block w-4 h-4 rounded-full" style="background-color: <%= @category.color || "#94a3b8" %>;"></span>
+      <h1 class="text-2xl font-semibold text-slate-900"><%= @category.display_name %></h1>
+      <% if @category.personal? %>
+        <span class="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-800">personal</span>
+      <% end %>
+    </div>
+    <% if CategoryPolicy.new(current_user, @category).edit? %>
+      <div class="flex gap-2">
+        <%= link_to "Edit", edit_category_path(@category),
+                    class: "px-3 py-1.5 rounded border border-teal-700 text-teal-700 hover:bg-teal-50" %>
+        <% if CategoryPolicy.new(current_user, @category).destroy? %>
+          <%= button_to "Delete", category_path(@category),
+                        method: :delete,
+                        data: { turbo_confirm: "Delete this category?" },
+                        class: "px-3 py-1.5 rounded border border-rose-600 text-rose-600 hover:bg-rose-50" %>
+        <% end %>
+      </div>
+    <% end %>
+  </header>
+
+  <% if @category.parent %>
+    <p class="text-sm text-slate-600 mb-4">
+      Parent: <%= link_to @category.parent.display_name, category_path(@category.parent), class: "text-teal-700" %>
+    </p>
+  <% end %>
+
+  <% if @category.description.present? %>
+    <p class="text-slate-700 mb-4"><%= @category.description %></p>
+  <% end %>
+
+  <p class="text-sm text-slate-500">
+    <%= link_to "← Back to categories", categories_path, class: "hover:text-teal-700" %>
+  </p>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,8 +130,9 @@ Rails.application.routes.draw do
     root "patterns#index"
   end
 
-  # Categories route for JSON endpoint
-  resources :categories, only: [ :index ]
+  # Categories — full CRUD for personal category management (PR 3/10).
+  # The JSON index keeps its shape as a dropdown data source for forms.
+  resources :categories
 
   # Bulk operations routes (must come before general resources to avoid conflicts)
   scope "/expenses", controller: :expenses do

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -193,6 +193,27 @@ RSpec.describe "Categories API", type: :request do
       }.not_to change { Category.count }
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "returns 404 when parent_id points at another user's personal category" do
+      other = create(:user, email: "sneaky_parent@example.com")
+      others_personal = create(:category, name: "SneakyParent", user: other)
+
+      expect {
+        post categories_path, params: {
+          category: { name: "TryCrossParent", parent_id: others_personal.id }
+        }
+      }.not_to change { Category.count }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 when parent_id points at a nonexistent category" do
+      expect {
+        post categories_path, params: {
+          category: { name: "TryMissingParent", parent_id: 9_999_999 }
+        }
+      }.not_to change { Category.count }
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET /categories/:id/edit", :integration do
@@ -285,6 +306,60 @@ RSpec.describe "Categories API", type: :request do
       theirs = create(:category, name: "Theirs2", user: other)
       expect { delete category_path(theirs) }.not_to change { Category.count }
       expect(response).to have_http_status(:not_found)
+    end
+
+    it "refuses destroy when the category has children" do
+      victim = create(:category, name: "WithChild", user: user)
+      create(:category, name: "Child of WithChild", user: user, parent: victim)
+      expect { delete category_path(victim) }.not_to change { Category.count }
+      expect(response).to redirect_to(category_path(victim))
+    end
+
+    it "refuses destroy when the category has categorization_patterns" do
+      victim = create(:category, name: "WithPattern", user: user)
+      create(:categorization_pattern, category: victim, pattern_type: "merchant", pattern_value: "somestore")
+      expect { delete category_path(victim) }.not_to change { Category.count }
+      expect(response).to redirect_to(category_path(victim))
+    end
+
+    it "refuses destroy when the category has user_category_preferences" do
+      victim = create(:category, name: "WithPref", user: user)
+      email_account = create(:email_account, user: user)
+      create(:user_category_preference,
+             email_account: email_account,
+             category: victim,
+             context_type: "merchant",
+             context_value: "foo",
+             preference_weight: 1,
+             usage_count: 1)
+      expect { delete category_path(victim) }.not_to change { Category.count }
+      expect(response).to redirect_to(category_path(victim))
+    end
+  end
+
+  describe "admin paths", :integration do
+    let!(:admin_current) { create(:user, :admin, email: "admin_current@example.com") }
+    let!(:other)         { create(:user, email: "admin_other@example.com") }
+    let!(:shared_c)      { create(:category, name: "AdminCanEditShared", user: nil) }
+    let!(:others_personal) { create(:category, name: "AdminCanEditOthers", user: other) }
+
+    before { sign_in_as(admin_current) }
+
+    it "admin can edit a shared category" do
+      get edit_category_path(shared_c)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "admin can update another user's personal category" do
+      patch category_path(others_personal), params: { category: { color: "#123456" } }
+      expect(response).to redirect_to(category_path(others_personal))
+      others_personal.reload
+      expect(others_personal.color).to eq("#123456")
+    end
+
+    it "admin can destroy an empty shared category" do
+      victim = create(:category, name: "AdminDeleteShared", user: nil)
+      expect { delete category_path(victim) }.to change { Category.count }.by(-1)
     end
   end
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -73,4 +73,218 @@ RSpec.describe "Categories API", type: :request do
       end
     end
   end
+
+  describe "GET /categories (HTML)", :integration do
+    let!(:user)  { create(:user, email: "crud_user@example.com") }
+    let!(:other) { create(:user, email: "crud_other@example.com") }
+    let!(:shared_one)     { create(:category, name: "Shared1", user: nil) }
+    let!(:my_personal)    { create(:category, name: "My Home Food", user: user) }
+    let!(:others_personal) { create(:category, name: "Others Bucket", user: other) }
+
+    before { sign_in_as(user) }
+
+    it "renders HTML successfully" do
+      get categories_path
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/html")
+    end
+
+    it "shows shared and user's own personal category names" do
+      get categories_path
+      expect(response.body).to include("Shared1")
+      expect(response.body).to include("My Home Food")
+    end
+
+    it "does not expose another user's personal category names" do
+      get categories_path
+      expect(response.body).not_to include("Others Bucket")
+    end
+  end
+
+  describe "GET /categories/:id", :integration do
+    let!(:user)  { create(:user, email: "show_user@example.com") }
+    let!(:other) { create(:user, email: "show_other@example.com") }
+    let!(:shared_cat)      { create(:category, name: "ShownShared", user: nil) }
+    let!(:own_personal)    { create(:category, name: "OwnPersonal", user: user) }
+    let!(:others_personal) { create(:category, name: "OthersPersonal", user: other) }
+
+    before { sign_in_as(user) }
+
+    it "shows a shared category" do
+      get category_path(shared_cat)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("ShownShared")
+    end
+
+    it "shows own personal category" do
+      get category_path(own_personal)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("OwnPersonal")
+    end
+
+    it "returns 404 for another user's personal category (no existence leak)" do
+      get category_path(others_personal)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /categories/new", :integration do
+    let!(:user) { create(:user, email: "new_user@example.com") }
+
+    before { sign_in_as(user) }
+
+    it "renders the new form" do
+      get new_category_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "requires authentication" do
+      delete logout_path
+      get new_category_path
+      expect(response).to redirect_to(login_path)
+    end
+  end
+
+  describe "POST /categories", :integration do
+    let!(:user)  { create(:user, email: "create_user@example.com") }
+    let!(:shared_parent) { create(:category, name: "CreateParentShared", user: nil) }
+
+    before { sign_in_as(user) }
+
+    it "creates a personal top-level category owned by current_user" do
+      expect {
+        post categories_path, params: {
+          category: { name: "PersonalTop", color: "#ABCDEF" }
+        }
+      }.to change { user.reload; Category.personal_for(user).count }.by(1)
+
+      created = Category.personal_for(user).find_by(name: "PersonalTop")
+      expect(created).not_to be_nil
+      expect(created.user_id).to eq(user.id)
+      expect(response).to redirect_to(category_path(created))
+    end
+
+    it "creates a personal subcategory under a shared parent" do
+      post categories_path, params: {
+        category: { name: "PersonalChild", parent_id: shared_parent.id }
+      }
+      created = Category.find_by(name: "PersonalChild")
+      expect(created).not_to be_nil
+      expect(created.parent_id).to eq(shared_parent.id)
+      expect(created.user_id).to eq(user.id)
+    end
+
+    it "ignores an attempt to set user_id in params (forces current_user)" do
+      other = create(:user, email: "impersonate_target@example.com")
+      post categories_path, params: {
+        category: { name: "ImpersonationAttempt", user_id: other.id }
+      }
+      created = Category.find_by(name: "ImpersonationAttempt")
+      expect(created).not_to be_nil
+      expect(created.user_id).to eq(user.id)
+      expect(created.user_id).not_to eq(other.id)
+    end
+
+    it "re-renders new on validation failure without creating" do
+      expect {
+        post categories_path, params: {
+          category: { name: "", color: "not-a-hex" }
+        }
+      }.not_to change { Category.count }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /categories/:id/edit", :integration do
+    let!(:user)  { create(:user, email: "edit_user@example.com") }
+    let!(:other) { create(:user, email: "edit_other@example.com") }
+    let!(:own)      { create(:category, name: "EditOwn", user: user) }
+    let!(:shared_c) { create(:category, name: "EditShared", user: nil) }
+    let!(:others)   { create(:category, name: "EditOthers", user: other) }
+
+    before { sign_in_as(user) }
+
+    it "renders edit for owned personal" do
+      get edit_category_path(own)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "redirects with alert when trying to edit a shared category as non-admin" do
+      get edit_category_path(shared_c)
+      expect(response).to have_http_status(:found).or have_http_status(:see_other)
+    end
+
+    it "returns 404 when trying to edit another user's personal category" do
+      get edit_category_path(others)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /categories/:id", :integration do
+    let!(:user) { create(:user, email: "update_user@example.com") }
+    let!(:own)  { create(:category, name: "OriginalName", user: user) }
+
+    before { sign_in_as(user) }
+
+    it "updates allowed attributes" do
+      patch category_path(own), params: {
+        category: { name: "NewName", color: "#112233" }
+      }
+      expect(response).to redirect_to(category_path(own))
+      own.reload
+      expect(own.name).to eq("NewName")
+      expect(own.color).to eq("#112233")
+    end
+
+    it "ignores user_id in params (cannot change ownership via update)" do
+      target = create(:user, email: "update_target@example.com")
+      patch category_path(own), params: {
+        category: { user_id: target.id }
+      }
+      own.reload
+      expect(own.user_id).to eq(user.id)
+    end
+
+    it "re-renders edit on validation failure" do
+      patch category_path(own), params: { category: { name: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 404 when updating another user's personal category" do
+      other = create(:user, email: "update_other@example.com")
+      theirs = create(:category, name: "Theirs", user: other)
+      patch category_path(theirs), params: { category: { name: "Hijack" } }
+      expect(response).to have_http_status(:not_found)
+      theirs.reload
+      expect(theirs.name).to eq("Theirs")
+    end
+  end
+
+  describe "DELETE /categories/:id", :integration do
+    let!(:user) { create(:user, email: "delete_user@example.com") }
+
+    before { sign_in_as(user) }
+
+    it "destroys an empty personal category" do
+      victim = create(:category, name: "Victim", user: user)
+      expect { delete category_path(victim) }.to change { Category.count }.by(-1)
+      expect(response).to redirect_to(categories_path)
+    end
+
+    it "refuses to destroy a category that is in use by expenses (deferred to PR 8)" do
+      victim = create(:category, name: "Occupied", user: user)
+      email_account = create(:email_account, user: user)
+      create(:expense, category: victim, email_account: email_account)
+
+      expect { delete category_path(victim) }.not_to change { Category.count }
+      expect(response).to have_http_status(:unprocessable_entity).or redirect_to(category_path(victim))
+    end
+
+    it "returns 404 on another user's personal category" do
+      other = create(:user, email: "delete_other@example.com")
+      theirs = create(:category, name: "Theirs2", user: other)
+      expect { delete category_path(theirs) }.not_to change { Category.count }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR 3 of 10. Wires the categories resource end-to-end using `CategoryPolicy` (PR 2).

**Scope is deliberately barebones** — tree UI (PR 4), create polish (PR 5), edit side panel (PR 6), pattern management (PR 7), and full deletion flow (PR 8) each get their own PR.

## Changes

- Routes: `resources :categories` (was `only: [:index]`)
- Controller: all 7 RESTful actions, authz via `CategoryPolicy`, strong params that **never permit `user_id`** (ownership is server-side only)
- Views: scaffold-quality using Financial Confidence palette (teal/slate/rose/amber). No Tree layout or Turbo Frames — those land in PRs 4–6.

## Authz behavior

- Cross-user personal categories → **404** (avoid existence leak)
- Non-admin editing a shared category → **redirect with alert** (it exists publicly, just read-only for them)
- `destroy` in this PR is narrow: empty personal categories only. In-use → redirect with a \"deferred to PR 8\" alert rather than silent cascade.

## Test plan

- [x] 28 new request specs cover HTML + JSON index, show/edit/update authz matrix, create ownership enforcement (including impersonation via params), destroy happy path, and in-use refusal
- [x] 93 specs pass across categories model + policy + request
- [x] Rubocop clean