### PR TITLE
fix(pattern-cache): cross-process counters + L2 hit recording (PER-549)

### DIFF
--- a/app/jobs/pattern_cache_warmer_job.rb
+++ b/app/jobs/pattern_cache_warmer_job.rb
@@ -133,15 +133,17 @@ class PatternCacheWarmerJob < ApplicationJob
   def check_cache_health(cache)
     metrics = cache.metrics
 
-    # Check hit rate using configuration
-    hit_rate = metrics[:hit_rate] || 0
+    # Check hit rate using configuration. nil means "no lookups in window"
+    # — skip the warn entirely rather than coerce nil → 0 and log a false
+    # "Low cache hit rate: 0%" on every quiet warmer run (PER-549).
+    hit_rate = metrics[:hit_rate]
     target_hit_rate = if defined?(Services::Infrastructure::PerformanceConfig)
                         Services::Infrastructure::PerformanceConfig.threshold_for(:cache, :hit_rate, :target)
     else
                         80.0
     end
 
-    if hit_rate < target_hit_rate
+    if hit_rate && hit_rate < target_hit_rate
       Rails.logger.warn "[PatternCacheWarmer] Low cache hit rate: #{hit_rate}% (target: #{target_hit_rate}%)"
     end
 

--- a/app/services/categorization/pattern_cache.rb
+++ b/app/services/categorization/pattern_cache.rb
@@ -339,8 +339,10 @@ module Services::Categorization
         # Check L2 (Rails.cache) is responding
         Rails.cache.write("cat:health_check", true, expires_in: 30.seconds)
 
-        # Check metrics are being collected
-        @metrics_collector.hit_rate >= 0
+        # Check metrics are being collected. hit_rate may be nil if no
+        # lookups have happened yet; that's a healthy "no traffic" state.
+        rate = @metrics_collector.hit_rate
+        rate.nil? || rate >= 0
 
         true
       rescue => e
@@ -365,13 +367,17 @@ module Services::Categorization
     # Get cache statistics (alias for metrics for compatibility)
     def stats
       metrics_data = metrics
+      rate = hit_rate
       {
         entries: metrics_data[:memory_cache_entries] || 0,
         memory_bytes: (metrics_data[:memory_cache_entries] || 0) * 1024, # Rough estimate
         hits: metrics_data.dig(:hits, :total) || 0,
         misses: metrics_data[:misses] || 0,
         evictions: metrics_data[:evictions] || 0,
-        hit_rate: (hit_rate / 100.0) # Convert percentage to decimal
+        # Decimal in [0, 1] for callers that want a fraction; nil when no
+        # lookups have happened yet so callers can distinguish "quiet"
+        # from "0% hit rate".
+        hit_rate: rate.nil? ? nil : (rate / 100.0)
       }
     end
 
@@ -426,17 +432,20 @@ module Services::Categorization
                             10.seconds
       end
 
+      # Detect L2 hit vs miss by tracking whether the fetch block ran. The
+      # earlier comment claimed "we handle this when we promote to L1" but
+      # the actual record_hit(:redis) call was never wired up — the result
+      # was that every L2 hit went uncounted, which is what produced the
+      # always-0% hit rate alert (PER-549).
+      block_ran = false
       value = Rails.cache.fetch(key, expires_in: l2_ttl, race_condition_ttl: race_condition_ttl) do
+        block_ran = true
         @metrics_collector.record_miss
         yield
       end
 
       if value
-        # Record L2 hit if the block was not executed (value was in L2 cache).
-        # Rails.cache.fetch doesn't distinguish, but the miss was already recorded
-        # inside the block if the block ran. If the block didn't run, we got an L2 hit.
-        # We handle this by recording the L2 hit when we promote to L1.
-
+        @metrics_collector.record_hit(:redis) unless block_ran
         # Promote to L1 memory cache
         write_to_memory(key, value, memory_ttl)
       end
@@ -601,20 +610,51 @@ module Services::Categorization
     end
 
     # Internal metrics collector
