### PR TITLE
fix(security): rack_attack blocklisted_responder receives a Request, not env hash

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -271,10 +271,12 @@ class Rack::Attack
 
   # === Blocked Response ===
 
-  self.blocklisted_responder = lambda do |env|
-    Rails.logger.error(
-      "Blocked request from IP #{env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_ADDR']}: #{env['PATH_INFO']}"
-    )
+  # Rack::Attack passes a Rack::Attack::Request (a Rack::Request subclass) here,
+  # not a raw env hash — `req.ip` already honors X-Forwarded-For via Rack's
+  # trusted-proxy chain. Treating it like a hash raised NoMethodError on every
+  # blocked request, returning 500 instead of the intended 403.
+  self.blocklisted_responder = lambda do |req|
+    Rails.logger.error("Blocked request from IP #{req.ip}: #{req.path}")
 
     [
       403,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -271,10 +271,13 @@ class Rack::Attack
 
   # === Blocked Response ===
 
-  # Rack::Attack passes a Rack::Attack::Request (a Rack::Request subclass) here,
-  # not a raw env hash — `req.ip` already honors X-Forwarded-For via Rack's
-  # trusted-proxy chain. Treating it like a hash raised NoMethodError on every
-  # blocked request, returning 500 instead of the intended 403.
+  # Rack::Attack >= 6.0 passes a Rack::Attack::Request (a Rack::Request
+  # subclass) here, not a raw env hash. `req.ip` honors the trusted-proxy
+  # chain via action_dispatch.trusted_proxies, so it returns the real
+  # client IP behind kamal-proxy. Reading env['HTTP_X_FORWARDED_FOR']
+  # directly bypasses that chain and is spoofable. Treating it like a
+  # hash raised NoMethodError on every blocked request, returning 500
+  # instead of the intended 403.
   self.blocklisted_responder = lambda do |req|
     Rails.logger.error("Blocked request from IP #{req.ip}: #{req.path}")
 

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -161,8 +161,12 @@ RSpec.describe "Rack::Attack throttle path matching", :unit do
     # raises NoMethodError on every blocked request, swallowing the intended
     # 403 with a 500. Lock the request-object API in.
     let(:initializer_content) { File.read(Rails.root.join("config/initializers/rack_attack.rb")) }
+    # Anchor on the comment-section header below the lambda. The previous
+    # `.*?end$` pattern truncated at the first inner `end` if the lambda
+    # ever grew an `if/end` or `begin/rescue/end`, which would silently let
+    # a regression past the negative assertions.
     let(:responder_block) do
-      initializer_content[/self\.blocklisted_responder = lambda do.*?end$/m]
+      initializer_content[/self\.blocklisted_responder = lambda do.*?(?=^\s*# ===|\Z)/m]
     end
 
     it "is defined" do
@@ -170,8 +174,11 @@ RSpec.describe "Rack::Attack throttle path matching", :unit do
     end
 
     it "uses the request object's API (req.ip, req.path), not env hash access" do
-      expect(responder_block).to include("req.ip")
-      expect(responder_block).to include("req.path")
+      # Word-boundary anchors so a typo like `req.ip_address` (which
+      # doesn't exist on Rack::Request and would 500 in production) can't
+      # silently pass a substring match.
+      expect(responder_block).to match(/\breq\.ip\b/)
+      expect(responder_block).to match(/\breq\.path\b/)
       expect(responder_block).not_to match(/env\[['"]HTTP_X_FORWARDED_FOR['"]\]/)
       expect(responder_block).not_to match(/env\[['"]REMOTE_ADDR['"]\]/)
       expect(responder_block).not_to match(/env\[['"]PATH_INFO['"]\]/)

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -155,6 +155,34 @@ RSpec.describe "Rack::Attack throttle path matching", :unit do
     end
   end
 
+  describe "blocklisted_responder" do
+    # Rack::Attack hands the responder a Rack::Attack::Request, not a Rack
+    # env hash. Treating it like a hash (e.g. env['HTTP_X_FORWARDED_FOR'])
+    # raises NoMethodError on every blocked request, swallowing the intended
+    # 403 with a 500. Lock the request-object API in.
+    let(:initializer_content) { File.read(Rails.root.join("config/initializers/rack_attack.rb")) }
+    let(:responder_block) do
+      initializer_content[/self\.blocklisted_responder = lambda do.*?end$/m]
+    end
+
+    it "is defined" do
+      expect(responder_block).to be_present
+    end
+
+    it "uses the request object's API (req.ip, req.path), not env hash access" do
+      expect(responder_block).to include("req.ip")
+      expect(responder_block).to include("req.path")
+      expect(responder_block).not_to match(/env\[['"]HTTP_X_FORWARDED_FOR['"]\]/)
+      expect(responder_block).not_to match(/env\[['"]REMOTE_ADDR['"]\]/)
+      expect(responder_block).not_to match(/env\[['"]PATH_INFO['"]\]/)
+    end
+
+    it "returns 403 with a forbidden message" do
+      expect(responder_block).to include("403")
+      expect(responder_block).to include("Forbidden")
+    end
+  end
+
   describe "cache store configuration" do
     it "uses Rails.cache unconditionally without Redis branching" do
       initializer_path = Rails.root.join("config/initializers/rack_attack.rb")


### PR DESCRIPTION
## Summary
- `Rack::Attack` passes the `blocklisted_responder` lambda a `Rack::Attack::Request` (a `Rack::Request` subclass), **not** a Rack env hash. The current code treats it like a hash (`env['HTTP_X_FORWARDED_FOR']`), which raises `NoMethodError` on every blocked request and returns a 500 with a stacktrace instead of the intended 403.
- Use `req.ip` (already honors X-Forwarded-For via Rack's trusted-proxy chain) and `req.path`. Adds a source-grep spec — consistent with the rest of `spec/initializers/rack_attack_spec.rb` — that locks the request-object API in so this can't silently regress.

## Where I noticed it
4 hits in production logs over the last 24h, all from external scanners hitting blocklisted paths:

| Time (UTC) | IP | Path | Match |
|---|---|---|---|
| 08:23 | 216.73.216.116 (AWS) | /sitemap.xml | block-bad-agents |
| 11:26 | 216.73.216.116 (AWS) | /sitemap.xml | block-bad-agents |
| 13:59 | 74.7.242.7 (NL/RIPE) | / | block-bad-agents |
| 14:30 | 216.73.216.116 (AWS) | /sitemap.xml | block-bad-agents |

The throttled_responder above already handles the request-vs-env case explicitly (`env.is_a?(Hash) ? env : env.env`) — only the blocklisted_responder was missed.

## Test plan
- [x] `bundle exec rspec spec/initializers/rack_attack_spec.rb` — 23 examples, 0 failures (3 new)
- [x] Pre-commit hook (rubocop + brakeman + ~7800 unit specs) — green
- [ ] After deploy: tail `kamal app logs` for the next blocked request and confirm a clean 403 instead of a 500