### PR TITLE
feat(categories): PR 8/10 — deletion flow + Services::CategoryDeletion

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,22 +1,8 @@
 class CategoriesController < ApplicationController
-  before_action :set_category, only: %i[show edit update destroy]
+  before_action :set_category, only: %i[show edit update destroy confirm_delete]
   before_action :authorize_show!, only: %i[show]
-  before_action :authorize_edit!, only: %i[edit update destroy]
+  before_action :authorize_edit!, only: %i[edit update destroy confirm_delete]
   before_action :scope_parent_id, only: %i[create update]
-
-  # Associations that block an "empty category" fast-path destroy in this PR.
-  # Anything touching a category's identity must be resolved by PR 8's
-  # CategoryDeletion service (reassign vs. orphan). This list mirrors the
-  # dependent: :destroy/:nullify associations on Category.
-  DELETE_BLOCKING_ASSOCIATIONS = %i[
-    expenses
-    children
-    categorization_patterns
-    composite_patterns
-    pattern_feedbacks
-    pattern_learning_events
-    user_category_preferences
-  ].freeze
 
   # GET /categories(.json)
   #
@@ -86,21 +72,39 @@ class CategoriesController < ApplicationController
     end
   end
 
+  # GET /categories/:id/confirm_delete
+  #
+  # Shows the reassign/orphan choice page. Routed only when the category
+  # has attached state that needs resolving; empty categories skip
+  # straight to destroy.
+  def confirm_delete
+    @reassign_candidates = CategoryPolicy.visible_scope(current_user)
+                                         .where.not(id: @category.id)
+                                         .order(:name)
+  end
+
   # DELETE /categories/:id
   #
-  # PR 3 ships a narrow destroy that only deletes *empty* personal categories
-  # — no expenses, no children, no patterns, no feedbacks/metrics/preferences.
-  # The full reassign/orphan flow is the subject of PR 8 (CategoryDeletion
-  # service); refusing a non-empty destroy here avoids silent cascade of
-  # dependent: :destroy associations.
+  # Delegates to Services::CategoryDeletion which handles both the
+  # "empty fast-path" (no dependents → plain destroy) and the full
+  # reassign / orphan flows. The :strategy param chooses between them;
+  # defaults to :orphan for personal categories when the user confirms
+  # without selecting a target.
   def destroy
-    if category_in_use?
-      redirect_to category_path(@category),
-                  alert: "This category is in use. Full deletion flow arrives in PR 8.",
-                  status: :see_other
-    else
-      @category.destroy
+    strategy = extract_destroy_strategy
+    result = Services::CategoryDeletion.new(
+      category:    @category,
+      actor:       current_user,
+      strategy:    strategy,
+      reassign_to: lookup_reassign_target
+    ).call
+
+    if result.success
       redirect_to categories_path, notice: "Category deleted.", status: :see_other
+    else
+      redirect_to category_path(@category),
+                  alert: result.error,
+                  status: :see_other
     end
   end
 
@@ -153,8 +157,20 @@ class CategoriesController < ApplicationController
     end
   end
 
-  def category_in_use?
-    DELETE_BLOCKING_ASSOCIATIONS.any? { |assoc| @category.public_send(assoc).exists? }
+  def extract_destroy_strategy
+    raw = params[:strategy].to_s
+    return raw.to_sym if %w[reassign orphan].include?(raw)
+
+    # Default path: shared categories must reassign (service enforces this
+    # and returns a clear error); personal categories default to orphan.
+    @category.shared? ? :reassign : :orphan
+  end
+
+  def lookup_reassign_target
+    id = params[:reassign_to_id]
+    return nil if id.blank?
+
+    CategoryPolicy.visible_scope(current_user).find_by(id: id)
   end
 
   # Splits the visible category set into shared roots, personal roots, and a

--- a/app/services/category_deletion.rb
+++ b/app/services/category_deletion.rb
@@ -78,9 +78,10 @@ module Services
       return blocked_by_personal_children_reason if blocked_by_personal_children?
 
       if @strategy == :reassign