+    #
+    # Hit/miss counters are backed by Rails.cache (Solid Cache → Postgres) so
+    # that the running Puma process AND the forked Solid Queue worker
+    # processes (`processes: 2` for high priority + `processes: 1` for
+    # standard, per config/queue.yml) share a single source of truth.
+    #
+    # Before this change, every process had its own per-instance counters,
+    # the PerformanceMonitoring thread runs in only one of them, and most
+    # real categorizations happen in different processes — so the monitoring
+    # thread always reported 0% hit rate even when categorization was
+    # working perfectly (PER-549).
+    #
+    # Operation timing samples (`@operations`) stay in-process — they're a
+    # debugging aid, not a cross-process metric, and shipping them through
+    # Rails.cache on every cached lookup would dwarf the underlying ops.
     class MetricsCollector
+      # Hit/miss keys are namespaced under the pattern cache and rotate
+      # daily, so today's counts are isolated from older windows and old
+      # windows expire naturally via Solid Cache's max_age. Rails.cache has
+      # no native key TTL on increment-only flows; the explicit window key
+      # handles rotation without the write+increment dance.
+      COUNTER_NAMESPACE = "#{CACHE_NAMESPACE}metrics:".freeze
+      WINDOW_TTL        = 25.hours # one full window plus the rotation overlap
+
+      # Test helper: clears the current window's hit/miss counters. Use in
+      # spec before-blocks so prior examples don't pollute the asserted
+      # counts. Not for production code — counters are window-rotated and
+      # auto-expire via Solid Cache's max_age.
+      def self.reset_window!
+        Rails.cache.delete("#{COUNTER_NAMESPACE}hits:memory:#{Date.current}")
+        Rails.cache.delete("#{COUNTER_NAMESPACE}hits:redis:#{Date.current}")
+        Rails.cache.delete("#{COUNTER_NAMESPACE}misses:#{Date.current}")
+      end
+
       def initialize
-        @hits = { memory: 0, redis: 0 }
-        @misses = 0
         @operations = Hash.new { |h, k| h[k] = [] }
         @lock = Mutex.new
       end
 
       def record_hit(level)
-        @lock.synchronize { @hits[level] += 1 }
+        cache_increment("hits:#{level}")
       end
 
       def record_miss
-        @lock.synchronize { @misses += 1 }
+        cache_increment("misses")
       end
 
       def record_operation(name, duration_ms)
@@ -625,18 +665,32 @@ module Services::Categorization
         end
       end
 
+      # Returns the hit rate as a percentage (0..100) for the current window,
+      # or nil when no lookups have happened yet. Returning nil instead of
+      # 0.0 lets the monitoring layer distinguish "no traffic" from "all
+      # misses" so it doesn't fire a critical alert during quiet periods.
       def hit_rate
-        total = @hits.values.sum + @misses
-        return 0.0 if total.zero?
+        h = hits
+        m = misses_count
+        total = h.values.sum + m
+        return nil if total.zero?
 
-        (@hits.values.sum.to_f / total * 100).round(2)
+        (h.values.sum.to_f / total * 100).round(2)
+      end
+
+      def hits
+        { memory: cache_read("hits:memory"), redis: cache_read("hits:redis") }
+      end
+
+      def misses_count
+        cache_read("misses")
       end
 
       def summary
         @lock.synchronize do
           {
-            hits: @hits.dup,
-            misses: @misses,
+            hits: hits,
+            misses: misses_count,
             hit_rate: hit_rate,
             operations: operation_stats
           }
@@ -644,6 +698,31 @@ module Services::Categorization
       end
 
       private
+
+      def cache_increment(suffix)
+        key = window_key(suffix)
+        # Solid Cache's increment is atomic but raises on missing key; seed
+        # then increment. The race between the two is benign — at worst we
+        # double-seed (write 0 twice) and one of the increments lands on a
+        # 0 we just wrote, which is the correct value anyway.
+        Rails.cache.write(key, 0, expires_in: WINDOW_TTL, raw: true) unless Rails.cache.exist?(key)
+        Rails.cache.increment(key, 1, expires_in: WINDOW_TTL)
+      rescue StandardError => e
+        # Don't let a metrics-cache hiccup propagate into the lookup path.
+        # The lookup result is the user-visible thing; metrics are
+        # diagnostic and can degrade gracefully.
+        Rails.logger.warn "[PatternCache::MetricsCollector] cache_increment(#{suffix}) failed: #{e.class}: #{e.message}"
+      end
+
+      def cache_read(suffix)
+        Rails.cache.read(window_key(suffix), raw: true).to_i
+      rescue StandardError
+        0
+      end
+
+      def window_key(suffix)
+        "#{COUNTER_NAMESPACE}#{suffix}:#{Date.current}"
+      end
 
       def operation_stats
         @operations.transform_values do |durations|

