### PR TITLE
fix(llm): wire ANTHROPIC_API_KEY end-to-end (credentials-or-ENV) — PER-548

### DIFF
--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -36,7 +36,12 @@ module Services::Categorization
         if client
           @client = client
         else
-          api_key = Rails.application.credentials.dig(:anthropic, :api_key)
+          # Credentials first (encrypted in repo), then ENV fallback so the
+          # key can be rotated via `kamal env push` without rebuilding the
+          # image. Without the ENV branch a stale credentials entry silently
+          # 401s on every call (PER-548).
+          api_key = Rails.application.credentials.dig(:anthropic, :api_key).presence ||
+                    ENV["ANTHROPIC_API_KEY"].presence
           raise ConfigurationError, "Anthropic API key not configured" unless api_key
 
           @client = Anthropic::Client.new(

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -30,6 +30,7 @@ REQUIRED_SECRETS = %w[
   KAMAL_REGISTRY_PASSWORD
   ADMIN_EMAIL
   ADMIN_PASSWORD
+  ANTHROPIC_API_KEY
 ].freeze
 
 # Must stay in sync with db/seeds.rb:370 — the production seed guard.
@@ -145,12 +146,16 @@ if secrets["ADMIN_EMAIL"] && !secrets["ADMIN_EMAIL"].empty? && secrets["ADMIN_EM
 end
 
 # --- Gate 4: config/deploy.yml env.secret sanity -------------------------
-say "Gate 4/8: config/deploy.yml declares ADMIN_EMAIL / ADMIN_PASSWORD under env.secret"
+say "Gate 4/8: config/deploy.yml declares ADMIN_EMAIL / ADMIN_PASSWORD / ANTHROPIC_API_KEY under env.secret"
 if DEPLOY_YML.file?
   yml = DEPLOY_YML.read.force_encoding(Encoding::UTF_8)
   yml = yml.scrub unless yml.valid_encoding?
   in_env_secret = false
-  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false }
+  # ANTHROPIC_API_KEY: required by Categorization::Strategies::LlmStrategy.
+  # Missing it makes the strategy 401 on every call and silently degrade to
+  # pattern-only categorization (PER-548). Treated as a deploy gate so the
+  # next contributor can't ship a deploy.yml that drops it.
+  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false, "ANTHROPIC_API_KEY" => false }
   yml.each_line do |line|
     stripped = line.strip
     if stripped.start_with?("secret:")

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -43,6 +43,10 @@ env:
     - POSTGRES_PASSWORD
     - ADMIN_EMAIL
     - ADMIN_PASSWORD
+    # Required for Categorization::Strategies::LlmStrategy (PR #421/#433).
+    # Without this the strategy 401s on every call and the circuit-breaker
+    # silently degrades to pattern-only categorization (PER-548).
+    - ANTHROPIC_API_KEY
   clear:
     RAILS_ENV: production
     POSTGRES_USER: expense_tracker

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -79,13 +79,52 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
       end
     end
 
-    it "raises an error when API key is not configured" do
+    it "raises an error when API key is not configured in credentials or ENV" do
       allow(Rails.application.credentials).to receive(:dig)
         .with(:anthropic, :api_key).and_return(nil)
+      ENV.delete("ANTHROPIC_API_KEY")
 
       expect { described_class.new }.to raise_error(
         Services::Categorization::Llm::Client::ConfigurationError,
         /API key not configured/
+      )
+    end
+
+    it "falls back to ENV['ANTHROPIC_API_KEY'] when credentials are blank (PER-548)" do
+      # Production scenario: credentials.yml.enc has a stale/blank entry but
+      # the operator pushed a fresh key via kamal env push. ENV must win.
+      allow(Rails.application.credentials).to receive(:dig)
+        .with(:anthropic, :api_key).and_return(nil)
+      env_key = "env-fallback-key-456"
+      ENV["ANTHROPIC_API_KEY"] = env_key
+      allow(Anthropic::Client).to receive(:new).and_call_original
+
+      begin
+        described_class.new
+      ensure
+        ENV.delete("ANTHROPIC_API_KEY")
+      end
+
+      expect(Anthropic::Client).to have_received(:new).with(
+        hash_including(api_key: env_key)
+      )
+    end
+
+    it "prefers credentials over ENV when both are present" do
+      # Credentials are the primary source of truth (encrypted at rest).
+      # ENV is fallback only — flipping the precedence would mean a
+      # forgotten dev shell could hijack the prod-resolved key path.
+      ENV["ANTHROPIC_API_KEY"] = "should-not-be-used"
+      allow(Anthropic::Client).to receive(:new).and_call_original
+
+      begin
+        described_class.new
+      ensure
+        ENV.delete("ANTHROPIC_API_KEY")
+      end
+
+      expect(Anthropic::Client).to have_received(:new).with(
+        hash_including(api_key: api_key)
       )
     end
   end