-        return "A reassign target is required."          if @reassign_to.nil?
-        return "Cannot reassign to the deleted category." if @reassign_to.id == @category.id
-        return "Reassign target is not accessible."       unless reassign_target_visible?
+        return "A reassign target is required."            if @reassign_to.nil?
+        return "Cannot reassign to the deleted category."  if @reassign_to.id == @category.id
+        return "Reassign target is not accessible."        unless reassign_target_visible?
+        return "Reassign target cannot be a descendant."   if reassign_target_is_descendant?
       end
 
       nil
@@ -92,6 +93,23 @@ module Services
 
     def reassign_target_visible?
       CategoryPolicy.new(@actor, @reassign_to).show?
+    end
+
+    # Walk up the parent chain from the reassign target: if we encounter
+    # the category being deleted, the target is a descendant. Reparenting
+    # children to a descendant would create a cycle (or reparent the target
+    # to itself once its parent is destroyed). `update_all` bypasses the
+    # model's `cannot_be_parent_of_itself` validation, so this check is the
+    # last line of defense against corruption of the tree.
+    def reassign_target_is_descendant?
+      current = @reassign_to
+      seen = Set.new
+      while current && !seen.include?(current.id)
+        return true if current.id == @category.id
+        seen << current.id
+        current = current.parent
+      end
+      false
     end
 
     # Deleting a shared category while some user has a personal child under

--- a/app/services/category_deletion.rb
+++ b/app/services/category_deletion.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Services
+  # Removes a category along with its downstream state using one of two
+  # strategies. Lives in a service object because the steps — moving or
+  # nullifying expenses, budgets, children, patterns — must run atomically,
+  # and the controller shouldn't care about the plumbing.
+  #
+  # Usage:
+  #
+  #   result = Services::CategoryDeletion.new(
+  #     category: category,
+  #     actor: current_user,
+  #     strategy: :reassign,  # or :orphan
+  #     reassign_to: target_category
+  #   ).call
+  #
+  #   if result.success
+  #     redirect_to categories_path, notice: "Category deleted."
+  #   else
+  #     flash[:alert] = result.error
+  #   end
+  #
+  # Rules enforced here (intentionally not in the controller):
+  #
+  # - Actor authorization: mirrors CategoryPolicy#destroy?.
+  # - Orphan strategy: forbidden for shared categories. Admins deleting a
+  #   shared category must reassign — anything else would cross-wire
+  #   downstream state for every user who sees that shared category.
+  # - Reassign target: must be visible to the actor; cannot be the
+  #   category being deleted.
+  # - Personal children under a shared parent block the shared parent's
+  #   deletion entirely. The admin must ask those users to reparent or
+  #   delete their children first. This is a safety net, not a user-facing
+  #   flow — the UI would normally prevent reaching this state.
+  #
+  # Transactional: any raise inside ActiveRecord::Base.transaction rolls
+  # everything back, so a unique-index violation on budget reassignment
+  # (e.g. the target already has an active budget for the same period)
+  # leaves the source intact.
+  class CategoryDeletion
+    Result = Struct.new(:success, :error, keyword_init: true)
+
+    VALID_STRATEGIES = %i[reassign orphan].freeze
+
+    def initialize(category:, actor:, strategy:, reassign_to: nil)
+      @category    = category
+      @actor       = actor
+      @strategy    = strategy
+      @reassign_to = reassign_to
+    end
+
+    def call
+      validation_error = validate
+      return failure(validation_error) if validation_error
+
+      ActiveRecord::Base.transaction do
+        case @strategy
+        when :reassign then reassign_dependents!
+        when :orphan   then orphan_dependents!
+        end
+        @category.destroy!
+      end
+
+      success
+    rescue ActiveRecord::RecordInvalid,
+           ActiveRecord::RecordNotDestroyed,
+           ActiveRecord::RecordNotUnique => e
+      failure(e.message)
+    end
+
+    private
+
+    def validate
+      return "You do not have permission to delete this category." unless authorized?
+      return "Strategy must be :reassign or :orphan." unless VALID_STRATEGIES.include?(@strategy)
+      return "Shared categories must use :reassign." if @category.shared? && @strategy == :orphan
+      return blocked_by_personal_children_reason if blocked_by_personal_children?
+
+      if @strategy == :reassign
+        return "A reassign target is required."          if @reassign_to.nil?
+        return "Cannot reassign to the deleted category." if @reassign_to.id == @category.id
+        return "Reassign target is not accessible."       unless reassign_target_visible?
+      end
+
+      nil
+    end
+
+    def authorized?
+      CategoryPolicy.new(@actor, @category).destroy?
+    end
+
+    def reassign_target_visible?
+      CategoryPolicy.new(@actor, @reassign_to).show?
+    end
+
+    # Deleting a shared category while some user has a personal child under
+    # it would orphan those children unexpectedly. Block instead.
+    def blocked_by_personal_children?
+      @category.shared? && @category.children.where.not(user_id: nil).exists?
+    end
+
+    def blocked_by_personal_children_reason
+      "Cannot delete: this shared category has personal children belonging to other users. Reparent them first."
+    end
+
+    def reassign_dependents!
+      @category.expenses.update_all(category_id: @reassign_to.id)
+      @category.children.update_all(parent_id: @reassign_to.id)
+      Budget.where(category_id: @category.id).update_all(category_id: @reassign_to.id)
+      # Patterns belong to the source category's identity. Destroy them
+      # explicitly so we do not move them and confuse the matcher.
+      @category.categorization_patterns.destroy_all
+    end
+
+    def orphan_dependents!
+      # `dependent: :nullify` on expenses + children does the right thing
+      # when we destroy the category below, but we explicitly nullify
+      # here so the intent is visible at the service level and so budgets
+      # (which lack a Rails-level cascade) get nulled too.
+      @category.expenses.update_all(category_id: nil)
+      @category.children.update_all(parent_id: nil)
+      Budget.where(category_id: @category.id).update_all(category_id: nil)
+      @category.categorization_patterns.destroy_all
+    end
+
+    def success
+      Result.new(success: true, error: nil)
+    end
+
+    def failure(message)
+      Result.new(success: false, error: message)
+    end
+  end
+end

