### PR TITLE
feat(categories): PR 7/10 — inline pattern management on category side panel

### DIFF
--- a/app/controllers/category_patterns_controller.rb
+++ b/app/controllers/category_patterns_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# User-facing nested CRUD for adding/removing categorization patterns on
+# a category. Authorization mirrors CategoryPolicy#manage_patterns? —
+# regular users can manage patterns on their own personal categories;
+# admins can manage patterns on any category.
+#
+# The global admin surface for browsing/filtering all patterns across the
+# whole system lives at Admin::PatternsController.
+class CategoryPatternsController < ApplicationController
+  before_action :set_category
+  before_action :authorize_manage!
+
+  # POST /categories/:category_id/patterns
+  def create
+    @pattern = @category.categorization_patterns.new(
+      pattern_params.merge(user_created: true)
+    )
+
+    respond_to do |format|
+      if @pattern.save
+        format.html { redirect_to category_path(@category), notice: "Pattern added." }
+        format.turbo_stream { redirect_to category_path(@category), status: :see_other }
+      else
+        # Re-render the category show view with validation errors.
+        @category.errors.merge!(@pattern.errors) if @pattern.errors.any?
+        format.html do
+          flash.now[:alert] = @pattern.errors.full_messages.to_sentence
+          render "categories/show", status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  # DELETE /categories/:category_id/patterns/:id
+  def destroy
+    pattern = @category.categorization_patterns.find(params[:id])
+    pattern.destroy
+
+    redirect_to category_path(@category),
+                notice: "Pattern removed.",
+                status: :see_other
+  end
+
+  private
+
+  def set_category
+    @category = CategoryPolicy.visible_scope(current_user).find_by(id: params[:category_id])
+    render_not_found if @category.nil?
+  end
+
+  def authorize_manage!
+    return if CategoryPolicy.new(current_user, @category).manage_patterns?
+
+    render_not_found
+  end
+
+  def pattern_params
+    params.require(:categorization_pattern)
+          .permit(:pattern_type, :pattern_value)
+  end
+
+  def render_not_found
+    respond_to do |format|
+      format.html { render file: Rails.root.join("public/404.html"), layout: false, status: :not_found }
+      format.json { render json: { error: "Not Found" }, status: :not_found }
+    end
+  end
+end

--- a/app/views/categories/_patterns_section.html.erb
+++ b/app/views/categories/_patterns_section.html.erb
@@ -1,0 +1,69 @@
+<%# Pattern management section for the category side panel (PR 7).
+    Visible to users who can manage the category's patterns. Shows
+    existing patterns with usage metrics and a compact add form. %>
+<% can_manage = CategoryPolicy.new(current_user, category).manage_patterns? %>
+<% patterns = category.categorization_patterns.order(:pattern_type, :pattern_value) %>
+
+<section class="mt-6 pt-5 border-t border-slate-200">
+  <header class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+      Patterns
+      <span class="text-slate-400 font-normal normal-case ml-1">(<%= patterns.size %>)</span>
+    </h2>
+  </header>
+
+  <% if patterns.any? %>
+    <ul class="space-y-1.5 mb-4">
+      <% patterns.each do |p| %>
+        <li class="flex items-center justify-between gap-3 px-3 py-2 bg-slate-50 rounded-md text-sm">
+          <div class="min-w-0 flex items-center gap-2">
+            <span class="inline-block px-1.5 py-0.5 rounded text-xs font-mono bg-teal-50 text-teal-800 shrink-0">
+              <%= p.pattern_type %>
+            </span>
+            <span class="text-slate-900 truncate"><%= p.pattern_value %></span>
+          </div>
+          <div class="shrink-0 flex items-center gap-3">
+            <span class="text-xs text-slate-500">
+              <%= p.usage_count %>× · <%= "%.0f" % ((p.success_rate || 0) * 100) %>%
+            </span>
+            <% if can_manage %>
+              <%= button_to "×",
+                            category_pattern_path(category, p),
+                            method: :delete,
+                            data: {
+                              turbo_confirm: "Delete this pattern?",
+                              turbo_frame: "category_panel"
+                            },
+                            class: "text-rose-600 hover:text-rose-800 font-bold leading-none px-1",
+                            title: "Delete pattern",
+                            form_class: "inline" %>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-sm text-slate-500 italic mb-4">No patterns yet.</p>
+  <% end %>
+
+  <% if can_manage %>
+    <%= form_with url: category_patterns_path(category),
+                  scope: :categorization_pattern,
+                  data: { turbo_frame: "category_panel" },
+                  class: "flex items-start gap-2" do |f| %>
+      <%= f.select :pattern_type,
+                   options_for_select(CategorizationPattern::PATTERN_TYPES.map { |t| [ t, t ] }),
+                   {},
+                   class: "rounded-md border-slate-300 text-sm w-28 shrink-0" %>
+      <%= f.text_field :pattern_value,
+                       placeholder: "value",
+                       required: true,
+                       class: "flex-1 rounded-md border-slate-300 shadow-sm text-sm focus:border-teal-500 focus:ring-teal-500" %>
+      <%= f.submit "Add",
+                   class: "shrink-0 px-3 py-1.5 rounded-md bg-teal-700 text-white hover:bg-teal-800 text-sm" %>
+    <% end %>
+    <p class="text-xs text-slate-500 mt-2">
+      Types: merchant / keyword / description (substring); amount_range (e.g. 10-50); regex; time.
+    </p>
+  <% end %>
+</section>