### PR DESCRIPTION
## Summary

Fixes [PER-548](https://linear.app/personal-brand-esoto/issue/PER-548). LLM categorization has been silently disabled in production — every Anthropic call returns 401, and PR #433's circuit-breaker falls back to pattern matching cleanly enough that it looked healthy. The 84.6% categorization rate is **all** patterns; the LLM has never categorized a single production expense.

## Why the original "just declare the secret" approach wasn't enough

The first commit on this branch only added `ANTHROPIC_API_KEY` to `config/deploy.yml` env.secret + the pre-deploy-check gates. Architecture review caught that **`Llm::Client#initialize` (`app/services/categorization/llm/client.rb:39`) reads exclusively from `Rails.application.credentials.dig(:anthropic, :api_key)`** — it never consulted `ENV`. So shipping the env var via Kamal would have had zero effect on production behavior. The 401s would have continued.

The second commit on this branch fixes the load-bearing piece: credentials-first, ENV-fallback in the client.

## Changes

### Application code

- **`app/services/categorization/llm/client.rb`** — read order: `Rails.application.credentials.dig(:anthropic, :api_key).presence` → `ENV["ANTHROPIC_API_KEY"].presence` → raise `ConfigurationError`. Credentials remain the primary source of truth (encrypted at rest); ENV is a rotation-friendly fallback.

### Operator/deploy

- **`config/deploy.yml`** — declare `ANTHROPIC_API_KEY` under `env.secret:` with an inline comment.
- **`bin/pre-deploy-check`** — add `ANTHROPIC_API_KEY` to `REQUIRED_SECRETS` (Gate 2) and to the env.secret declaration check (Gate 4). Both gates fail fast if a future deploy drops the key on either side.

### Tests

- **`spec/services/categorization/llm/client_spec.rb`** — update existing "raises when not configured" to clear ENV too; add **ENV-fallback** spec (credentials blank → ENV wins) and **precedence** spec (both set → credentials wins, prevents stale dev-shell hijacking the resolved key path).

## Why credentials-then-ENV (not the reverse)

Credentials are encrypted at rest in `config/credentials/production.yml.enc` — the canonical source. ENV is the rotation-friendly path. If ENV took precedence, a developer who forgot to `unset ANTHROPIC_API_KEY` in their shell could accidentally hijack the resolved key in any Rails console session, including against a production database via `kamal app exec`.

## Operator action required after merge

`.kamal/secrets` is gitignored, so the actual secret reference must be added locally. After this PR merges:

1. **Add the field to 1Password.** In the existing `Personal Brand/Expense Tracker` item, add a field named `ANTHROPIC_API_KEY` containing your Anthropic API key.
2. **Append to `.kamal/secrets`** (mirrors the existing pattern):
   ```
   ANTHROPIC_API_KEY=$(op read "op://Personal Brand/Expense Tracker/ANTHROPIC_API_KEY")
   ```
3. **Run gates**: `bin/pre-deploy-check`. They'll now hard-fail if step 1 or 2 was skipped.
4. **Deploy**: `kamal deploy`.

## Test plan

- [x] `bundle exec rspec spec/services/categorization/llm/client_spec.rb` — 28 examples, 0 failures (3 new)
- [x] `ruby -ryaml -e "p YAML.unsafe_load_file('config/deploy.yml')['env']['secret']"` includes `ANTHROPIC_API_KEY`
- [x] `bundle exec rubocop` — green on touched files
- [x] Pre-commit hook (rubocop + brakeman + ~7800 unit specs) — green on both commits
- [ ] Operator: after the four-step procedure, `kamal secrets print` shows `ANTHROPIC_API_KEY=[redacted]`
- [ ] Operator: post-deploy, `kamal app logs --since 10m | grep -iE 'LlmStrategy|circuit'` shows fresh categorizations without `circuit open` lines
- [ ] Operator: console on prod — `Services::Categorization::Llm::Client.new` returns a working client without raising `ConfigurationError`

## Related

- PER-548 — this fix's parent ticket
- PER-549 — PatternCache hit-rate metric stuck at 0% (separate issue, low priority)
- PR #433 — the circuit-breaker that's been masking this since Apr 16