--- a/app/views/categories/confirm_delete.html.erb
+++ b/app/views/categories/confirm_delete.html.erb
@@ -1,0 +1,60 @@
+<%# PR 8 — deletion confirmation. Wrapped in the side-panel Turbo
+    Frame so it displays inline on /categories. %>
+<%= turbo_frame_tag "category_panel" do %>
+  <section class="p-6">
+    <header class="flex items-center justify-between mb-4">
+      <h1 class="text-lg font-semibold text-slate-900">Delete <%= @category.display_name %></h1>
+      <%= link_to "Cancel", category_path(@category),
+                  data: { turbo_frame: "category_panel" },
+                  class: "text-sm text-slate-600 hover:text-slate-900" %>
+    </header>
+
+    <p class="text-sm text-slate-700 mb-4">
+      This category has attached state. Choose what to do with it before deleting.
+    </p>
+
+    <%= form_with url: category_path(@category), method: :delete,
+                  data: { turbo_frame: "category_panel" },
+                  class: "space-y-4" do |f| %>
+      <fieldset class="space-y-3">
+        <% unless @category.shared? %>
+          <label class="flex items-start gap-3 p-3 border border-slate-200 rounded-md hover:bg-slate-50 cursor-pointer">
+            <%= f.radio_button :strategy, "orphan",
+                               checked: true,
+                               class: "mt-1 text-teal-700 focus:ring-teal-500" %>
+            <span>
+              <span class="block font-medium text-slate-900 text-sm">Orphan</span>
+              <span class="block text-xs text-slate-600 mt-0.5">
+                Leave expenses uncategorized; drop patterns. Children detach.
+              </span>
+            </span>
+          </label>
+        <% end %>
+
+        <label class="flex items-start gap-3 p-3 border border-slate-200 rounded-md hover:bg-slate-50 cursor-pointer">
+          <%= f.radio_button :strategy, "reassign",
+                             checked: @category.shared?,
+                             class: "mt-1 text-teal-700 focus:ring-teal-500" %>
+          <span class="flex-1">
+            <span class="block font-medium text-slate-900 text-sm">Reassign</span>
+            <span class="block text-xs text-slate-600 mt-0.5 mb-2">
+              Move expenses, budgets, and children to another category. Patterns are dropped.
+            </span>
+            <%= f.select :reassign_to_id,
+                         options_for_select(@reassign_candidates.map { |c| [ c.display_name, c.id ] }),
+                         { include_blank: "— pick a target —" },
+                         class: "block w-full rounded-md border-slate-300 shadow-sm text-sm" %>
+          </span>
+        </label>
+      </fieldset>
+
+      <div class="flex items-center gap-3 pt-2">
+        <%= f.submit "Delete category",
+                     class: "inline-flex items-center px-4 py-2 rounded-md bg-rose-600 text-white hover:bg-rose-700 text-sm" %>
+        <%= link_to "Cancel", category_path(@category),
+                    data: { turbo_frame: "category_panel" },
+                    class: "text-sm text-slate-600 hover:text-slate-900" %>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -19,10 +19,20 @@
                       data: { turbo_frame: "category_panel" },
                       class: "px-3 py-1.5 rounded-md border border-teal-700 text-teal-700 hover:bg-teal-50 text-sm" %>
           <% if CategoryPolicy.new(current_user, @category).destroy? %>