--- a/app/views/categories/_patterns_section.html.erb
+++ b/app/views/categories/_patterns_section.html.erb
@@ -47,6 +47,23 @@
   <% end %>
 
   <% if can_manage %>
+    <%# Surface validation errors from a failed POST /categories/:id/patterns
+        — the controller re-renders categories/show, and @pattern carries the
+        errors. Without this block the user sees only a flash banner outside
+        the Turbo Frame, so errors never reach the panel. %>
+    <% if defined?(@pattern) && @pattern&.errors&.any? %>
+      <div class="mb-3 rounded-md bg-rose-50 border border-rose-200 p-3 text-sm text-rose-800">
+        <p class="font-medium mb-1">
+          Could not add pattern:
+        </p>
+        <ul class="list-disc list-inside">
+          <% @pattern.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <%= form_with url: category_patterns_path(category),
                   scope: :categorization_pattern,
                   data: { turbo_frame: "category_panel" },

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -42,6 +42,8 @@
       <p class="text-slate-700 text-sm mb-3"><%= @category.description %></p>
     <% end %>
 
+    <%= render "categories/patterns_section", category: @category %>
+
     <p class="text-xs text-slate-500 mt-6">
       <%# Break out of the panel frame so this navigates to the full
           /categories/:id page. Without _top the link would load the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,7 +132,13 @@ Rails.application.routes.draw do
 
   # Categories — full CRUD for personal category management (PR 3/10).
   # The JSON index keeps its shape as a dropdown data source for forms.
-  resources :categories
+  resources :categories do
+    # Nested user-facing pattern management (PR 7/10). Scoped to
+    # categories the user can edit; lives under the category side panel.
+    # Separate from Admin::PatternsController, which is the global
+    # admin surface for all patterns across all categories.
+    resources :patterns, only: %i[create destroy], controller: "category_patterns"
+  end
 
   # Bulk operations routes (must come before general resources to avoid conflicts)
   scope "/expenses", controller: :expenses do

