### PR TITLE
cleanup(pattern-cache): rename :redis metric key to :l2

### DIFF
--- a/app/services/categorization/pattern_cache.rb
+++ b/app/services/categorization/pattern_cache.rb
@@ -442,8 +442,8 @@ module Services::Categorization
 
       # Detect L2 hit vs miss by tracking whether the fetch block ran. The
       # earlier comment claimed "we handle this when we promote to L1" but
-      # the actual record_hit(:redis) call was never wired up — the result
-      # was that every L2 hit went uncounted, which is what produced the
+      # the actual record_hit call was never wired up — the result was
+      # that every L2 hit went uncounted, which is what produced the
       # always-0% hit rate alert (PER-549).
       block_ran = false
       value = Rails.cache.fetch(key, expires_in: l2_ttl, race_condition_ttl: race_condition_ttl) do
@@ -453,7 +453,7 @@ module Services::Categorization
       end
 
       if value
-        @metrics_collector.record_hit(:redis) unless block_ran
+        @metrics_collector.record_hit(:l2) unless block_ran
         # Promote to L1 memory cache
         write_to_memory(key, value, memory_ttl)
       end
@@ -652,7 +652,7 @@ module Services::Categorization
         raise "reset_window! is a test helper; never invoke from production" if Rails.env.production?
 
         Rails.cache.delete("#{COUNTER_NAMESPACE}hits:memory:#{Date.current}")
-        Rails.cache.delete("#{COUNTER_NAMESPACE}hits:redis:#{Date.current}")
+        Rails.cache.delete("#{COUNTER_NAMESPACE}hits:l2:#{Date.current}")
         Rails.cache.delete("#{COUNTER_NAMESPACE}misses:#{Date.current}")
       end
 
@@ -691,7 +691,11 @@ module Services::Categorization
       end
 
       def hits
-        { memory: cache_read("hits:memory"), redis: cache_read("hits:redis") }
+        # Keys named after the cache layer they count, not the underlying
+        # store. PER-315 migrated L2 from Redis → Solid Cache; the hash
+        # key is :l2 to reflect that. (Pre-2026-05-03 the key was :redis
+        # — leftover from the Redis era.)
+        { memory: cache_read("hits:memory"), l2: cache_read("hits:l2") }
       end
 
       def misses_count

--- a/app/services/categorization/pattern_cache.rb
+++ b/app/services/categorization/pattern_cache.rb
@@ -376,7 +376,7 @@ module Services::Categorization
         memory_bytes: (metrics_data[:memory_cache_entries] || 0) * 1024, # Rough estimate
         # Sum the per-tier hash directly. Pre-PER-549 this read
         # `metrics_data.dig(:hits, :total)` but `:total` was never a key
-        # in the {memory:, redis:} shape, so #stats has been silently
+        # in the {memory:, l2:} shape, so #stats has been silently
         # returning hits=0 to dashboard helpers and the /api/health
         # endpoint since the metrics shape was introduced.
         hits: hits_hash.is_a?(Hash) ? hits_hash.values.sum : (hits_hash || 0),

--- a/lib/tasks/pattern_cache_monitor.rake
+++ b/lib/tasks/pattern_cache_monitor.rake
@@ -236,7 +236,7 @@ namespace :cache do
     metrics = cache.metrics
     puts "   Memory entries: #{metrics[:memory_cache_entries]}"
     puts "   Hit rate: #{cache.hit_rate}%"
-    puts "   Total hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :redis).to_i}"
+    puts "   Total hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :l2).to_i}"
     puts "   Total misses: #{metrics[:misses] || 0}"
   end
 end

--- a/lib/tasks/pattern_cache_monitor.rake
+++ b/lib/tasks/pattern_cache_monitor.rake
@@ -25,17 +25,17 @@ namespace :cache do
         puts "🏥 CACHE HEALTH"
         puts "-" * 30
         puts "Status: #{cache.healthy? ? '✅ Healthy' : '❌ Unhealthy'}"
-        puts "Redis Available: #{metrics[:redis_available] ? '✅ Yes' : '❌ No'}"
+        puts "L2 Cache Available: #{metrics[:l2_cache_available] ? '✅ Yes' : '❌ No'}"
         puts
 
         # Cache Statistics
         puts "📊 CACHE STATISTICS"
         puts "-" * 30
         puts "Memory Cache Entries: #{metrics[:memory_cache_entries]}"
-        puts "Hit Rate: #{cache.hit_rate}%"
-        puts "Total Hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :redis).to_i}"
-        puts "  - Memory Hits: #{metrics.dig(:hits, :memory) || 0}"
-        puts "  - Redis Hits: #{metrics.dig(:hits, :redis) || 0}"
+        puts "Hit Rate: #{cache.hit_rate.nil? ? 'n/a (no lookups in window)' : "#{cache.hit_rate}%"}"
+        puts "Total Hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :l2).to_i}"
+        puts "  - Memory (L1) Hits: #{metrics.dig(:hits, :memory) || 0}"
+        puts "  - L2 Hits: #{metrics.dig(:hits, :l2) || 0}"
         puts "Total Misses: #{metrics[:misses] || 0}"
         puts
 
@@ -44,7 +44,7 @@ namespace :cache do
         puts "-" * 30
         config = metrics[:configuration] || {}
         puts "Memory TTL: #{config[:memory_ttl]} seconds"
-        puts "Redis TTL: #{config[:redis_ttl]} seconds"
+        puts "L2 TTL: #{config[:l2_ttl]} seconds"
         puts "Max Memory Size: #{config[:max_memory_size]} KB"
         puts
 