-            <%= button_to "Delete", category_path(@category),
-                          method: :delete,
-                          data: { turbo_confirm: "Delete this category?" },
+            <%# For empty categories the confirm_delete page would be
+                overkill — a single confirm dialog and straight delete is
+                nicer. For anything with dependents, route through the
+                reassign/orphan chooser. %>
+            <% if @category.expenses.exists? || @category.children.exists? || @category.categorization_patterns.exists? %>
+              <%= link_to "Delete", confirm_delete_category_path(@category),
+                          data: { turbo_frame: "category_panel" },
                           class: "px-3 py-1.5 rounded-md border border-rose-600 text-rose-600 hover:bg-rose-50 text-sm" %>
+            <% else %>
+              <%= button_to "Delete", category_path(@category),
+                            method: :delete,
+                            data: { turbo_confirm: "Delete this category?" },
+                            class: "px-3 py-1.5 rounded-md border border-rose-600 text-rose-600 hover:bg-rose-50 text-sm" %>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,12 @@ Rails.application.routes.draw do
   # Categories — full CRUD for personal category management (PR 3/10).
   # The JSON index keeps its shape as a dropdown data source for forms.
   resources :categories do
+    # PR 8: deletion confirmation page — renders the reassign/orphan
+    # chooser for non-empty categories before hitting DELETE.
+    member do
+      get :confirm_delete
+    end
+
     # Nested user-facing pattern management (PR 7/10). Scoped to
     # categories the user can edit; lives under the category side panel.
     # Separate from Admin::PatternsController, which is the global

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -494,13 +494,35 @@ RSpec.describe "Categories API", type: :request do
       expect(response).to redirect_to(categories_path)
     end
 
-    it "refuses to destroy a category that is in use by expenses (deferred to PR 8)" do
+    it "deletes a personal category with expenses via :orphan by default" do
       victim = create(:category, name: "Occupied", user: user)
+      email_account = create(:email_account, user: user)
+      expense = create(:expense, category: victim, email_account: email_account)
+
+      expect { delete category_path(victim) }.to change { Category.count }.by(-1)
+      expect(expense.reload.category_id).to be_nil
+      expect(response).to redirect_to(categories_path)
+    end
+
+    it "deletes a personal category via :reassign when strategy+target are provided" do
+      victim = create(:category, name: "ReassignSource", user: user)
+      target = create(:category, name: "ReassignTarget", user: user)
+      email_account = create(:email_account, user: user)
+      expense = create(:expense, category: victim, email_account: email_account)
+
+      delete category_path(victim), params: { strategy: "reassign", reassign_to_id: target.id }
+      expect(Category.exists?(victim.id)).to be false
+      expect(expense.reload.category_id).to eq(target.id)
+    end
+
+    it "keeps the category and surfaces error when reassign is chosen without a target" do
+      victim = create(:category, name: "NoTarget", user: user)
       email_account = create(:email_account, user: user)
       create(:expense, category: victim, email_account: email_account)
 
