### PR TITLE
perf(db): drop structurally redundant expenses indexes (PER-505)

### DIFF
--- a/db/migrate/20260501120000_drop_redundant_expenses_indexes.rb
+++ b/db/migrate/20260501120000_drop_redundant_expenses_indexes.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class DropRedundantExpensesIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    # 1. BRIN index on amount — structurally wrong type for a low-cardinality
+    #    decimal column with non-sequential distribution. BRIN is only useful for
+    #    physical-order-correlated append-only data (e.g. time-series IDs).
+    remove_index :expenses, name: "idx_expenses_amount_range", algorithm: :concurrently, if_exists: true
+
+    # 2. GIST trigram on merchant_normalized — redundant with the GIN trigram
+    #    index (idx_expenses_merchant_search). GIN outperforms GIST for
+    #    equality, LIKE, and containment queries; GIST's only advantage is
+    #    nearest-neighbour <-> operator which we don't use here.
+    remove_index :expenses, name: "index_expenses_merchant_similarity", algorithm: :concurrently, if_exists: true
+
+    # 3. Partial category+transaction_date index — idx_expenses_category_date
+    #    is (category_id, transaction_date) WHERE category_id IS NOT NULL AND
+    #    deleted_at IS NULL. The unfiltered index
+    #    index_expenses_on_category_id_and_transaction_date covers the same
+    #    column set with no restriction, making this partial index redundant:
+    #    the planner can use the broader index for any query that also matches
+    #    the partial predicate.
+    remove_index :expenses, name: "idx_expenses_category_date", algorithm: :concurrently, if_exists: true
+  end
+
+  def down
+    add_index :expenses, :amount,
+              name: "idx_expenses_amount_range",
+              using: :brin,
+              comment: "BRIN index for amount range queries",
+              algorithm: :concurrently
+
+    add_index :expenses, :merchant_normalized,
+              name: "index_expenses_merchant_similarity",
+              using: :gist,
+              opclass: :gist_trgm_ops,
+              where: "(merchant_normalized IS NOT NULL)",
+              algorithm: :concurrently
+
+    add_index :expenses, %i[category_id transaction_date],
+              name: "idx_expenses_category_date",
+              where: "((category_id IS NOT NULL) AND (deleted_at IS NULL))",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_232621) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -354,7 +354,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_232621) do
     t.index "EXTRACT(hour FROM transaction_date), EXTRACT(dow FROM transaction_date)", name: "idx_expenses_hour_dow"
     t.index "EXTRACT(year FROM transaction_date), EXTRACT(month FROM transaction_date)", name: "idx_expenses_year_month", where: "(deleted_at IS NULL)", comment: "For monthly/yearly aggregations"
     t.index ["amount", "transaction_date", "merchant_name"], name: "idx_expenses_manual_duplicate_check", unique: true, where: "((deleted_at IS NULL) AND (merchant_name IS NOT NULL) AND (email_account_id IS NULL))", comment: "Unique constraint for detecting duplicate manual expenses (email_account_id IS NULL)"
-    t.index ["amount"], name: "idx_expenses_amount_range", using: :brin, comment: "BRIN index for amount range queries"
     t.index ["auto_categorized", "categorization_confidence"], name: "idx_expenses_auto_categorization", where: "((auto_categorized = true) AND (deleted_at IS NULL))", comment: "Index for tracking auto-categorization"
     t.index ["bank_name", "transaction_date"], name: "idx_expenses_bank_date", where: "(deleted_at IS NULL)"
     t.index ["bank_name", "transaction_date"], name: "index_expenses_on_bank_name_and_transaction_date"
@@ -365,7 +364,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_232621) do
     t.index ["category_id", "created_at"], name: "idx_uncategorized_expenses", where: "(category_id IS NULL)"
     t.index ["category_id", "merchant_normalized"], name: "index_expenses_on_category_id_and_merchant_normalized"
     t.index ["category_id", "transaction_date", "amount"], name: "index_expenses_uncategorized", where: "(category_id IS NULL)"
