### PR TITLE
feat(categories): PR 10/10 — feature flag + rollout gate

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,10 @@
 class CategoriesController < ApplicationController
+  # Read actions (index/show) stay open so existing consumers (dropdowns,
+  # budgets) keep working during the Personal Category Management
+  # rollout. Write actions require the PR 10 feature flag.
+  before_action :require_category_management_feature,
+                only: %i[new create edit update destroy confirm_delete]
+
   before_action :set_category, only: %i[show edit update destroy confirm_delete]
   before_action :authorize_show!, only: %i[show]
   before_action :authorize_edit!, only: %i[edit update destroy confirm_delete]
@@ -203,5 +209,15 @@ class CategoriesController < ApplicationController
       format.html { render file: Rails.root.join("public/404.html"), layout: false, status: :not_found }
       format.json { render json: { error: "Not Found" }, status: :not_found }
     end
+  end
+
+  # Feature-flag gate — admins always pass; everyone else needs the
+  # PERSONAL_CATEGORIES_OPEN_TO_ALL env flag.
+  def require_category_management_feature
+    return if current_user&.can_manage_categories?
+
+    redirect_to categories_path,
+                alert: "Personal category management isn't available on your account yet.",
+                status: :see_other
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,22 @@ class User < ApplicationRecord
     admin?
   end
 
+  # Personal Category Management feature flag (PR 10/10).
+  #
+  # Gates whether a user can see and use the /categories surface:
+  # the tree index, create/edit/delete personal categories, inline
+  # pattern management. Admins are always in; everyone else is opt-in
+  # per env flag so we can ship to ourselves first, exercise the flow,
+  # then open up.
+  #
+  # To roll out to all users, set PERSONAL_CATEGORIES_OPEN_TO_ALL=true
+  # in credentials/env. To roll back, unset it — admins keep access.
+  def can_manage_categories?
+    return true if admin?
+
+    ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"].to_s == "true"
+  end
+
   private
 
   def downcase_email

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -25,12 +25,17 @@ class CategoryPolicy
     return false if user.nil?
     return true if admin?
 
+    # Read access intentionally ignores the feature flag: if a user
+    # created personal categories while the flag was on and an admin
+    # later flips it off, their existing data stays visible (they just
+    # can't edit it). No silent data loss on rollback.
     category.shared? || owned_by_user?
   end
 
   def create?
     return false if user.nil?
     return true if admin?
+    return false unless user.can_manage_categories?
 
     # Non-admins cannot create shared categories (user_id nil) and cannot
     # create categories on behalf of another user.
@@ -40,6 +45,7 @@ class CategoryPolicy
   def edit?
     return false if user.nil?
     return true if admin?
+    return false unless user.can_manage_categories?
 
     owned_by_user?
   end
@@ -52,6 +58,15 @@ class CategoryPolicy
 
   def manage_patterns?
     edit?
+  end
+
+  # Gate for the /categories index surface — used by navigation
+  # helpers to hide the link for users without the feature flag.
+  # Admins always in.
+  def self.can_access?(user)
+    return false if user.nil?
+
+    user.can_manage_categories?
   end
 
   # Returns an ActiveRecord::Relation of categories the user may see.

--- a/app/views/categories/_tree_node.html.erb
+++ b/app/views/categories/_tree_node.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </div>
     <div class="shrink-0 flex items-center gap-3">
-      <% if category.shared? && category.root? %>
+      <% if category.shared? && category.root? && CategoryPolicy.can_access?(current_user) %>
         <%= link_to "+ Add subcategory",
                     new_category_path(parent_id: category.id),
                     data: { turbo_frame: "category_panel" },

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,8 +10,10 @@
         Shared categories on the left; your personal categories on the right.
       </p>
     </div>
-    <%= link_to "New category", new_category_path,
-                class: "inline-flex items-center px-4 py-2 rounded-md bg-teal-700 text-white hover:bg-teal-800 text-sm" %>
+    <% if CategoryPolicy.can_access?(current_user) %>
+      <%= link_to "New category", new_category_path,
+                  class: "inline-flex items-center px-4 py-2 rounded-md bg-teal-700 text-white hover:bg-teal-800 text-sm" %>
+    <% end %>
   </header>
 
   <div class="grid grid-cols-1 lg:grid-cols-[1fr_1fr_minmax(320px,400px)] gap-6 items-start">

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -64,6 +64,11 @@ env:
     SOLID_QUEUE_IN_PUMA: true
     # Host for DNS rebinding protection
     RAILS_HOST: expense-tracker.estebansoto.dev