-      expect { delete category_path(victim) }.not_to change { Category.count }
-      expect(response).to have_http_status(:unprocessable_entity).or redirect_to(category_path(victim))
+      delete category_path(victim), params: { strategy: "reassign" }
+      expect(Category.exists?(victim.id)).to be true
+      expect(response).to redirect_to(category_path(victim))
     end
 
     it "returns 404 on another user's personal category" do
@@ -510,32 +532,43 @@ RSpec.describe "Categories API", type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
-    it "refuses destroy when the category has children" do
+    it "deletes a personal category with children via :orphan (children detach)" do
       victim = create(:category, name: "WithChild", user: user)
-      create(:category, name: "Child of WithChild", user: user, parent: victim)
-      expect { delete category_path(victim) }.not_to change { Category.count }
-      expect(response).to redirect_to(category_path(victim))
+      child = create(:category, name: "Child of WithChild", user: user, parent: victim)
+      expect { delete category_path(victim) }.to change { Category.count }.by(-1)
+      expect(child.reload.parent_id).to be_nil
     end
 
-    it "refuses destroy when the category has categorization_patterns" do
+    it "deletes a personal category with patterns via :orphan (patterns cascade)" do
       victim = create(:category, name: "WithPattern", user: user)
       create(:categorization_pattern, category: victim, pattern_type: "merchant", pattern_value: "somestore")
-      expect { delete category_path(victim) }.not_to change { Category.count }
-      expect(response).to redirect_to(category_path(victim))
+      expect {
+        delete category_path(victim)
+      }.to change { Category.count }.by(-1).and change { CategorizationPattern.count }.by(-1)
+    end
+  end
+
+  describe "GET /categories/:id/confirm_delete", :integration do
+    let!(:user) { create(:user, email: "confirm_user@example.com") }
+
+    before { sign_in_as(user) }
+
+    it "renders the reassign/orphan chooser for a category with dependents" do
+      victim = create(:category, name: "ConfirmVictim", user: user)
+      email_account = create(:email_account, user: user)
+      create(:expense, category: victim, email_account: email_account)
+
+      get confirm_delete_category_path(victim)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Orphan")
+      expect(response.body).to include("Reassign")
     end
 
-    it "refuses destroy when the category has user_category_preferences" do
-      victim = create(:category, name: "WithPref", user: user)
-      email_account = create(:email_account, user: user)
-      create(:user_category_preference,
-             email_account: email_account,
-             category: victim,
-             context_type: "merchant",
-             context_value: "foo",
-             preference_weight: 1,
-             usage_count: 1)
-      expect { delete category_path(victim) }.not_to change { Category.count }
-      expect(response).to redirect_to(category_path(victim))
+    it "returns 404 for another user's personal category" do
+      other = create(:user, email: "confirm_other@example.com")
+      theirs = create(:category, name: "NotYoursConfirm", user: other)
+      get confirm_delete_category_path(theirs)
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -559,9 +592,18 @@ RSpec.describe "Categories API", type: :request do
       expect(others_personal.color).to eq("#123456")
     end
 
-    it "admin can destroy an empty shared category" do
+    it "admin deleting a shared category must provide a reassign target (design-doc rule)" do
       victim = create(:category, name: "AdminDeleteShared", user: nil)
-      expect { delete category_path(victim) }.to change { Category.count }.by(-1)
+      fallback = create(:category, name: "AdminDeleteFallback", user: nil)
+      expect {
+        delete category_path(victim), params: { strategy: "reassign", reassign_to_id: fallback.id }
+      }.to change { Category.count }.by(-1)
+    end
+
+    it "admin deleting a shared category without a target surfaces the error" do
+      victim = create(:category, name: "AdminDeleteSharedNoTarget", user: nil)
+      expect { delete category_path(victim) }.not_to change { Category.count }
+      expect(response).to redirect_to(category_path(victim))
     end
   end
 end

