### PR TITLE
fix(spec): zone-consistent comparisons in dashboard filter week/month tests

### DIFF
--- a/spec/services/dashboard_expense_filter_service_spec.rb
+++ b/spec/services/dashboard_expense_filter_service_spec.rb
@@ -312,13 +312,19 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
         end
       end
 
+      # transaction_date is a zone-aware Time (Central America, UTC-6).
+      # Comparing Time to a plain Date coerces the Date as 00:00 UTC, which
+      # breaks at zone boundaries — e.g. a Sunday fixture at 00:00 -0600 is
+      # 06:00 UTC, which is *after* end_of_week (Sun 00:00 UTC). Compare
+      # Time-to-Time using .beginning_of_day / .end_of_day so both sides
+      # share the configured zone.
       context "week filter" do
         let(:params) { base_params.merge(period: "week") }
 
         it "returns current week's expenses" do
           dates = result.expenses.map(&:transaction_date)
-          expect(dates.min).to be >= Date.current.beginning_of_week
-          expect(dates.max).to be <= Date.current.end_of_week
+          expect(dates.min).to be >= Date.current.beginning_of_week.beginning_of_day
+          expect(dates.max).to be <= Date.current.end_of_week.end_of_day
         end
       end
 
@@ -327,8 +333,8 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
 
         it "returns current month's expenses" do
           dates = result.expenses.map(&:transaction_date)
-          expect(dates.min).to be >= Date.current.beginning_of_month
-          expect(dates.max).to be <= Date.current.end_of_month
+          expect(dates.min).to be >= Date.current.beginning_of_month.beginning_of_day
+          expect(dates.max).to be <= Date.current.end_of_month.end_of_day
         end
       end
     end


### PR DESCRIPTION
## Summary
- The week filter assertion compared `transaction_date` (zone-aware `Time` in Central America, UTC-6) against `Date.current.end_of_week` (a plain `Date`). Ruby coerces the `Date` as `00:00 UTC`, so a fixture at `00:00 -0600` (= `06:00 UTC`) on Sunday lands *after* `end_of_week` and fails the `<=` check.
- Symptom: the test only failed on **Sundays in CR** — making it look flaky. It blocked today's pre-commit hook (Apr 26 is Sunday) on an unrelated branch.
- Fix: compare `Time` to `Time` via `.beginning_of_day` / `.end_of_day` so both sides share the configured zone. Same change applied to the `month` context for symmetry — same latent bug, just only fires on the Jan 31 / Feb boundary.

## Why the production code is fine
`DashboardExpenseFilterService#period_range` (line 347–360) already uses `Date.current.beginning_of_day` / `.end_of_day` to build proper zone-aware `Time` ranges, and the cursor pagination explicitly comments on avoiding UTC-midnight ambiguity (line 207). This is purely a test-side bug.

## Test plan
- [x] `bundle exec rspec spec/services/dashboard_expense_filter_service_spec.rb` — 44 examples, 0 failures
- [x] Pre-commit hook (rubocop + brakeman + 7846 unit specs) — green
- [ ] Reviewer: confirm comment explains *why* this needed `.end_of_day` so future readers don't "simplify" it back