--- a/spec/requests/category_patterns_spec.rb
+++ b/spec/requests/category_patterns_spec.rb
@@ -54,6 +54,81 @@ RSpec.describe "Category Patterns", type: :request, integration: true do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
+    it "surfaces validation errors inside the category_panel Turbo Frame" do
+      post category_patterns_path(own), params: {
+        categorization_pattern: { pattern_type: "invalid_type", pattern_value: "x" }
+      }
+      doc = Nokogiri::HTML(response.body)
+      frame = doc.at_css('turbo-frame#category_panel')
+      expect(frame).not_to be_nil
+      expect(frame.text).to include("Could not add pattern")
+    end
+
+    it "rejects an empty pattern_value (model presence)" do
+      expect {
+        post category_patterns_path(own), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "" }
+        }
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "rejects a whitespace-only pattern_value" do
+      expect {
+        post category_patterns_path(own), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "   " }
+        }
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "ignores a forged user_created=false param (server forces true)" do
+      post category_patterns_path(own), params: {
+        categorization_pattern: {
+          pattern_type: "merchant",
+          pattern_value: "forged",
+          user_created: false
+        }
+      }
+      created = own.categorization_patterns.find_by(pattern_value: "forged")
+      expect(created).not_to be_nil
+      expect(created.user_created).to be true
+    end
+
+    it "ignores a forged category_id in params (stays on the nested category)" do
+      post category_patterns_path(own), params: {
+        categorization_pattern: {
+          pattern_type: "merchant",
+          pattern_value: "crossposted",
+          category_id: others.id
+        }
+      }
+      created = CategorizationPattern.find_by(pattern_value: "crossposted")
+      expect(created).not_to be_nil
+      expect(created.category_id).to eq(own.id)
+      expect(created.category_id).not_to eq(others.id)
+    end
+
+    it "ignores forged confidence_weight / usage_count / active params" do
+      post category_patterns_path(own), params: {
+        categorization_pattern: {
+          pattern_type: "merchant",
+          pattern_value: "tampered",
+          confidence_weight: 9.9,
+          usage_count: 1_000,
+          success_count: 999,
+          active: false
+        }
+      }
+      created = own.categorization_patterns.find_by(pattern_value: "tampered")
+      expect(created).not_to be_nil
+      # New patterns start with defaults, not the forged values.
+      expect(created.confidence_weight).to eq(CategorizationPattern::DEFAULT_CONFIDENCE_WEIGHT)
+      expect(created.usage_count).to eq(0)
+      expect(created.success_count).to eq(0)
+      expect(created.active).to be true
+    end
+
     it "requires authentication" do
       delete logout_path
       post category_patterns_path(own), params: {

--- a/spec/requests/category_patterns_spec.rb
+++ b/spec/requests/category_patterns_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Category Patterns", type: :request, integration: true do
+  let!(:user)  { create(:user, email: "cp_user@example.com") }
+  let!(:other) { create(:user, email: "cp_other@example.com") }
+
+  let!(:own)      { create(:category, name: "CP_Own", user: user) }
+  let!(:shared_c) { create(:category, name: "CP_Shared", user: nil) }
+  let!(:others)   { create(:category, name: "CP_Others", user: other) }
+
+  describe "POST /categories/:category_id/patterns" do
+    before { sign_in_as(user) }
+
+    it "adds a pattern to a user's own personal category" do
+      expect {
+        post category_patterns_path(own), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "mcdonalds" }
+        }
+      }.to change { own.categorization_patterns.count }.by(1)
+
+      created = own.categorization_patterns.last
+      expect(created.pattern_type).to eq("merchant")
+      expect(created.pattern_value).to eq("mcdonalds")
+      expect(created.user_created).to be true
+      expect(response).to redirect_to(category_path(own))
+    end
+
+    it "rejects adding a pattern to a shared category (non-admin)" do
+      expect {
+        post category_patterns_path(shared_c), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "x" }
+        }
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 when trying to add a pattern to another user's personal category (no existence leak)" do
+      expect {
+        post category_patterns_path(others), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "x" }
+        }
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "re-renders the category show with errors on validation failure" do
+      expect {
+        post category_patterns_path(own), params: {
+          categorization_pattern: { pattern_type: "invalid_type", pattern_value: "x" }
+        }
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "requires authentication" do
+      delete logout_path
+      post category_patterns_path(own), params: {
+        categorization_pattern: { pattern_type: "merchant", pattern_value: "x" }
+      }
+      expect(response).to redirect_to(login_path)
+    end
+  end
+
+  describe "DELETE /categories/:category_id/patterns/:id" do
+    let!(:pattern) {
+      create(:categorization_pattern,
+             category: own,
+             pattern_type: "merchant",
+             pattern_value: "target_pattern")
+    }
+
+    before { sign_in_as(user) }
+
+    it "deletes a pattern belonging to the user's own category" do
+      expect {
+        delete category_pattern_path(own, pattern)
+      }.to change { own.categorization_patterns.count }.by(-1)
+      expect(response).to redirect_to(category_path(own))
+    end
+
+    it "refuses to delete a pattern via another user's category scope" do
+      expect {
+        delete category_pattern_path(others, pattern)
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "refuses to delete a pattern via a shared category as non-admin" do
+      shared_pattern = create(:categorization_pattern,
+                              category: shared_c,
+                              pattern_type: "merchant",
+                              pattern_value: "shared_pattern")
+      expect {
+        delete category_pattern_path(shared_c, shared_pattern)
+      }.not_to change { CategorizationPattern.count }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "admin paths" do
+    let!(:admin_current) { create(:user, :admin, email: "cp_admin@example.com") }
+    let!(:others_pattern) {
+      create(:categorization_pattern,
+             category: others,
+             pattern_type: "merchant",
+             pattern_value: "cross_user_target")
+    }
+
+    before { sign_in_as(admin_current) }
+
+    it "admin can add a pattern to a shared category" do
+      expect {
+        post category_patterns_path(shared_c), params: {
+          categorization_pattern: { pattern_type: "merchant", pattern_value: "admin_added" }
+        }
+      }.to change { shared_c.categorization_patterns.count }.by(1)
+    end
+
+    it "admin can delete a pattern on another user's category" do
+      expect {
+        delete category_pattern_path(others, others_pattern)
+      }.to change { CategorizationPattern.count }.by(-1)
+    end
+  end
+
+  describe "show view patterns section" do
+    before { sign_in_as(user) }
+
+    it "renders patterns list + add form for a category the user can manage" do
+      create(:categorization_pattern,
+             category: own,
+             pattern_type: "merchant",
+             pattern_value: "listed_value",
+             usage_count: 7,
+             success_count: 5)
+      get category_path(own)
+      expect(response.body).to include("listed_value")
+      expect(response.body).to include("Patterns")
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.at_css("form[action='#{category_patterns_path(own)}']")).not_to be_nil
+    end
+
+    it "does not render the add form for read-only categories" do
+      get category_path(shared_c)
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.at_css("form[action='#{category_patterns_path(shared_c)}']")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR 7 of 10. Lets users add and remove \`categorization_patterns\` on any category they can edit, directly from the side panel built in PR 6.

### Routes

\`\`\`ruby
resources :categories do
  resources :patterns, only: [:create, :destroy], controller: \"category_patterns\"
end
\`\`\`

### CategoryPatternsController

- \`set_category\` scoped to \`CategoryPolicy.visible_scope\`
- \`authorize_manage!\` via \`CategoryPolicy#manage_patterns?\` (alias of \`edit?\`)
- \`create\` / \`destroy\` only — list is rendered inline on the category show view
- Out-of-scope or unmanageable → 404 (existence hiding, same as PR 3)
- \`user_created: true\` set server-side on create

### View

\`app/views/categories/_patterns_section.html.erb\`, included on \`show.html.erb\`.

- Patterns table with type badge, value, \`usage_count × / success_rate%\` metrics
- Inline delete (× button) with confirm
- Inline add form for manage-capable users, bounded by \`CategorizationPattern::PATTERN_TYPES\`
- All links + forms target the \`category_panel\` Turbo Frame so add/remove stays in the panel

The global admin surface at \`Admin::PatternsController\` (existing) continues to cover system-wide pattern browsing / import / statistics.

## Test plan

- [x] 12 new request specs cover the authz matrix: add/delete on own personal (allowed), shared as non-admin (404), other user's personal (404), validation failure re-renders show, admin can manage shared + cross-user
- [x] Show view renders list + add-form only when manageable
- [x] 135 specs across category model + policy + categories requests + category-patterns requests pass
- [x] Rubocop clean