--- a/spec/services/category_deletion_spec.rb
+++ b/spec/services/category_deletion_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
+  let!(:user)  { create(:user, email: "cd_user@example.com") }
+  let!(:other) { create(:user, email: "cd_other@example.com") }
+  let!(:email_account) { create(:email_account, user: user) }
+
+  describe ".call with :orphan" do
+    it "destroys an empty personal category" do
+      c = create(:category, name: "EmptyPersonal", user: user)
+      result = described_class.new(category: c, actor: user, strategy: :orphan).call
+      expect(result.success).to be true
+      expect(Category.exists?(c.id)).to be false
+    end
+
+    it "nullifies expenses' category_id" do
+      c = create(:category, name: "HasExpenses", user: user)
+      expense = create(:expense, category: c, email_account: email_account)
+      result = described_class.new(category: c, actor: user, strategy: :orphan).call
+      expect(result.success).to be true
+      expect(expense.reload.category_id).to be_nil
+    end
+
+    it "cascades patterns + feedbacks via dependent: :destroy" do
+      c = create(:category, name: "HasPatterns", user: user)
+      create(:categorization_pattern, category: c, pattern_type: "merchant", pattern_value: "xx")
+      expect {
+        described_class.new(category: c, actor: user, strategy: :orphan).call
+      }.to change { CategorizationPattern.count }.by(-1)
+    end
+
+    it "nullifies children categories (detached, not deleted)" do
+      parent   = create(:category, name: "OrphanParent", user: user)
+      child    = create(:category, name: "OrphanChild", user: user, parent: parent)
+      described_class.new(category: parent, actor: user, strategy: :orphan).call
+      child.reload
+      expect(child.parent_id).to be_nil
+      expect(Category.exists?(child.id)).to be true
+    end
+
+    it "nullifies attached budgets when orphaning" do
+      c = create(:category, name: "Budgeted", user: user)
+      budget = create(:budget,
+                      email_account: email_account,
+                      user: user,
+                      category: c,
+                      name: "Food",
+                      amount: 100,
+                      period: :monthly,
+                      start_date: Date.current,
+                      currency: "CRC")
+      described_class.new(category: c, actor: user, strategy: :orphan).call
+      expect(budget.reload.category_id).to be_nil
+    end
+
+    it "refuses :orphan for shared categories (admin must reassign)" do
+      shared = create(:category, name: "SharedCantOrphan", user: nil)
+      admin = create(:user, :admin, email: "cd_admin_orphan@example.com")
+      result = described_class.new(category: shared, actor: admin, strategy: :orphan).call
+      expect(result.success).to be false
+      expect(result.error).to match(/reassign/i)
+    end
+  end
+
+  describe ".call with :reassign" do
+    let!(:source) { create(:category, name: "SourceReassign", user: user) }
+    let!(:target) { create(:category, name: "TargetReassign", user: user) }
+
+    it "moves expenses to the target category" do
+      expense = create(:expense, category: source, email_account: email_account)
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
+      expect(result.success).to be true
+      expect(expense.reload.category_id).to eq(target.id)
+    end
+
+    it "moves children to the target category" do
+      child = create(:category, name: "ChildToMove", user: user, parent: source)
+      described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
+      expect(child.reload.parent_id).to eq(target.id)
+    end
+
+    it "moves attached budgets to the target category" do
+      budget = create(:budget,
+                      email_account: email_account,
+                      user: user,
+                      category: source,
+                      name: "Reassigned Budget",
+                      amount: 200,
+                      period: :monthly,
+                      start_date: Date.current,
+                      currency: "CRC")
+      described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
+      expect(budget.reload.category_id).to eq(target.id)
+    end
+
+    it "destroys patterns on the source (they belong to source's identity)" do
+      create(:categorization_pattern, category: source, pattern_type: "merchant", pattern_value: "srcpat")
+      expect {
+        described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
+      }.to change { CategorizationPattern.count }.by(-1)
+    end
+
+    it "refuses when reassign_to is missing" do
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: nil).call
+      expect(result.success).to be false
+      expect(result.error).to match(/target/i)
+    end
+
+    it "refuses when reassign_to == category (self-reassignment)" do
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: source).call
+      expect(result.success).to be false
+    end
+
+    it "refuses when reassign_to is not visible to the actor" do
+      others_cat = create(:category, name: "OthersCatForReassign", user: other)
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: others_cat).call
+      expect(result.success).to be false
+      expect(Category.exists?(source.id)).to be true
+    end
+
+    it "rolls back when reassigning would violate a unique budget constraint" do
+      # Existing active monthly budget on target for the same email_account
+      create(:budget,
+             email_account: email_account,
+             user: user,
+             category: target,
+             name: "Existing Target Budget",
+             amount: 500,
+             period: :monthly,
+             start_date: Date.current,
+             currency: "CRC")
+      # Now create an active monthly budget on source — reassign would collide.
+      create(:budget,
+             email_account: email_account,
+             user: user,
+             category: source,
+             name: "Source Budget",
+             amount: 100,
+             period: :monthly,
+             start_date: Date.current,
+             currency: "CRC")
+
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
+      expect(result.success).to be false
+      expect(Category.exists?(source.id)).to be true # rolled back
+    end
+  end
+
+  describe "authorization" do
+    it "refuses when actor cannot destroy the category" do
+      others_cat = create(:category, name: "NotYours", user: other)
+      result = described_class.new(category: others_cat, actor: user, strategy: :orphan).call
+      expect(result.success).to be false
+      expect(result.error).to match(/permission|cannot/i)
+      expect(Category.exists?(others_cat.id)).to be true
+    end
+
+    it "allows admins to delete any category" do
+      admin = create(:user, :admin, email: "cd_admin@example.com")
+      target = create(:category, name: "AdminTarget", user: nil)
+      # shared requires reassign; build a reassign destination
+      reassign_to = create(:category, name: "AdminFallback", user: nil)
+      result = described_class.new(category: target,
+                                   actor: admin,
+                                   strategy: :reassign,
+                                   reassign_to: reassign_to).call
+      expect(result.success).to be true
+      expect(Category.exists?(target.id)).to be false
+    end
+  end
+
+  describe "shared category with personal children" do
+    it "blocks deletion while personal children exist under the shared parent" do
+      shared_parent = create(:category, name: "SharedParent", user: nil)
+      create(:category, name: "PersonalChildUnderShared", user: user, parent: shared_parent)
+      reassign_to = create(:category, name: "SharedFallback", user: nil)
+
+      admin = create(:user, :admin, email: "cd_admin2@example.com")
+      result = described_class.new(category: shared_parent,
+                                   actor: admin,
+                                   strategy: :reassign,
+                                   reassign_to: reassign_to).call
+      expect(result.success).to be false
+      expect(result.error).to match(/personal children/i)
+    end
+  end
+end

