### PR TITLE
feat(categories): PR 5/10 — create flow polish (color picker + inline add subcategory)

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -51,8 +51,15 @@ class CategoriesController < ApplicationController
   end
 
   # GET /categories/new
+  #
+  # Supports ?parent_id=X to prefill the parent selector, used by the
+  # inline "+ Add subcategory" affordance on each shared root in the tree
+  # view. The parent_id is validated against the visible scope — an
+  # invalid or out-of-scope id is silently dropped (the user can still
+  # pick a parent from the form).
   def new
-    @category = Category.new(user: current_user)
+    parent = resolve_prefill_parent(params[:parent_id])
+    @category = Category.new(user: current_user, parent: parent)
   end
 
   # POST /categories
@@ -167,6 +174,12 @@ class CategoriesController < ApplicationController
     return :personal_root if category.parent_id.nil? && category.personal?
 
     :child
+  end
+
+  def resolve_prefill_parent(id)
+    return nil if id.blank?
+
+    CategoryPolicy.visible_scope(current_user).find_by(id: id)
   end
 
   def render_not_found

--- a/app/javascript/controllers/category_color_picker_controller.js
+++ b/app/javascript/controllers/category_color_picker_controller.js
@@ -1,0 +1,64 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Keeps a native <input type="color"> and a sibling hex text field in
+// sync so the category form supports either direct typing (#0f766e) or
+// graphical selection. Preview swatch updates on every change.
+//
+// Targets:
+//   - picker: the <input type="color"> element
+//   - text:   the text field that actually submits the form value
+//   - swatch: a visual preview block (optional)
+//
+// The text field is the source of truth (it is the form input). The
+// picker mirrors it. Typing a valid hex updates the picker + swatch;
+// picking a color via the OS dialog updates the text + swatch.
+export default class extends Controller {
+  static targets = ["picker", "text", "swatch"]
+
+  connect() {
+    this.syncFromText()
+  }
+
+  pickerChanged() {
+    this.textTarget.value = this.pickerTarget.value
+    this.updateSwatch(this.pickerTarget.value)
+  }
+
+  textChanged() {
+    const value = this.textTarget.value.trim()
+    if (this.isValidHex(value)) {
+      this.pickerTarget.value = this.expandShortHex(value)
+      this.updateSwatch(value)
+    }
+  }
+
+  syncFromText() {
+    const value = this.textTarget.value.trim()
+    if (this.isValidHex(value)) {
+      this.pickerTarget.value = this.expandShortHex(value)
+      this.updateSwatch(value)
+    } else {
+      this.updateSwatch("#94a3b8") // slate-400 fallback
+    }
+  }
+
+  updateSwatch(value) {
+    if (this.hasSwatchTarget) {
+      this.swatchTarget.style.backgroundColor = value
+    }
+  }
+
+  isValidHex(value) {
+    return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(value)
+  }
+
+  // <input type="color"> requires a 6-char hex, so expand shorthand
+  // like #f00 → #ff0000 before assigning.
+  expandShortHex(value) {
+    if (value.length === 4) {
+      const [, r, g, b] = value
+      return `#${r}${r}${g}${g}${b}${b}`
+    }
+    return value
+  }
+}

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -22,11 +22,27 @@
                     class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
   </div>
 
-  <div>
+  <div data-controller="category-color-picker" class="space-y-2">
     <%= f.label :color, class: "block text-sm font-medium text-slate-700" %>
-    <%= f.text_field :color, placeholder: "#0f766e",
-                     class: "mt-1 block w-48 rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500" %>
-    <p class="text-xs text-slate-500 mt-1">Hex color, e.g. #0f766e. Stimulus picker arrives in PR 5.</p>
+    <div class="flex items-center gap-3">
+      <span data-category-color-picker-target="swatch"
+            class="inline-block w-10 h-10 rounded-md border border-slate-300"
+            aria-hidden="true"></span>
+      <input type="color"
+             data-category-color-picker-target="picker"
+             data-action="input->category-color-picker#pickerChanged"
+             value="<%= category.color.presence || "#0f766e" %>"
+             class="h-10 w-14 rounded-md border border-slate-300 p-1 cursor-pointer"
+             aria-label="Pick color">
+      <%= f.text_field :color,
+                       placeholder: "#0f766e",
+                       data: {
+                         "category-color-picker-target": "text",
+                         action: "input->category-color-picker#textChanged"
+                       },
+                       class: "block w-32 rounded-md border-slate-300 shadow-sm focus:border-teal-500 focus:ring-teal-500 font-mono text-sm" %>
+    </div>
+    <p class="text-xs text-slate-500">Type a hex code or use the picker. Either updates the other.</p>
   </div>
 
   <div>

--- a/app/views/categories/_tree_node.html.erb
+++ b/app/views/categories/_tree_node.html.erb
@@ -18,10 +18,18 @@
         </span>
       <% end %>
     </div>