--- a/app/services/categorization/pattern_cache.rb
+++ b/app/services/categorization/pattern_cache.rb
@@ -340,9 +340,11 @@ module Services::Categorization
         Rails.cache.write("cat:health_check", true, expires_in: 30.seconds)
 
         # Check metrics are being collected. hit_rate may be nil if no
-        # lookups have happened yet; that's a healthy "no traffic" state.
-        rate = @metrics_collector.hit_rate
-        rate.nil? || rate >= 0
+        # lookups have happened yet; that's a healthy "no traffic" state,
+        # not a failure. The actual contract for this method is "did the
+        # health probes succeed?" — the metrics call merely needs to not
+        # raise.
+        @metrics_collector.hit_rate
 
         true
       rescue => e
@@ -368,10 +370,16 @@ module Services::Categorization
     def stats
       metrics_data = metrics
       rate = hit_rate
+      hits_hash = metrics_data[:hits]
       {
         entries: metrics_data[:memory_cache_entries] || 0,
         memory_bytes: (metrics_data[:memory_cache_entries] || 0) * 1024, # Rough estimate
-        hits: metrics_data.dig(:hits, :total) || 0,
+        # Sum the per-tier hash directly. Pre-PER-549 this read
+        # `metrics_data.dig(:hits, :total)` but `:total` was never a key
+        # in the {memory:, redis:} shape, so #stats has been silently
+        # returning hits=0 to dashboard helpers and the /api/health
+        # endpoint since the metrics shape was introduced.
+        hits: hits_hash.is_a?(Hash) ? hits_hash.values.sum : (hits_hash || 0),
         misses: metrics_data[:misses] || 0,
         evictions: metrics_data[:evictions] || 0,
         # Decimal in [0, 1] for callers that want a fraction; nil when no
@@ -634,11 +642,15 @@ module Services::Categorization
       COUNTER_NAMESPACE = "#{CACHE_NAMESPACE}metrics:".freeze
       WINDOW_TTL        = 25.hours # one full window plus the rotation overlap
 
-      # Test helper: clears the current window's hit/miss counters. Use in
+      # Test helper: clears the current window's hit/miss counters
+      # globally across every process reading this Rails.cache. Use in
       # spec before-blocks so prior examples don't pollute the asserted
-      # counts. Not for production code — counters are window-rotated and
-      # auto-expire via Solid Cache's max_age.
+      # counts. Not for production — counters are window-rotated and
+      # auto-expire via Solid Cache's max_age, and zeroing them mid-day
+      # would silence the very alerts PER-549/PER-550 added.
       def self.reset_window!
+        raise "reset_window! is a test helper; never invoke from production" if Rails.env.production?
+
         Rails.cache.delete("#{COUNTER_NAMESPACE}hits:memory:#{Date.current}")
         Rails.cache.delete("#{COUNTER_NAMESPACE}hits:redis:#{Date.current}")
         Rails.cache.delete("#{COUNTER_NAMESPACE}misses:#{Date.current}")
@@ -687,26 +699,37 @@ module Services::Categorization
       end
 
       def summary
-        @lock.synchronize do
-          {
-            hits: hits,
-            misses: misses_count,
-            hit_rate: hit_rate,
-            operations: operation_stats
-          }
-        end
+        # hits / misses_count / hit_rate read from Rails.cache and don't
+        # need the in-process @lock — fetch them outside the synchronize
+        # block so a slow Rails.cache read can't serialize concurrent
+        # summary calls. The lock only guards @operations.
+        cache_hits = hits
+        cache_misses = misses_count
+        cache_hit_rate = hit_rate
+
+        ops = @lock.synchronize { operation_stats }
+
+        {
+          hits: cache_hits,
+          misses: cache_misses,
+          hit_rate: cache_hit_rate,
+          operations: ops
+        }
       end
 
       private
 
       def cache_increment(suffix)
-        key = window_key(suffix)
-        # Solid Cache's increment is atomic but raises on missing key; seed
-        # then increment. The race between the two is benign — at worst we
-        # double-seed (write 0 twice) and one of the increments lands on a
-        # 0 we just wrote, which is the correct value anyway.
-        Rails.cache.write(key, 0, expires_in: WINDOW_TTL, raw: true) unless Rails.cache.exist?(key)
-        Rails.cache.increment(key, 1, expires_in: WINDOW_TTL)
+        # Solid Cache's `increment` is upsert-atomic: missing key → seeds
+        # at amount, existing → SELECT...FOR UPDATE-protected increment.
+        # The earlier "exist? + write 0 + increment" sequence assumed
+        # Memcached semantics ("raises on missing key") which Solid Cache
+        # does not share. Single round-trip on every code path.
+        # `expires_in:` only takes effect on the seeding write — once the
+        # key exists, Solid Cache preserves the original `expires_at`.
+        # That's fine here because window keys rotate by date suffix, so
+        # each new day's first increment establishes the TTL fresh.
+        Rails.cache.increment(window_key(suffix), 1, expires_in: WINDOW_TTL)
       rescue StandardError => e
         # Don't let a metrics-cache hiccup propagate into the lookup path.
         # The lookup result is the user-visible thing; metrics are

--- a/app/services/infrastructure/monitoring_service.rb
+++ b/app/services/infrastructure/monitoring_service.rb
@@ -675,7 +675,9 @@ module Services::Infrastructure
           def identify_pattern_cache_issues(metrics)
             issues = []
 
-            issues << "Low hit rate (#{metrics[:hit_rate]}%)" if metrics[:hit_rate].to_f < 80
+            # Skip the hit-rate issue when nil — that's "no traffic in the
+            # current window," not a real performance problem (PER-549).
+            issues << "Low hit rate (#{metrics[:hit_rate]}%)" if metrics[:hit_rate] && metrics[:hit_rate] < 80
             issues << "High memory usage (#{metrics[:memory_entries]} entries)" if metrics[:memory_entries].to_i > 10_000
             issues << "L2 cache unavailable" unless metrics[:l2_cache_available]
             issues << "Slow lookups (#{metrics[:average_lookup_time_ms]}ms)" if metrics[:average_lookup_time_ms].to_f > 5
@@ -686,7 +688,9 @@ module Services::Infrastructure
           def generate_cache_recommendations(pattern_cache_health, rails_cache_health)
             recommendations = []
 
-            if pattern_cache_health[:hit_rate].to_f < 80
+            # Same nil-aware guard: don't recommend cache tuning when there's
+            # no traffic in the current window.
+            if pattern_cache_health[:hit_rate] && pattern_cache_health[:hit_rate] < 80
               recommendations << "Consider increasing cache warming frequency"
               recommendations << "Review pattern matching logic for optimization"
             end

--- a/app/services/infrastructure/monitoring_service.rb
+++ b/app/services/infrastructure/monitoring_service.rb
@@ -645,11 +645,16 @@ module Services::Infrastructure
 
             metrics = pattern_cache_metrics
 
+            # nil hit_rate means "no lookups in window" — treat as healthy
+            # rather than degraded (PER-549). nil.to_f silently coerces to
+            # 0.0 which would otherwise classify a quiet cache as "degraded".
             status = if metrics[:error]
                        "critical"
-            elsif metrics[:hit_rate].to_f < 50
+            elsif metrics[:hit_rate].nil?
+                       "healthy"
+            elsif metrics[:hit_rate] < 50
                        "degraded"
-            elsif metrics[:hit_rate].to_f < 80
+            elsif metrics[:hit_rate] < 80
                        "warning"
             else
                        "healthy"

--- a/config/initializers/performance_monitoring.rb
+++ b/config/initializers/performance_monitoring.rb
@@ -155,7 +155,8 @@ module PerformanceMonitoring
       health = metrics[:health]
 
       Rails.logger.info "[PerformanceMonitoring] Cache Performance Summary:"
-      Rails.logger.info "  Hit Rate: #{cache_metrics[:hit_rate]}%"
+      hit_rate_display = cache_metrics[:hit_rate].nil? ? "n/a (no lookups in window)" : "#{cache_metrics[:hit_rate]}%"
+      Rails.logger.info "  Hit Rate: #{hit_rate_display}"
       Rails.logger.info "  Memory Entries: #{cache_metrics[:memory_entries]}"
       Rails.logger.info "  Avg Lookup Time: #{cache_metrics[:average_lookup_time_ms]}ms"
       Rails.logger.info "  Health Status: #{health[:overall]}"
@@ -174,18 +175,23 @@ module PerformanceMonitoring
       cache_metrics = metrics[:pattern_cache]
       issues = []
 
-      # Check cache hit rate using configuration
-      hit_rate = cache_metrics[:hit_rate].to_f
-      hit_rate_severity = Services::Infrastructure::PerformanceConfig.check_threshold(:cache, :hit_rate, 100 - hit_rate)
+      # Check cache hit rate using configuration. PatternCache#hit_rate
+      # returns nil when there have been no lookups in the current window —
+      # treat that as "no traffic, healthy" rather than "0% hit rate", or
+      # the alert fires every monitoring tick on a freshly-warmed cache.
+      hit_rate = cache_metrics[:hit_rate]
+      if hit_rate
+        hit_rate_severity = Services::Infrastructure::PerformanceConfig.check_threshold(:cache, :hit_rate, 100 - hit_rate.to_f)
 
-      if hit_rate_severity != :healthy
-        target = Services::Infrastructure::PerformanceConfig.threshold_for(:cache, :hit_rate, :target)
-        issues << {
-          type: :low_hit_rate,
-          severity: hit_rate_severity,
-          message: "Cache hit rate is #{hit_rate}% (target: >#{target}%)",
-          metrics: { hit_rate: hit_rate }
-        }
+        if hit_rate_severity != :healthy
+          target = Services::Infrastructure::PerformanceConfig.threshold_for(:cache, :hit_rate, :target)
+          issues << {
+            type: :low_hit_rate,
+            severity: hit_rate_severity,
+            message: "Cache hit rate is #{hit_rate}% (target: >#{target}%)",
+            metrics: { hit_rate: hit_rate }
+          }
+        end
       end
 
       # Check lookup time using configuration

--- a/spec/jobs/pattern_cache_warmer_job_spec.rb
+++ b/spec/jobs/pattern_cache_warmer_job_spec.rb
@@ -425,8 +425,11 @@ RSpec.describe PatternCacheWarmerJob, type: :job, unit: true do
     context 'with nil hit_rate' do
       let(:hit_rate) { nil }
 
-      it 'treats nil as 0 and logs warning' do
-        expect(Rails.logger).to receive(:warn).with(/Low cache hit rate: 0%/)
+      it 'treats nil as "no traffic" and skips the low-hit-rate warning (PER-549)' do
+        # Pre-PER-549 this test asserted the OLD bug: nil → coerced to 0
+        # → warned every quiet run. The new contract is nil means "no
+        # lookups in window," which is healthy, not low.
+        expect(Rails.logger).not_to receive(:warn).with(/Low cache hit rate/)
         job.send(:check_cache_health, cache)
       end
     end
@@ -444,7 +447,10 @@ RSpec.describe PatternCacheWarmerJob, type: :job, unit: true do
       let(:cache_metrics) { {} }
 
       it 'handles missing keys gracefully' do
-        expect(Rails.logger).to receive(:warn).with(/Low cache hit rate: 0%/)
+        # No hit_rate key (treated as nil → no warn, per PER-549). L2
+        # availability is the only orthogonal warning that should still
+        # fire on an empty metrics hash.
+        expect(Rails.logger).not_to receive(:warn).with(/Low cache hit rate/)
         expect(Rails.logger).to receive(:warn).with(/L2 cache is not available/)
         job.send(:check_cache_health, cache)
       end

--- a/spec/services/categorization/pattern_cache_spec.rb
+++ b/spec/services/categorization/pattern_cache_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     cache.invalidate_all
     # Reset singleton for test isolation
     Services::Categorization::PatternCache.instance_variable_set(:@instance, nil)
+    # Reset cross-process metric counters (PER-549) so prior examples
+    # don't pollute hit/miss assertions in this one.
+    Services::Categorization::PatternCache::MetricsCollector.reset_window!
   end
 
   describe "#initialize", performance: true do
@@ -403,6 +406,55 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
         :min_ms,
         :max_ms
       )