@@ -115,17 +115,17 @@ namespace :cache do
     puts "🏥 CACHE HEALTH"
     puts "-" * 30
     puts "Status: #{cache.healthy? ? '✅ Healthy' : '❌ Unhealthy'}"
-    puts "Redis Available: #{metrics[:redis_available] ? '✅ Yes' : '❌ No'}"
+    puts "L2 Cache Available: #{metrics[:l2_cache_available] ? '✅ Yes' : '❌ No'}"
     puts
 
     # Cache Statistics
     puts "📊 CACHE STATISTICS"
     puts "-" * 30
     puts "Memory Cache Entries: #{metrics[:memory_cache_entries]}"
-    puts "Hit Rate: #{cache.hit_rate}%"
-    puts "Total Hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :redis).to_i}"
-    puts "  - Memory Hits: #{metrics.dig(:hits, :memory) || 0}"
-    puts "  - Redis Hits: #{metrics.dig(:hits, :redis) || 0}"
+    puts "Hit Rate: #{cache.hit_rate.nil? ? 'n/a (no lookups in window)' : "#{cache.hit_rate}%"}"
+    puts "Total Hits: #{metrics.dig(:hits, :memory).to_i + metrics.dig(:hits, :l2).to_i}"
+    puts "  - Memory (L1) Hits: #{metrics.dig(:hits, :memory) || 0}"
+    puts "  - L2 Hits: #{metrics.dig(:hits, :l2) || 0}"
     puts "Total Misses: #{metrics[:misses] || 0}"
     puts
 
@@ -134,7 +134,7 @@ namespace :cache do
     puts "-" * 30
     config = metrics[:configuration] || {}
     puts "Memory TTL: #{config[:memory_ttl]} seconds"
-    puts "Redis TTL: #{config[:redis_ttl]} seconds"
+    puts "L2 TTL: #{config[:l2_ttl]} seconds"
     puts "Max Memory Size: #{config[:max_memory_size]} KB"
     puts
 

--- a/spec/services/categorization/pattern_cache_spec.rb
+++ b/spec/services/categorization/pattern_cache_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
       ) { raise "block should not run on L2 hit" }
 
       hits = fresh_cache.metrics[:hits]
-      expect(hits[:redis]).to eq(1), "expected 1 L2 hit, got #{hits.inspect} (PER-549 regression)"
+      expect(hits[:l2]).to eq(1), "expected 1 L2 hit, got #{hits.inspect} (PER-549 regression)"
       expect(hits[:memory]).to eq(0)
     end
 
@@ -468,7 +468,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
       # The unit-style L2-hit spec above calls fetch_with_tiered_cache via
       # send to keep the assertion narrow. This sibling spec drives the
       # public API end-to-end: warm L1+L2 once, drop L1, then a second
-      # public call must hit L2 and increment :redis. Without this the
+      # public call must hit L2 and increment :l2. Without this the
       # narrow spec could silently rot if a future refactor inlined
       # Rails.cache.fetch outside fetch_with_tiered_cache.
       pattern  # create the AR record
@@ -479,7 +479,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
       fresh_cache.get_pattern(pattern.id)
 
       hits = fresh_cache.metrics[:hits]
-      expect(hits[:redis]).to eq(1), "expected an L2 hit via public API; got #{hits.inspect}"
+      expect(hits[:l2]).to eq(1), "expected an L2 hit via public API; got #{hits.inspect}"
       expect(hits[:memory]).to eq(0)
     end
 


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #510. PER-315 (completed 2026-03-31) migrated PatternCache's L2 from a raw Redis client to Solid Cache, but the metric key name `:redis` stuck around. PR #510's metric overhaul reproduced the misnomer in 3 new places (Rails.cache window key, hits hash shape, public-API spec assertions). This PR finishes the rename so the key reflects the architecture.

## Changes

- `record_hit(:redis)` → `record_hit(:l2)` in `fetch_with_tiered_cache`
- `hits[:redis]` → `hits[:l2]` in `MetricsCollector#hits`
- Window key `cat:metrics:hits:redis:DATE` → `cat:metrics:hits:l2:DATE`
- `reset_window!` deletes the new key
- Specs assert `hits[:l2]` instead of `hits[:redis]`
- `lib/tasks/pattern_cache_monitor.rake`:
  - "Redis Hits" → "L2 Hits"
  - "Redis TTL" → "L2 TTL"
  - "Redis Available" → "L2 Cache Available"
  - **drops dead reads** of `metrics[:redis_available]` / `config[:redis_ttl]` (the actual keys are `:l2_cache_available` / `:l2_ttl` — the rake task has been printing nil/false there for as long as those metrics existed)
  - hit_rate display now respects the nil-on-no-data semantics from PR #510

## Why this is safe

Cross-file review on PR #510 found no external consumer of `metrics[:hits][:redis]`. Window counters rotate daily anyway, so the rename loses today's L2 hit count and nothing else.

## Test plan

- [x] `bundle exec rspec spec/services/categorization/pattern_cache_spec.rb spec/services/categorization/pattern_cache_unit_spec.rb` — 33 unit + 41 perf examples, 0 failures
- [x] `bundle exec rubocop` — clean on touched files
- [x] Pre-commit hook (rubocop + brakeman + ~7800 unit specs) — green
- [ ] Operator: post-deploy, `bin/rails categorization:cache:monitor` should print "L2 Hits", "L2 TTL", "L2 Cache Available" and a real hit rate (or `n/a (no lookups in window)` immediately after warmer rotation)