--- a/spec/services/category_deletion_spec.rb
+++ b/spec/services/category_deletion_spec.rb
@@ -120,7 +120,16 @@ RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
       expect(Category.exists?(source.id)).to be true
     end
 
-    it "rolls back when reassigning would violate a unique budget constraint" do
+    it "refuses when reassign_to is a direct child of the category being deleted (would create a cycle)" do
+      child = create(:category, name: "CycleChild", user: user, parent: source)
+      result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: child).call
+      expect(result.success).to be false
+      expect(result.error).to match(/descendant/i)
+      expect(Category.exists?(source.id)).to be true
+      expect(child.reload.parent_id).to eq(source.id) # unchanged
+    end
+
+    it "rolls back fully when reassigning would violate a unique budget constraint" do
       # Existing active monthly budget on target for the same email_account
       create(:budget,
              email_account: email_account,
@@ -131,20 +140,31 @@ RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
              period: :monthly,
              start_date: Date.current,
              currency: "CRC")
-      # Now create an active monthly budget on source — reassign would collide.
-      create(:budget,
-             email_account: email_account,
-             user: user,
-             category: source,
-             name: "Source Budget",
-             amount: 100,
-             period: :monthly,
-             start_date: Date.current,
-             currency: "CRC")
+      source_budget = create(:budget,
+                             email_account: email_account,
+                             user: user,
+                             category: source,
+                             name: "Source Budget",
+                             amount: 100,
+                             period: :monthly,
+                             start_date: Date.current,
+                             currency: "CRC")
+      source_expense = create(:expense, category: source, email_account: email_account)
+      source_child   = create(:category, name: "SourceChild", user: user, parent: source)
+      source_pattern = create(:categorization_pattern,
+                              category: source,
+                              pattern_type: "merchant",
+                              pattern_value: "rb_src")
 
       result = described_class.new(category: source, actor: user, strategy: :reassign, reassign_to: target).call
       expect(result.success).to be false