-    t.index ["category_id", "transaction_date"], name: "idx_expenses_category_date", where: "((category_id IS NOT NULL) AND (deleted_at IS NULL))"
     t.index ["category_id", "transaction_date"], name: "idx_expenses_uncategorized", where: "((category_id IS NULL) AND (deleted_at IS NULL))", comment: "Index for finding uncategorized expenses"
     t.index ["category_id", "transaction_date"], name: "index_expenses_on_category_id_and_transaction_date"
     t.index ["created_at", "transaction_date"], name: "index_expenses_on_created_and_transaction_date"
@@ -377,7 +375,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_232621) do
     t.index ["merchant_normalized", "category_id"], name: "index_expenses_uncategorized_with_merchant", where: "((category_id IS NULL) AND (merchant_normalized IS NOT NULL))"
     t.index ["merchant_normalized", "transaction_date", "amount"], name: "index_expenses_on_merchant_date_amount"
     t.index ["merchant_normalized"], name: "idx_expenses_merchant_search", opclass: :gin_trgm_ops, where: "((merchant_normalized IS NOT NULL) AND (deleted_at IS NULL))", using: :gin, comment: "Trigram index for merchant name fuzzy search"
-    t.index ["merchant_normalized"], name: "index_expenses_merchant_similarity", opclass: :gist_trgm_ops, where: "(merchant_normalized IS NOT NULL)", using: :gist
     t.index ["status"], name: "index_expenses_on_status"
     t.index ["transaction_date", "category_id", "amount"], name: "idx_expenses_analytics", where: "(deleted_at IS NULL)", comment: "Covering index for date-based analytics"
     t.index ["updated_at", "category_id"], name: "idx_expenses_dashboard_metrics"


### PR DESCRIPTION
## Summary

Drops three structurally redundant indexes from the `expenses` table. All drops use `disable_ddl_transaction!` + `algorithm: :concurrently` for lock-free production execution.

## Indexes Dropped

| Dropped Index | Overlaps With | Reason |
|---|---|---|
| `idx_expenses_amount_range` (BRIN on `amount`) | No direct overlap — wrong type | BRIN only helps when physical row order correlates with column values (e.g. append-only time-series IDs). `amount` is a low-cardinality decimal with no physical ordering, so BRIN produces misleading planner statistics and adds write overhead with zero query benefit. |
| `index_expenses_merchant_similarity` (GIST trigram on `merchant_normalized`) | `idx_expenses_merchant_search` (GIN trigram on same column) | GIN strictly outperforms GIST for `LIKE`/containment/`@@` queries. GIST's only advantage is nearest-neighbour `<->` distance ordering, which is not used anywhere in this codebase. Keeping both means double write cost on every insert/update. |
| `idx_expenses_category_date` (`category_id, transaction_date` WHERE `category_id IS NOT NULL AND deleted_at IS NULL`) | `index_expenses_on_category_id_and_transaction_date` (same columns, no WHERE) | The partial index is a strict subset of the unfiltered index. PostgreSQL can use the broader index for any query that also satisfies the partial predicate, making the partial index redundant. |

## Indexes NOT Dropped (and why)

- `idx_expenses_bank_date` vs `index_expenses_on_bank_name_and_transaction_date`: similar column pair but the partial index has a `WHERE deleted_at IS NULL` filter that makes it useful for soft-delete-aware queries. Left for a future `pg_stat_user_indexes` sampling pass.
- `idx_expenses_uncategorized` / `index_expenses_uncategorized` / `idx_uncategorized_expenses`: these use different column sets and WHERE clauses; not structurally redundant without real usage data.

## Test plan

- [x] `RAILS_ENV=test bin/rails db:migrate` — exits 0, all three removes confirmed
- [x] `RAILS_ENV=test bin/rails db:rollback` — exits 0, all three indexes recreated
- [x] `db/schema.rb` updated: dropped index names no longer present
- [x] `bundle exec rubocop` — no offenses on migration file
- [x] Pre-commit hook passed: 7848 unit examples, 0 failures; Brakeman 0 warnings
- [x] `config/database.yml` NOT committed