### PR TITLE
fix(categories): restore 'Category updated.' flash on turbo_stream path

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -84,6 +84,7 @@ class CategoriesController < ApplicationController
         format.html { redirect_to category_path(@category), notice: "Category updated." }
         format.turbo_stream do
           if @category.parent_id == previous_parent_id
+            flash.now[:notice] = "Category updated."
             render :update
           else
             redirect_to category_path(@category), notice: "Category updated."

--- a/app/views/categories/update.turbo_stream.erb
+++ b/app/views/categories/update.turbo_stream.erb
@@ -1,6 +1,8 @@
 <%# Keeps the tree header in sync with the side panel after an inline
     rename / recolor. Only runs when parent_id did not change — moves fall
     back to the HTML redirect so the tree structure reflows. %>
+<% flash.now[:notice] = "Category updated." %>
+
 <%= turbo_stream.replace dom_id(@category, :tree_header) do %>
   <%= render "tree_header", category: @category %>
 <% end %>
@@ -11,3 +13,7 @@
 <%= turbo_stream.replace "category_panel" do %>
   <%= render template: "categories/show" %>
 <% end %>
+
+<%# Restore the toast that the redirect path used to provide. Matches the
+    existing project pattern (e.g. admin/patterns_controller.rb:713). %>
+<%= turbo_stream.replace "flash", partial: "shared/flash" %>

--- a/app/views/categories/update.turbo_stream.erb
+++ b/app/views/categories/update.turbo_stream.erb
@@ -1,7 +1,6 @@
 <%# Keeps the tree header in sync with the side panel after an inline
     rename / recolor. Only runs when parent_id did not change — moves fall
     back to the HTML redirect so the tree structure reflows. %>
-<% flash.now[:notice] = "Category updated." %>
 
 <%= turbo_stream.replace dom_id(@category, :tree_header) do %>
   <%= render "tree_header", category: @category %>

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -508,6 +508,15 @@ RSpec.describe "Categories API", type: :request do
         expect(response.body).to include("StreamedName")
       end
 
+      it "restores the 'Category updated.' flash so users still get visual confirmation" do
+        patch category_path(own),
+              params: { category: { name: "FlashName" } },
+              headers: turbo_headers
+
+        expect(response.body).to include('target="flash"')
+        expect(response.body).to include("Category updated.")
+      end
+
       it "falls back to a redirect when parent_id changes (tree structure shifts)" do
         parent = create(:category, name: "NewParent", user: nil)
 


### PR DESCRIPTION
## Summary
Follow-up to #501. The new `update.turbo_stream.erb` silently updated the tree header + panel without showing a flash toast — losing the "Category updated." confirmation that the redirect path used to provide. This restores it.

- Set `flash.now[:notice] = "Category updated."` in `update.turbo_stream.erb`
- Append a `turbo_stream.replace "flash", partial: "shared/flash"` action so the toast renders alongside the tree/panel updates
- Added a spec asserting the flash target + content are present in the stream response

Mirrors the existing project pattern (`admin/patterns_controller.rb:713`, `concerns/user_authentication.rb:203`).

## Test plan
- [x] `bundle exec rspec spec/requests/categories_spec.rb` — 7 PATCH examples pass (1 new)