-      expect(Category.exists?(source.id)).to be true # rolled back
+
+      # Full rollback — nothing moved, nothing deleted
+      expect(Category.exists?(source.id)).to be true
+      expect(source_expense.reload.category_id).to eq(source.id)
+      expect(source_child.reload.parent_id).to eq(source.id)
+      expect(source_budget.reload.category_id).to eq(source.id)
+      expect(CategorizationPattern.exists?(source_pattern.id)).to be true
     end
   end
 
@@ -172,9 +192,9 @@ RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
   end
 
   describe "shared category with personal children" do
-    it "blocks deletion while personal children exist under the shared parent" do
+    it "blocks deletion while personal children exist under the shared parent and preserves both" do
       shared_parent = create(:category, name: "SharedParent", user: nil)
-      create(:category, name: "PersonalChildUnderShared", user: user, parent: shared_parent)
+      child = create(:category, name: "PersonalChildUnderShared", user: user, parent: shared_parent)
       reassign_to = create(:category, name: "SharedFallback", user: nil)
 
       admin = create(:user, :admin, email: "cd_admin2@example.com")
@@ -184,6 +204,11 @@ RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
                                    reassign_to: reassign_to).call
       expect(result.success).to be false
       expect(result.error).to match(/personal children/i)
+
+      # Nothing moved, nothing deleted.
+      expect(Category.exists?(shared_parent.id)).to be true
+      expect(child.reload.parent_id).to eq(shared_parent.id)
+      expect(child.user_id).to eq(user.id)
     end
   end
 end


### PR DESCRIPTION
## Summary

PR 8 of 10. Replaces PR 3's narrow \"refuse if in use\" behavior with the full reassign/orphan deletion flow from the design doc.

### Services::CategoryDeletion

- **`:orphan`** — expenses \`category_id\` → NULL, children \`parent_id\` → NULL, budgets \`category_id\` → NULL, categorization_patterns destroyed.
- **`:reassign`** — expenses, children, budgets move to \`reassign_to\`; categorization_patterns destroyed (they belong to source's identity).
- Shared categories must use \`:reassign\` (orphaning would crosswire state for every user who sees them).
- Blocks deletion when a shared category has personal children belonging to other users (safety net; UI would normally prevent this).
- Runs in a transaction; any raise rolls back. Budget unique-constraint collisions on reassign leave the source intact.
- Authorization via \`CategoryPolicy#destroy?\`; reassign target must be visible to the actor and cannot be the category being deleted.

### Controller + routes

- \`GET /categories/:id/confirm_delete\` — renders the reassign/orphan chooser for non-empty categories.
- \`DELETE /categories/:id\` — delegates to \`Services::CategoryDeletion\`. Extracts \`:strategy\` + \`:reassign_to_id\` from params; defaults to \`:orphan\` for personal and \`:reassign\` for shared.

### View

\`app/views/categories/confirm_delete.html.erb\` — wrapped in the \`category_panel\` Turbo Frame from PR 6 so the chooser renders inline on \`/categories\`.

\`show.html.erb\` Delete affordance now routes through \`confirm_delete\` for non-empty categories; empty categories get one-click confirm + destroy.

## Test plan

- [x] 17 service specs cover orphan paths, shared rejection of orphan, reassign state moves, reassign target validation (missing / self / cross-user / budget collision), authorization matrix, shared + personal-child blocker
- [x] Request specs updated: personal destroy defaults to orphan and now succeeds with dependents; new specs for reassign flow, missing-target error, confirm_delete render, admin shared deletion
- [x] 162 specs across service + model + policy + request pass
- [x] Rubocop clean