### PR TITLE
fix(categories): sync tree header on side-panel rename

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -70,9 +70,26 @@ class CategoriesController < ApplicationController
   end
 
   # PATCH/PUT /categories/:id
+  #
+  # On success, Turbo Frame submits from the side panel receive a stream
+  # response that re-renders both the panel (show view) and the matching
+  # tree-node header on the index — keeping the left-hand tree in sync
+  # with the rename/recolor without a full reload. Parent moves fall
+  # back to a redirect because the tree structure shifts.
   def update
+    previous_parent_id = @category.parent_id
+
     if @category.update(category_params)
-      redirect_to category_path(@category), notice: "Category updated."
+      respond_to do |format|
+        format.html { redirect_to category_path(@category), notice: "Category updated." }
+        format.turbo_stream do
+          if @category.parent_id == previous_parent_id
+            render :update
+          else
+            redirect_to category_path(@category), notice: "Category updated."
+          end
+        end
+      end
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/categories/_tree_header.html.erb
+++ b/app/views/categories/_tree_header.html.erb
@@ -1,0 +1,33 @@
+<%# Inner content of a tree-node header. Kept in its own partial so the
+    update.turbo_stream response can re-render exactly this block after an
+    inline rename / recolor. Locals: category. %>
+<div id="<%= dom_id(category, :tree_header) %>" class="flex items-center justify-between gap-3">
+  <div class="flex items-center gap-3 min-w-0">
+    <span class="shrink-0 inline-block w-3 h-3 rounded-full"
+          style="background-color: <%= category.color.presence || "#94a3b8" %>;"
+          aria-hidden="true"></span>
+    <%= link_to category.display_name,
+                category_path(category),
+                data: { turbo_frame: "category_panel" },
+                class: "text-slate-900 hover:text-teal-700 truncate" %>
+    <% if category.personal? %>
+      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
+        personal
+      </span>
+    <% end %>
+  </div>
+  <div class="shrink-0 flex items-center gap-3">
+    <% if category.shared? && category.root? && CategoryPolicy.can_access?(current_user) %>
+      <%= link_to "+ Add subcategory",
+                  new_category_path(parent_id: category.id),
+                  data: { turbo_frame: "category_panel" },
+                  class: "text-sm text-teal-700 hover:text-teal-900",
+                  title: "Create a personal subcategory under #{category.display_name}" %>
+    <% end %>
+    <% if CategoryPolicy.new(current_user, category).edit? %>
+      <%= link_to "Edit", edit_category_path(category),
+                  data: { turbo_frame: "category_panel" },
+                  class: "text-sm text-teal-700 hover:text-teal-900" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/categories/_tree_node.html.erb
+++ b/app/views/categories/_tree_node.html.erb
@@ -4,36 +4,7 @@
     - depth: nesting level (0 for a root) %>
 <% children = children_by_parent[category.id] || [] %>
 <li class="<%= depth.zero? ? 'px-4 py-3' : 'pl-8 py-2 border-l border-slate-200 ml-4' %>">
-  <div class="flex items-center justify-between gap-3">
-    <div class="flex items-center gap-3 min-w-0">
-      <span class="shrink-0 inline-block w-3 h-3 rounded-full"
-            style="background-color: <%= category.color.presence || "#94a3b8" %>;"
-            aria-hidden="true"></span>
-      <%= link_to category.display_name,
-                  category_path(category),
-                  data: { turbo_frame: "category_panel" },
-                  class: "text-slate-900 hover:text-teal-700 truncate" %>
-      <% if category.personal? %>
-        <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
-          personal
-        </span>
-      <% end %>
-    </div>
-    <div class="shrink-0 flex items-center gap-3">
-      <% if category.shared? && category.root? && CategoryPolicy.can_access?(current_user) %>
-        <%= link_to "+ Add subcategory",
-                    new_category_path(parent_id: category.id),
-                    data: { turbo_frame: "category_panel" },
-                    class: "text-sm text-teal-700 hover:text-teal-900",
-                    title: "Create a personal subcategory under #{category.display_name}" %>
-      <% end %>
-      <% if CategoryPolicy.new(current_user, category).edit? %>
-        <%= link_to "Edit", edit_category_path(category),
-                    data: { turbo_frame: "category_panel" },
-                    class: "text-sm text-teal-700 hover:text-teal-900" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render "tree_header", category: category %>
 
   <% if children.any? %>
     <ul class="mt-2 space-y-0">

--- a/app/views/categories/update.turbo_stream.erb
+++ b/app/views/categories/update.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%# Keeps the tree header in sync with the side panel after an inline
+    rename / recolor. Only runs when parent_id did not change — moves fall
+    back to the HTML redirect so the tree structure reflows. %>
+<%= turbo_stream.replace dom_id(@category, :tree_header) do %>
+  <%= render "tree_header", category: @category %>
+<% end %>
+
+<%# Replace the panel with the show view. show.html.erb wraps its content
+    in `turbo_frame_tag "category_panel"` already, so this re-renders the
+    panel with the fresh attributes in a single stream action. %>
+<%= turbo_stream.replace "category_panel" do %>
+  <%= render template: "categories/show" %>
+<% end %>

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -492,6 +492,32 @@ RSpec.describe "Categories API", type: :request do
       theirs.reload
       expect(theirs.name).to eq("Theirs")
     end
+
+    context "when the request accepts turbo_stream (side-panel submit)" do
+      let(:turbo_headers) { { "Accept" => "text/vnd.turbo-stream.html" } }
+
+      it "replaces the tree-node header and the panel so the left tree stays in sync" do
+        patch category_path(own),
+              params: { category: { name: "StreamedName" } },
+              headers: turbo_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq(Mime[:turbo_stream])
+        expect(response.body).to include(%(target="#{ActionView::RecordIdentifier.dom_id(own, :tree_header)}"))
+        expect(response.body).to include('target="category_panel"')
+        expect(response.body).to include("StreamedName")
+      end
+
+      it "falls back to a redirect when parent_id changes (tree structure shifts)" do
+        parent = create(:category, name: "NewParent", user: nil)
+
+        patch category_path(own),
+              params: { category: { parent_id: parent.id } },
+              headers: turbo_headers
+
+        expect(response).to redirect_to(category_path(own))
+      end
+    end
   end
 
   describe "DELETE /categories/:id", :integration do


### PR DESCRIPTION
## Summary
- Side panel rename/recolor now updates the left-hand tree in place via `turbo_stream`
- Added `_tree_header` partial with a `dom_id(category, :tree_header)` Turbo-Stream target
- `CategoriesController#update` responds with `update.turbo_stream.erb` replacing both the header and the `category_panel` frame; parent moves still redirect because the tree structure reflows

## Why
Found during a Playwright smoke test of the recently merged category PRs (#485–#494, #496, #497). Editing a personal category from the side panel correctly updated the panel frame but left the tree showing the stale name/color until a full page reload.

## Test plan
- [x] `bundle exec rspec spec/requests/categories_spec.rb` — 73 examples, 0 failures (2 new stream specs)
- [x] Playwright smoke: renamed `TreeSyncTest → TreeSyncRenamed` + changed swatch color; both the tree header and the panel updated without navigation
- [x] `bundle exec rubocop` on touched files — 0 offenses