+    end
+  end
+
+  describe "metrics behavior — PER-549 fixes", performance: true do
+    let(:fresh_cache) { described_class.new }
+
+    before do
+      Services::Categorization::PatternCache::MetricsCollector.reset_window!
+    end
+
+    it "returns nil hit_rate when no lookups have happened in the window" do
+      # Before this fix, hit_rate returned 0.0 with no traffic, which
+      # tripped the :low_hit_rate critical alert every monitoring tick on
+      # a freshly-warmed cache. nil now signals "no data, not zero" so the
+      # initializer can skip the alert.
+      expect(fresh_cache.hit_rate).to be_nil
+    end
+
+    it "records an L2 hit when the value is in Rails.cache but not L1 memory" do
+      # Seed L2 directly, bypass L1, then hit_rate must include the L2 hit.
+      key = "#{described_class::PATTERN_KEY_PREFIX}seed:42"
+      Rails.cache.write(key, { id: 42, name: "test" })
+
+      fresh_cache.send(
+        :fetch_with_tiered_cache,
+        key,
+        memory_ttl: 5.minutes,
+        l2_ttl: 1.hour
+      ) { raise "block should not run on L2 hit" }
+
+      hits = fresh_cache.metrics[:hits]
+      expect(hits[:redis]).to eq(1), "expected 1 L2 hit, got #{hits.inspect} (PER-549 regression)"
+      expect(hits[:memory]).to eq(0)
+    end
+
+    it "shares counters across instances via Rails.cache (cross-process visibility)" do
+      # Two PatternCache instances stand in for two separate Solid Queue
+      # worker processes. They share the Rails.cache backing store, so a
+      # hit recorded by one is visible to the other. Before this fix the
+      # counters were per-instance, so the monitoring thread (running in
+      # one process) couldn't see hits in another.
+      cache_a = described_class.new
+      cache_b = described_class.new
+
+      cache_a.instance_variable_get(:@metrics_collector).record_hit(:memory)
+      cache_a.instance_variable_get(:@metrics_collector).record_hit(:memory)
+
+      expect(cache_b.metrics[:hits][:memory]).to eq(2)
+      expect(cache_b.hit_rate).to eq(100.0)
     end
   end
 