+    # Personal Category Management rollout kill-switch (PR 10/10).
+    # "true" → open to all users. Unset / any other value → admins only.
+    # Toggle by editing here and re-deploying; effect is immediate on
+    # restart. No migration needed to roll back.
+    PERSONAL_CATEGORIES_OPEN_TO_ALL: "false"
 
 # Useful aliases
 aliases:

--- a/spec/models/user_category_management_flag_spec.rb
+++ b/spec/models/user_category_management_flag_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# PR 10/10 — User#can_manage_categories? feature flag.
+RSpec.describe User, type: :model, integration: true do
+  describe "#can_manage_categories?" do
+    let(:admin) { create(:user, :admin, email: "flag_admin@example.com") }
+    let(:user)  { create(:user, email: "flag_user@example.com") }
+
+    before do
+      ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
+    end
+
+    it "is always true for admins regardless of the env flag" do
+      expect(admin.can_manage_categories?).to be true
+    end
+
+    it "is false for regular users when the env flag is unset" do
+      expect(user.can_manage_categories?).to be false
+    end
+
+    it "is false for regular users when the env flag is the string 'false'" do
+      ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "false"
+      expect(user.can_manage_categories?).to be false
+    ensure
+      ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
+    end
+
+    it "is true for regular users when the env flag is the string 'true'" do
+      ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true"
+      expect(user.can_manage_categories?).to be true
+    ensure
+      ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
+    end
+  end
+end

--- a/spec/policies/category_policy_spec.rb
+++ b/spec/policies/category_policy_spec.rb
@@ -3,6 +3,14 @@
 require "rails_helper"
 
 RSpec.describe CategoryPolicy, type: :policy, integration: true do
