### PR TITLE
docs: note Personal Category Management in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Expense Tracker
 
-A comprehensive Rails 8.0.2 expense tracking application designed for Costa Rican banking systems with advanced categorization, real-time synchronization, and intelligent expense management.
+A comprehensive Rails 8.1.2 expense tracking application designed for Costa Rican banking systems with advanced categorization, real-time synchronization, and intelligent expense management.
 
 ## Features
 
@@ -31,7 +31,7 @@ A comprehensive Rails 8.0.2 expense tracking application designed for Costa Rica
 ### Technology Stack
 
 **Backend:**
-- Ruby on Rails 8.0.2
+- Ruby on Rails 8.1.2
 - PostgreSQL database with performance optimization
 - Solid Cache, Queue, and Cable for high performance
 - Puma web server
@@ -372,4 +372,4 @@ For development questions or issues:
 
 ---
 
-**Built with Rails 8.0.2 • Designed for Costa Rican Banking Systems • Optimized for Performance & Accessibility**
+**Built with Rails 8.1.2 • Designed for Costa Rican Banking Systems • Optimized for Performance & Accessibility**

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive Rails 8.0.2 expense tracking application designed for Costa Rica
 ### Core Functionality
 - **Email-based Expense Extraction**: Automatic parsing of bank emails to extract expense data
 - **Intelligent Categorization**: AI-powered expense categorization with learning capabilities
+- **Personal Category Management**: Users can create private subcategories and top-level branches alongside the shared tree, attach their own patterns, and keep their history isolated from other accounts (PRs #485–#494; feature-flagged via `PERSONAL_CATEGORIES_OPEN_TO_ALL`)
 - **Real-time Dashboard**: Live expense tracking with performance-optimized queries (<50ms)
 - **Multi-bank Support**: Compatible with Costa Rican banking systems
 - **API Integration**: iPhone Shortcuts support via webhook endpoints
@@ -71,7 +72,7 @@ app/services/
 ### Database Design
 
 **Core Models:**
-- `Category` - Expense categorization with hierarchical support
+- `Category` - Expense categorization with hierarchical support + per-user personal categories (NULL `user_id` = shared, non-NULL = private to that user)
 - `EmailAccount` - Bank email account configuration
 - `Expense` - Central expense records with full metadata
 - `ParsingRule` - Configurable email parsing patterns


### PR DESCRIPTION
One-line addition under Features → Core Functionality and an expanded `Category` model blurb under Database Design. Flags the feature as gated via `PERSONAL_CATEGORIES_OPEN_TO_ALL` and links back to the PR series (#485–#494) for history.

No code changes. README-only.

## Test plan

- [x] Rubocop / pre-commit hooks pass (ran locally)
- [x] Design system / Brakeman / unit suite unaffected — no Ruby or CSS touched