--- a/spec/services/categorization/pattern_cache_spec.rb
+++ b/spec/services/categorization/pattern_cache_spec.rb
@@ -453,8 +453,45 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
       cache_a.instance_variable_get(:@metrics_collector).record_hit(:memory)
       cache_a.instance_variable_get(:@metrics_collector).record_hit(:memory)
 
+      # Assert the storage location, not just visibility — that's the
+      # property which gives cross-process safety. A regression that
+      # moved counters back into instance state would still pass a pure
+      # cache_b.metrics check (since both instances are in the same
+      # process), but would fail this Rails.cache.read assertion.
+      key = "cat:metrics:hits:memory:#{Date.current}"
+      expect(Rails.cache.read(key, raw: true).to_i).to eq(2)
       expect(cache_b.metrics[:hits][:memory]).to eq(2)
       expect(cache_b.hit_rate).to eq(100.0)
+    end
+
+    it "records an L2 hit through the public get_pattern path (regression guard)" do
+      # The unit-style L2-hit spec above calls fetch_with_tiered_cache via
+      # send to keep the assertion narrow. This sibling spec drives the
+      # public API end-to-end: warm L1+L2 once, drop L1, then a second
+      # public call must hit L2 and increment :redis. Without this the
+      # narrow spec could silently rot if a future refactor inlined
+      # Rails.cache.fetch outside fetch_with_tiered_cache.
+      pattern  # create the AR record
+      fresh_cache.get_pattern(pattern.id)
+      fresh_cache.clear_memory_cache
+      Services::Categorization::PatternCache::MetricsCollector.reset_window!
+
+      fresh_cache.get_pattern(pattern.id)
+
+      hits = fresh_cache.metrics[:hits]
+      expect(hits[:redis]).to eq(1), "expected an L2 hit via public API; got #{hits.inspect}"
+      expect(hits[:memory]).to eq(0)
+    end
+
+    it "swallows Rails.cache errors during record_hit so the lookup path stays alive" do
+      # The cache_increment rescue is load-bearing — its comment
+      # explicitly says metrics must never break categorization. This
+      # spec locks that guarantee in.
+      collector = described_class::MetricsCollector.new
+      allow(Rails.cache).to receive(:increment).and_raise(StandardError, "DB down")
+
+      expect(Rails.logger).to receive(:warn).with(/cache_increment.*failed/)
+      expect { collector.record_hit(:memory) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
## Summary

Closes [PER-549](https://linear.app/personal-brand-esoto/issue/PER-549). Production has been firing a `[PERFORMANCE ALERT - CRITICAL] low_hit_rate: Cache hit rate is 0.0%` every 5 minutes for at least 6 days, even though categorization is succeeding at 84.6% (last 7d) using the cache. **It was a metrics bug, not a real cache miss.**

Three compounding bugs were keeping the alert firing:

### 1. L2 hits were never recorded
`app/services/categorization/pattern_cache.rb#fetch_with_tiered_cache` had a comment claiming "We handle this by recording the L2 hit when we promote to L1" but the actual `record_hit(:redis)` call was never wired up. Every Rails.cache hit went uncounted.

**Fix:** track whether the fetch block ran via a `block_ran` sentinel; record an L2 hit only when it didn't.

### 2. Counters were per-process; the monitoring thread couldn't see them
Production runs Puma + Solid Queue with `processes: 2` for high priority + `processes: 1` for standard (`config/queue.yml`). Each forked worker has its own `MetricsCollector` with its own in-memory counters. The `PerformanceMonitoring` thread runs in only one process — so it always read empty counters even though real categorization was happening in the other workers.

**Fix:** back the counters with `Rails.cache` (Solid Cache → Postgres) so all processes increment a single source of truth. Counters use daily-rotating window keys (`cat:metrics:hits:memory:#{Date.current}`) that auto-expire via Solid Cache's `max_age` — no manual cleanup, no unbounded growth.

### 3. `hit_rate` returned 0.0 on no-data, indistinguishable from 100% miss
Fresh cache + no traffic = 0/0 = 0.0, which the alert subscriber compared against the 90% target and flagged as critical.

**Fix:** `hit_rate` returns `nil` when total = 0; alert subscriber and `MonitoringService#identify_pattern_cache_issues` skip on nil rather than firing.

## Empirical confirmation (pre-fix, prod)

```
$ kamal app exec --reuse 'bin/rails runner ...'
BEFORE: hits={memory: 0, redis: 0} misses=0
AFTER:  hits={memory: 4, redis: 0} misses=1   ← redis stays 0 even with L2 hits
HIT_RATE=80.0
```

After the fix, the same lookup pattern records L2 hits, and the cross-process counters become visible to the monitoring thread.

## Out of scope

In-process operation timing samples (`@operations`) stay in-process. They're a debugging aid, not a cross-process signal, and shipping per-lookup timing through Rails.cache would dwarf the underlying ops we're trying to measure.

## Test plan

- [x] `bundle exec rspec spec/services/categorization/pattern_cache_spec.rb spec/services/categorization/pattern_cache_unit_spec.rb` — 39 examples, 0 failures (3 new)
- [x] Full `bundle exec rspec spec/services/categorization/ spec/services/infrastructure/ --tag unit` — 1559 examples, 0 failures
- [x] `bundle exec rubocop` — green on changed files
- [x] Pre-commit hook (rubocop + brakeman + ~7800 unit specs) — green
- [ ] Operator: after `kamal deploy`, watch `kamal app logs` for the next monitoring tick. Expected: `Hit Rate: n/a (no lookups in window)` initially, then a real percentage once the next ProcessEmailJob runs through pattern matching.

## Related

- PER-548 / PR #508 / PR #509 — the LLM key rotation that unblocked categorization (separate fix)
- PR #433 — the auth circuit breaker that's been masking the LLM auth failure
- PER-550 — alert when LLM auth circuit opens (the *other* signal that needs human visibility)