+  # PR 10: most policy examples predate the feature flag and exercise
+  # the authz matrix assuming the flag is on. The flag-off gating is
+  # covered in its own describe block below. Keep the global default
+  # "flag on" so those earlier cases keep testing the matrix, not the
+  # rollout.
+  before { ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true" }
+  after  { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
   let(:user)       { create(:user) }
   let(:other)      { create(:user, email: "other@example.com") }
   let(:admin)      { create(:user, :admin, email: "admin@example.com") }
@@ -129,6 +137,86 @@ RSpec.describe CategoryPolicy, type: :policy, integration: true do
 
     it "returns an empty relation when user is nil (fail closed)" do
       expect(described_class.visible_scope(nil)).to be_empty
+    end
+  end
+
+  describe "feature-flag gating (PR 10)" do
+    let(:user)  { create(:user, email: "flag_reg@example.com") }
+    let(:admin) { create(:user, :admin, email: "flag_admin@example.com") }
+    let(:own)   { create(:category, name: "FlagOwn", user: user) }
+    let(:shared_c) { create(:category, name: "FlagShared", user: nil) }
+
+    context "when the flag is off and user is not admin" do
+      before { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
+      it "blocks create on own personal" do
+        new_personal = Category.new(user: user, name: "X")
+        expect(described_class.new(user, new_personal).create?).to be false
+      end
+
+      it "blocks edit on own personal" do
+        expect(described_class.new(user, own).edit?).to be false
+      end
+
+      it "blocks destroy on own personal" do
+        expect(described_class.new(user, own).destroy?).to be false
+      end
+
+      it "keeps show open for existing owned categories (no silent data loss on rollback)" do
+        expect(described_class.new(user, own).show?).to be true
+      end
+
+      it "keeps show open for shared categories" do
+        expect(described_class.new(user, shared_c).show?).to be true
+      end
+    end
+
+    context "when the flag is on" do
+      around do |example|
+        ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true"
+        example.run
+        ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
+      end
+
+      it "allows create on own personal" do
+        new_personal = Category.new(user: user, name: "X")
+        expect(described_class.new(user, new_personal).create?).to be true
+      end
+
+      it "allows edit + destroy on own personal" do
+        expect(described_class.new(user, own).edit?).to be true
+        expect(described_class.new(user, own).destroy?).to be true
+      end
+    end
+
+    it "admins bypass the flag" do
+      expect(described_class.new(admin, shared_c).edit?).to be true
+    end
+  end
+
+  describe ".can_access?" do
+    let(:user)  { create(:user, email: "access_user@example.com") }
+    let(:admin) { create(:user, :admin, email: "access_admin@example.com") }
+
+    before { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
+    it "returns false for nil" do
+      expect(described_class.can_access?(nil)).to be false
+    end
+
+    it "returns true for admin regardless of flag" do
+      expect(described_class.can_access?(admin)).to be true
+    end
+
+    it "returns false for regular user without flag" do
+      expect(described_class.can_access?(user)).to be false
+    end
+
+    it "returns true for regular user when flag is on" do
+      ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true"
+      expect(described_class.can_access?(user)).to be true
+    ensure
+      ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
     end
   end
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe "Categories API", type: :request do
   let!(:category_food) { create(:category, name: "Food", color: "#FF6B6B") }
   let!(:category_transport) { create(:category, name: "Transport", color: "#4ECDC4") }
 
+  # PR 10: most examples exercise the write surface and predate the
+  # feature flag — treat the flag as on by default, and let the one
+  # describe that tests the gate unset it explicitly.
+  before do
+    ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true"
+  end
+
+  after do
+    ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL")
+  end
+
   describe "GET /categories.json", :unit do
     context "when authenticated" do
       before { sign_in_admin(admin_user) }
@@ -569,6 +580,62 @@ RSpec.describe "Categories API", type: :request do
       theirs = create(:category, name: "NotYoursConfirm", user: other)
       get confirm_delete_category_path(theirs)
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "feature flag (PR 10)", :integration do
+    let!(:regular) { create(:user, email: "flag_regular@example.com") }
+
+    before { sign_in_as(regular) }
+
+    context "when the flag is off" do
+      # The outer before block sets the flag on by default. Flip it off
+      # for this context via an after-all setup. The nested-hook ordering
+      # guarantees this before runs AFTER the outer "set flag on" before.
+      before { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
+      it "GET /categories/new redirects" do
+        get new_category_path
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(categories_path)
+        follow_redirect!
+        expect(response.body).to include("Personal category management isn&#39;t available")
+      end
+
+      it "POST /categories is blocked" do
+        expect {
+          post categories_path, params: { category: { name: "ShouldNotCreate" } }
+        }.not_to change { Category.count }
+        expect(response).to redirect_to(categories_path)
+      end
+
+      it "GET /categories still loads (read access is always open)" do
+        get categories_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not render the 'New category' button" do
+        get categories_path
+        expect(response.body).not_to include("New category")
+      end
+    end
+
+    context "when flag is on (outer before sets it true)" do
+      it "GET /categories/new renders normally" do
+        get new_category_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "POST /categories creates as expected" do
+        expect {
+          post categories_path, params: { category: { name: "FlagEnabledCreate" } }
+        }.to change { Category.count }.by(1)
+      end
+
+      it "renders the 'New category' button" do
+        get categories_path
+        expect(response.body).to include("New category")
+      end
     end
   end
 

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -618,6 +618,19 @@ RSpec.describe "Categories API", type: :request do
         get categories_path
         expect(response.body).not_to include("New category")
       end
+
+      it "GET /categories/:id/confirm_delete redirects (write surface gated)" do
+        own = create(:category, name: "FlagOffConfirm", user: regular)
+        get confirm_delete_category_path(own)
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(categories_path)
+      end
+
+      it "DELETE /categories/:id is blocked (write gate)" do
+        own = create(:category, name: "FlagOffDestroy", user: regular)
+        expect { delete category_path(own) }.not_to change { Category.count }
+        expect(response).to redirect_to(categories_path)
+      end
     end
 
     context "when flag is on (outer before sets it true)" do

--- a/spec/requests/category_patterns_spec.rb
+++ b/spec/requests/category_patterns_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Category Patterns", type: :request, integration: true do
+  # PR 10: these examples predate the feature flag — treat the flag as
+  # on so they continue to exercise the real authz matrix.
+  before { ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true" }
+  after  { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
   let!(:user)  { create(:user, email: "cp_user@example.com") }
   let!(:other) { create(:user, email: "cp_other@example.com") }
 

--- a/spec/requests/category_patterns_spec.rb
+++ b/spec/requests/category_patterns_spec.rb
@@ -205,6 +205,38 @@ RSpec.describe "Category Patterns", type: :request, integration: true do
     end
   end
 
+  describe "feature flag gate (PR 10)" do
+    # Explicit flag-off coverage for the nested pattern resource —
+    # manage_patterns? aliases edit?, which requires the flag for
+    # non-admin users.
+    context "when the flag is off" do
+      before { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
+      before { sign_in_as(user) }
+
+      it "POST /categories/:id/patterns is blocked — category_panel shows authorization failure" do
+        expect {
+          post category_patterns_path(own), params: {
+            categorization_pattern: { pattern_type: "merchant", pattern_value: "blocked" }
+          }
+        }.not_to change { CategorizationPattern.count }
+        # CategoryPolicy#manage_patterns? returns false so the controller
+        # treats the request as out-of-scope (404) to preserve existence
+        # hiding.
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "DELETE /categories/:id/patterns/:id is blocked" do
+        pattern = create(:categorization_pattern,
+                         category: own,
+                         pattern_type: "merchant",
+                         pattern_value: "blocked_destroy")
+        expect { delete category_pattern_path(own, pattern) }.not_to change { CategorizationPattern.count }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "show view patterns section" do
     before { sign_in_as(user) }
 

--- a/spec/services/category_deletion_spec.rb
+++ b/spec/services/category_deletion_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Services::CategoryDeletion, type: :service, integration: true do
+  # PR 10: the service delegates authorization to CategoryPolicy#destroy?,
+  # which now requires the feature flag for non-admin users. Enable the
+  # flag globally for this spec so the matrix tests keep exercising the
+  # real service logic.
+  before { ENV["PERSONAL_CATEGORIES_OPEN_TO_ALL"] = "true" }
+  after  { ENV.delete("PERSONAL_CATEGORIES_OPEN_TO_ALL") }
+
   let!(:user)  { create(:user, email: "cd_user@example.com") }
   let!(:other) { create(:user, email: "cd_other@example.com") }
   let!(:email_account) { create(:email_account, user: user) }


### PR DESCRIPTION
## Summary

**Final PR in the Personal Category Management series.** Ships the roll-out gate from the design doc — admins always in, everyone else opt-in via env flag.

## Flag

\`User#can_manage_categories?\`:

- \`true\` for admins (always)
- \`true\` for regular users only when \`ENV[\"PERSONAL_CATEGORIES_OPEN_TO_ALL\"] == \"true\"\`

Flip the env var to roll out; unset to roll back.

## Policy gate (\`CategoryPolicy\`)

- \`create?\` / \`edit?\` / \`update?\` / \`destroy?\` / \`manage_patterns?\` require the flag (non-admin only)
- \`show?\` intentionally **ignores** the flag — if a user created personal categories during an open window and an admin later rolls back, their data still renders read-only. No silent loss.
- New class method \`CategoryPolicy.can_access?(user)\` for UI visibility.

## Controller + UI

- \`require_category_management_feature\` before_action gates write actions; index + show stay open so existing dropdowns/budgets keep working.
- Non-flagged users hitting a write action → redirect with friendly alert.
- \"New category\" button and \"+ Add subcategory\" affordance hidden when the flag is off.

## Test plan

- [x] 4 model specs: admin bypass, env unset, \"false\", \"true\"
- [x] Policy gating: create/edit/destroy blocked when flag off; show still open; admin bypass; `.can_access?`
- [x] Request specs: \`/categories/new\` redirects when off; \`POST /categories\` blocked; \`/categories\` still loads read-only; \"New category\" button hidden
- [x] Existing specs updated to default flag-on so the authz matrix keeps being tested
- [x] 8,964 full unit suite pass
- [x] Rubocop clean

---

## Series recap — all 10 PRs

| # | Title | PR |
|---|---|---|
| 1 | user_id scoping + tree rules | #485 |
| 2 | CategoryPolicy | #486 |
| 3 | CRUD controller + routes | #487 |
| 4 | Two-column tree index view | #488 |
| 5 | Create flow polish (color picker + Add subcategory) | #489 |
| 6 | Turbo Frame side panel | #490 |
| 7 | Inline pattern management | #491 |
| 8 | Reassign/orphan deletion + service | #492 |
| 9 | \`usable_by\` + bypass fixes | #493 |
| 10 | Feature flag + rollout | this PR |