-    <% if CategoryPolicy.new(current_user, category).edit? %>
-      <%= link_to "Edit", edit_category_path(category),
-                  class: "shrink-0 text-sm text-teal-700 hover:text-teal-900" %>
-    <% end %>
+    <div class="shrink-0 flex items-center gap-3">
+      <% if category.shared? && category.root? %>
+        <%= link_to "+ Add subcategory",
+                    new_category_path(parent_id: category.id),
+                    class: "text-sm text-teal-700 hover:text-teal-900",
+                    title: "Create a personal subcategory under #{category.display_name}" %>
+      <% end %>
+      <% if CategoryPolicy.new(current_user, category).edit? %>
+        <%= link_to "Edit", edit_category_path(category),
+                    class: "text-sm text-teal-700 hover:text-teal-900" %>
+      <% end %>
+    </div>
   </div>
 
   <% if children.any? %>

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -198,6 +198,63 @@ RSpec.describe "Categories API", type: :request do
       get new_category_path
       expect(response).to redirect_to(login_path)
     end
+
+    context "with a ?parent_id= prefill (inline + Add subcategory flow)" do
+      let!(:shared_parent) { create(:category, name: "PrefillShared", user: nil) }
+
+      it "preselects the shared parent in the form select" do
+        get new_category_path(parent_id: shared_parent.id)
+        expect(response).to have_http_status(:ok)
+        doc = Nokogiri::HTML(response.body)
+        selected = doc.at_css('select[name="category[parent_id]"] option[selected]')
+        expect(selected&.attr("value")).to eq(shared_parent.id.to_s)
+      end
+
+      it "silently drops a parent_id pointing at another user's personal category" do
+        other = create(:user, email: "prefill_other@example.com")
+        others = create(:category, name: "OthersPrefill", user: other)
+        get new_category_path(parent_id: others.id)
+        expect(response).to have_http_status(:ok)
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css('select[name="category[parent_id]"] option[selected]')).to be_nil
+      end
+
+      it "silently drops a parent_id that does not exist" do
+        get new_category_path(parent_id: 9_999_999)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "inline '+ Add subcategory' affordance on shared roots", :integration do
+    let!(:user) { create(:user, email: "affordance_user@example.com") }
+    let!(:shared_root)  { create(:category, name: "AffordShared", user: nil) }
+    let!(:shared_child) { create(:category, name: "AffordSharedChild", user: nil, parent: shared_root) }
+    let!(:personal_root) { create(:category, name: "AffordPersonal", user: user) }
+
+    before { sign_in_as(user) }
+
+    it "shows an Add subcategory link on shared root rows" do
+      get categories_path
+      doc = Nokogiri::HTML(response.body)
+      links = doc.css("a").select { |a| a.text.include?("Add subcategory") && a["href"] =~ /parent_id=#{shared_root.id}/ }
+      expect(links).not_to be_empty
+    end
+
+    it "does not show Add subcategory on shared children (only on roots)" do
+      get categories_path
+      doc = Nokogiri::HTML(response.body)
+      # Find the tree-node row for the shared child and make sure it has no affordance.
+      link = doc.css("a").find { |a| a.text.include?("Add subcategory") && a["href"] =~ /parent_id=#{shared_child.id}/ }
+      expect(link).to be_nil
+    end
+
+    it "does not show Add subcategory on personal roots" do
+      get categories_path
+      doc = Nokogiri::HTML(response.body)
+      link = doc.css("a").find { |a| a.text.include?("Add subcategory") && a["href"] =~ /parent_id=#{personal_root.id}/ }
+      expect(link).to be_nil
+    end
   end
 
   describe "POST /categories", :integration do

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -210,6 +210,14 @@ RSpec.describe "Categories API", type: :request do
         expect(selected&.attr("value")).to eq(shared_parent.id.to_s)
       end
 
+      it "preselects the user's own personal category as a parent" do
+        own = create(:category, name: "PrefillOwnPersonal", user: user)
+        get new_category_path(parent_id: own.id)
+        doc = Nokogiri::HTML(response.body)
+        selected = doc.at_css('select[name="category[parent_id]"] option[selected]')
+        expect(selected&.attr("value")).to eq(own.id.to_s)
+      end
+
       it "silently drops a parent_id pointing at another user's personal category" do
         other = create(:user, email: "prefill_other@example.com")
         others = create(:category, name: "OthersPrefill", user: other)


### PR DESCRIPTION
## Summary

PR 5 of 10. Three create-path improvements from the design doc.

### 1. Stimulus color picker

Native \`<input type=\"color\">\` synced with a hex text field. Either source updates the other + a live swatch. Accepts shorthand (#f00) and normalizes it for the native picker. Controller: \`app/javascript/controllers/category_color_picker_controller.js\` (auto-registered via stimulus-loading).

### 2. Inline \"+ Add subcategory\" on shared tree roots

Links to \`/categories/new?parent_id=<shared_root>\`. Shown only on shared **roots** — not on shared children, not on personal roots (no shared parent implied). Realizes the design doc's \"one click to start a personal subcategory under any shared parent.\"

### 3. \`new\` action prefill

Controller resolves \`params[:parent_id]\` through \`CategoryPolicy.visible_scope(current_user)\` via a new \`resolve_prefill_parent\` helper. Out-of-scope or nonexistent ids are **silently dropped** — the user still lands on a working form with no parent preselected. Keeps the existence-hiding guarantee intact for \`/new\`.

## Test plan

- [x] 6 new specs: parent preselected for valid in-scope id, dropped for cross-user id, dropped for nonexistent id, affordance rendered on shared roots, NOT on shared children, NOT on personal roots
- [x] 48 request specs pass, 113 across model/policy/request
- [x] Rubocop clean