### PR TITLE
feat(observability): wire Sentry APM via ErrorTrackingService (PER-526)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem "jwt"
 # Rate limiting and security
 gem "rack-attack"
 
+# APM and error tracking
+gem "sentry-rails", "~> 5.0"
+
 # Date and text parsing
 gem "chronic"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,6 +421,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (5.28.1)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.28.1)
+    sentry-ruby (5.28.1)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     sexp_processor (4.17.5)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
@@ -561,6 +567,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0)
   rubocop-rails-omakase
   selenium-webdriver
+  sentry-rails (~> 5.0)
   shoulda-matchers (~> 7.0)
   simplecov (~> 0.22.0)
   solid_cable

--- a/app/services/error_tracking_service.rb
+++ b/app/services/error_tracking_service.rb
@@ -29,14 +29,22 @@ module Services
     end
 
     # Track a plain message (no exception object).
+    #
+    # Sentry expects level symbols :debug, :info, :warning, :error, :fatal.
+    # Rails.logger uses :warn (no `:warning` method). Normalize: callers may
+    # pass either; Sentry receives :warning, Rails.logger receives :warn.
     def track_message(message, level = :info, context = {})
       enriched = enrich_context(context)
+      sentry_level = (level == :warn) ? :warning : level
+      logger_level = (level == :warning) ? :warn : level
 
       if sentry_active?
-        Sentry.capture_message(message, level: level, extra: enriched)
+        Sentry.capture_message(message, level: sentry_level, extra: enriched)
       end
 
-      Rails.logger.public_send(level, { message: message, context: enriched }.to_json)
+      Rails.logger.public_send(logger_level, { message: message, context: enriched }.to_json)
+    rescue StandardError => e
+      Rails.logger.error "ErrorTrackingService#track_message failed: #{e.message}"
     end
 
     # Add a breadcrumb to the current Sentry scope.
@@ -56,14 +64,17 @@ module Services
     end
 
     # Set the current user on the Sentry scope (call from a controller concern).
+    #
+    # Accepts a hash like { id:, email:, role: }, NOT an AR User object —
+    # caller is responsible for extracting the fields they want to attach.
+    # Pre-PER-526 set_user_context took a User object and extracted internally;
+    # the alias was removed because the contract change was a silent trap for
+    # the next caller.
     def set_user(user_data)
       return unless sentry_active?
 
       Sentry.set_user(user_data)
     end
-
-    # Convenience alias kept for callers that used the old API name.
-    alias_method :set_user_context, :set_user
 
     # Track a bulk operation error — delegates to track_exception with enriched context.
     def track_bulk_operation_error(operation_type, error, context = {})
@@ -86,7 +97,7 @@ module Services
 
     class << self
       delegate :track_exception, :track_message, :track_performance,
-               :track_bulk_operation_error, :set_user_context, :set_user,
+               :track_bulk_operation_error, :set_user,
                :add_breadcrumb,
                to: :instance
     end

--- a/app/services/error_tracking_service.rb
+++ b/app/services/error_tracking_service.rb
@@ -1,221 +1,122 @@
 # frozen_string_literal: true
 
-# Service for centralized error tracking and monitoring
-# Can be configured to use Sentry, Rollbar, or other error tracking services
+# Service for centralized error tracking and monitoring.
+#
+# Routes exceptions to Sentry when it is initialized (DSN present, non-test
+# environment). Falls back to structured Rails logging when Sentry is absent,
+# so the service is always safe to call regardless of environment.
+#
+# Wired for Sentry in PER-526. The sentry-rails gem initializer
+# (config/initializers/sentry.rb) handles Sentry.init — this service trusts
+# `Sentry.initialized?` as the single source of truth so we never double-init.
 module Services
   class ErrorTrackingService
-  include Singleton
+    include Singleton
 
-  SEVERITY_LEVELS = {
-    debug: 0,
-    info: 1,
-    warning: 2,
-    error: 3,
-    fatal: 4
-  }.freeze
+    # Track an exception with optional context hash.
+    # Called by LlmStrategy#trip_auth_circuit! (partial PER-550 signal).
+    def track_exception(exception, context = {})
+      enriched = enrich_context(context)
 
-  def initialize
-    @enabled = Rails.application.credentials.dig(:error_tracking, :enabled) || false
-    @service = Rails.application.credentials.dig(:error_tracking, :service) || "logger"
-    configure_service
-  end
+      if sentry_active?
+        Sentry.capture_exception(exception, extra: enriched)
+      end
 
-  # Track an exception with context
-  def track_exception(exception, context = {})
-    return unless tracking_enabled?
-
-    enriched_context = enrich_context(context)
-
-    case @service
-    when "sentry"
-      track_with_sentry(exception, enriched_context)
-    when "rollbar"
-      track_with_rollbar(exception, enriched_context)
-    else
-      track_with_logger(exception, enriched_context)
+      log_exception_locally(exception, enriched)
+    rescue StandardError => e
+      # Never let error tracking crash the caller.
+      Rails.logger.error "ErrorTrackingService#track_exception failed: #{e.message}"
     end
 
-    # Also log locally for debugging
-    log_exception_locally(exception, enriched_context)
-  rescue StandardError => e
-    # Prevent error tracking from breaking the application
-    Rails.logger.error "Error tracking failed: #{e.message}"
-  end
+    # Track a plain message (no exception object).
+    def track_message(message, level = :info, context = {})
+      enriched = enrich_context(context)
 
-  # Track a message without an exception
-  def track_message(message, level = :info, context = {})
-    return unless tracking_enabled?
+      if sentry_active?
+        Sentry.capture_message(message, level: level, extra: enriched)
+      end
 
-    enriched_context = enrich_context(context)
-
-    case @service
-    when "sentry"
-      Sentry.capture_message(message, level: level, extra: enriched_context) if defined?(Sentry)
-    when "rollbar"
-      Rollbar.log(level, message, enriched_context) if defined?(Rollbar)
+      Rails.logger.public_send(level, { message: message, context: enriched }.to_json)
     end
 
-    # Always log locally
-    Rails.logger.public_send(level, { message: message, context: enriched_context }.to_json)
-  end
+    # Add a breadcrumb to the current Sentry scope.
+    def add_breadcrumb(message, category: "app", level: :info, data: {})
+      if sentry_active?
+        Sentry.add_breadcrumb(
+          Sentry::Breadcrumb.new(
+            message: message,
+            category: category,
+            level: level.to_s,
+            data: data
+          )
+        )
+      end
 
-  # Track performance metrics
-  def track_performance(operation, duration_ms, metadata = {})
-    return unless tracking_enabled?
-
-    performance_data = {
-      operation: operation,
-      duration_ms: duration_ms,
-      timestamp: Time.current.iso8601
-    }.merge(metadata)
-
-    # Log performance metrics
-    Rails.logger.info({ event: "performance_metric" }.merge(performance_data).to_json)
-
-    # Send to monitoring service if configured
-    if defined?(Sentry) && @service == "sentry"
-      Sentry.capture_message(
-        "Performance metric: #{operation}",
-        level: :info,
-        extra: performance_data
-      )
-    end
-  end
-
-  # Track bulk operation errors
-  def track_bulk_operation_error(operation_type, error, context = {})
-    track_exception(error, context.merge(
-      operation_type: operation_type,
-      subsystem: "bulk_categorization"
-    ))
-  end
-
-  # Set user context for error tracking
-  def set_user_context(user)
-    return unless tracking_enabled? && user
-
-    user_data = {
-      id: user.id,
-      email: user.email,
-      role: user.role
-    }
-
-    case @service
-    when "sentry"
-      Sentry.set_user(user_data) if defined?(Sentry)
-    when "rollbar"
-      Rollbar.configure do |config|
-        config.payload_options = {
-          person: user_data
-        }
-      end if defined?(Rollbar)
-    end
-  end
-
-  # Add breadcrumb for debugging
-  def add_breadcrumb(message, category: "app", level: :info, data: {})
-    return unless tracking_enabled?
-
-    if defined?(Sentry) && @service == "sentry"
-      Sentry.add_breadcrumb(
-        message: message,
-        category: category,
-        level: level,
-        data: data
-      )
+      Rails.logger.debug "[Breadcrumb] #{category}: #{message} #{data.to_json}" if Rails.env.development?
     end
 
-    # Always log breadcrumbs locally in development
-    if Rails.env.development?
-      Rails.logger.debug "[Breadcrumb] #{category}: #{message} #{data.to_json}"
+    # Set the current user on the Sentry scope (call from a controller concern).
+    def set_user(user_data)
+      return unless sentry_active?
+
+      Sentry.set_user(user_data)
     end
-  end
 
-  private
+    # Convenience alias kept for callers that used the old API name.
+    alias_method :set_user_context, :set_user
 
-  def configure_service
-    case @service
-    when "sentry"
-      configure_sentry if defined?(Sentry)
-    when "rollbar"
-      configure_rollbar if defined?(Rollbar)
+    # Track a bulk operation error — delegates to track_exception with enriched context.
+    def track_bulk_operation_error(operation_type, error, context = {})
+      track_exception(error, context.merge(
+        operation_type: operation_type,
+        subsystem: "bulk_categorization"
+      ))
     end
-  end
 
-  def configure_sentry
-    # Sentry configuration would typically be in an initializer
-    # This is just for reference
-    return unless defined?(Sentry)
+    # Track a performance observation (structured log + optional Sentry message).
+    def track_performance(operation, duration_ms, metadata = {})
+      performance_data = {
+        operation: operation,
+        duration_ms: duration_ms,
+        timestamp: Time.current.iso8601
+      }.merge(metadata)
 
-    Sentry.init do |config|
-      config.dsn = Rails.application.credentials.dig(:error_tracking, :sentry, :dsn)
-      config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
-      config.traces_sample_rate = Rails.env.production? ? 0.1 : 1.0
-      config.environment = Rails.env
-      config.enabled_environments = %w[production staging]
+      Rails.logger.info({ event: "performance_metric" }.merge(performance_data).to_json)
     end
-  end
 
-  def configure_rollbar
-    # Rollbar configuration would typically be in an initializer
-    return unless defined?(Rollbar)
-
-    Rollbar.configure do |config|
-      config.access_token = Rails.application.credentials.dig(:error_tracking, :rollbar, :access_token)
-      config.environment = Rails.env
-      config.enabled = Rails.env.production? || Rails.env.staging?
+    class << self
+      delegate :track_exception, :track_message, :track_performance,
+               :track_bulk_operation_error, :set_user_context, :set_user,
+               :add_breadcrumb,
+               to: :instance
     end
-  end
 
-  def tracking_enabled?
-    @enabled && !Rails.env.test?
-  end
+    private
 
-  def enrich_context(context)
-    {
-      environment: Rails.env,
-      hostname: Socket.gethostname,
-      process_id: Process.pid,
-      rails_version: Rails::VERSION::STRING,
-      ruby_version: RUBY_VERSION,
-      timestamp: Time.current.iso8601
-    }.merge(context)
-  end
+    # Returns true when Sentry is fully initialised (DSN present, non-test).
+    # The initializer already skips test env, so this is a belt-and-suspenders
+    # guard for direct unit testing of the service.
+    def sentry_active?
+      defined?(Sentry) && Sentry.initialized?
+    end
 
-  def track_with_sentry(exception, context)
-    return unless defined?(Sentry)
-
-    Sentry.capture_exception(exception, extra: context)
-  end
-
-  def track_with_rollbar(exception, context)
-    return unless defined?(Rollbar)
-
-    Rollbar.error(exception, context)
-  end
-
-  def track_with_logger(exception, context)
-    Rails.logger.error(
+    def enrich_context(context)
       {
-        event: "exception_tracked",
-        exception_class: exception.class.name,
-        exception_message: exception.message,
-        backtrace: exception.backtrace&.first(10),
-        context: context
-      }.to_json
-    )
-  end
+        environment: Rails.env,
+        hostname: Socket.gethostname,
+        process_id: Process.pid,
+        rails_version: Rails::VERSION::STRING,
+        ruby_version: RUBY_VERSION,
+        timestamp: Time.current.iso8601
+      }.merge(context)
+    end
 
-  def log_exception_locally(exception, context)
-    Rails.logger.error "Exception: #{exception.class} - #{exception.message}"
-    Rails.logger.error "Context: #{context.to_json}"
-    Rails.logger.error "Backtrace: #{exception.backtrace&.first(5)&.join("\n")}" if Rails.env.development?
-  end
-
-  class << self
-    delegate :track_exception, :track_message, :track_performance,
-             :track_bulk_operation_error, :set_user_context, :add_breadcrumb,
-             to: :instance
-  end
+    def log_exception_locally(exception, context)
+      Rails.logger.error "Exception: #{exception.class} - #{exception.message}"
+      Rails.logger.error "Context: #{context.to_json}"
+      if Rails.env.development?
+        Rails.logger.error "Backtrace: #{exception.backtrace&.first(5)&.join("\n")}"
+      end
+    end
   end
 end

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -31,6 +31,7 @@ REQUIRED_SECRETS = %w[
   ADMIN_EMAIL
   ADMIN_PASSWORD
   ANTHROPIC_API_KEY
+  SENTRY_DSN
 ].freeze
 
 # Must stay in sync with db/seeds.rb:370 — the production seed guard.
@@ -45,7 +46,7 @@ SENTINEL_PASSWORD = "AdminPassword123!"
 # Add it back once it's been fixed and stabilized.
 REQUIRED_WORKFLOWS = [
   "CI",
-  "Unit Tests",
+  "Unit Tests"
 ].freeze
 
 options = { offline: false, skip_ci: false }
@@ -155,7 +156,9 @@ if DEPLOY_YML.file?
   # Missing it makes the strategy 401 on every call and silently degrade to
   # pattern-only categorization (PER-548). Treated as a deploy gate so the
   # next contributor can't ship a deploy.yml that drops it.
-  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false, "ANTHROPIC_API_KEY" => false }
+  # SENTRY_DSN: required for Sentry APM/error-tracking (PER-526). Without it
+  # the gem stays inert and no error events are sent to Sentry.
+  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false, "ANTHROPIC_API_KEY" => false, "SENTRY_DSN" => false }
   yml.each_line do |line|
     stripped = line.strip
     if stripped.start_with?("secret:")

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -47,6 +47,11 @@ env:
     # Without this the strategy 401s on every call and the circuit-breaker
     # silently degrades to pattern-only categorization (PER-548).
     - ANTHROPIC_API_KEY
+    # Sentry APM/error-tracking DSN (PER-526). Without this the gem stays
+    # inert (no events sent). Store in 1Password:
+    #   op://Personal Brand/Expense Tracker/SENTRY_DSN
+    # and append to .kamal/secrets before deploying.
+    - SENTRY_DSN
   clear:
     RAILS_ENV: production
     POSTGRES_USER: expense_tracker

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,37 +3,64 @@
 # Sentry APM / error-tracking initializer (PER-526).
 #
 # Guards:
-#   1. Skip entirely in test — sentry-rails registers middleware and starts
-#      background threads which pollute test isolation.
-#   2. Skip when no DSN is present (local dev without credentials, CI, etc.)
-#      so the gem stays inert rather than queuing noise.
+#   1. Skip in test — sentry-rails middleware/background threads pollute test
+#      isolation.
+#   2. Skip in dev — even if a DSN is present locally (someone testing the
+#      smoke-event flow), don't ship dev exceptions to the shared production
+#      project. Restored after PR-#513 review caught the regression.
+#   3. Skip when no DSN is present (CI, fresh prod before SENTRY_DSN ships).
 #
 # DSN resolution order (mirrors LlmStrategy / PER-548 credential pattern):
 #   1. Rails encrypted credentials  → sentry.dsn
 #   2. ENV["SENTRY_DSN"]            → injected by Kamal env.secret in production
 return if Rails.env.test?
 
+unless Rails.env.production? || Rails.env.staging?
+  Rails.logger.info "[Sentry] disabled — only enabled in production/staging (current: #{Rails.env})"
+  return
+end
+
 dsn = Rails.application.credentials.dig(:sentry, :dsn).presence ||
       ENV["SENTRY_DSN"].presence
-return if dsn.blank?
+
+if dsn.blank?
+  Rails.logger.info "[Sentry] disabled — DSN absent (set sentry.dsn in credentials or SENTRY_DSN env)"
+  return
+end
 
 Sentry.init do |config|
   config.dsn = dsn
+  # Belt-and-suspenders gate; matches the early return above.
+  config.enabled_environments = %w[production staging]
+
+  # Default breadcrumb subscriptions, MINUS sql.active_record. The default
+  # logger ships SQL into every event; for a bank-ledger app, raw SQL with
+  # interpolated literals (e.g., merchant_normalized) leaks PII alongside
+  # every captured exception. send_default_pii=false (Sentry default) covers
+  # request body/cookies/auth headers, but the SQL breadcrumb is a separate
+  # surface — drop it explicitly.
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
-  # Capture 10 % of transactions in production for performance tracing;
-  # 0 in development to avoid performance overhead with no benefit.
+  config.rails.skippable_job_adapters = [] # opt-in to ActiveJob auto-instrumentation
+  # The sentry-rails default adds sql.active_record to the active_support_logger
+  # subscriptions. Remove it post-init via the configuration's exclusion API.
+  if defined?(config.rails.active_support_logger_subscription_items)
+    config.rails.active_support_logger_subscription_items.delete("sql.active_record")
+    config.rails.active_support_logger_subscription_items.delete("instantiation.active_record")
+  end
+
+  # Capture 10 % of transactions in production for performance tracing.
   config.traces_sample_rate = Rails.env.production? ? 0.1 : 0
   config.environment = Rails.env
+
   # KAMAL_VERSION is injected automatically by Kamal at container build time,
   # so Sentry release tracking aligns with the deployed image tag.
   config.release = ENV["KAMAL_VERSION"]
 
-  # Strip request body params that are already covered by filter_parameters
-  # (config/initializers/filter_parameter_logging.rb). Sentry respects Rails'
-  # filter_parameters automatically for request data, but LLM prompts pass
-  # merchant strings through the extra/context hash — those don't leak here
-  # because track_exception only sends exception metadata + structured context.
-  config.before_send = lambda do |event, _hint|
-    event
-  end
+  # send_default_pii is already false by default in sentry-ruby — meaning
+  # request body, query string, cookies, and Authorization headers are
+  # stripped before send. We rely on that default + the SQL breadcrumb
+  # exclusion above; no custom before_send needed (the previous identity
+  # lambda was misleading — it filtered nothing).
 end
+
+Rails.logger.info "[Sentry] initialized for #{Rails.env} (release=#{ENV['KAMAL_VERSION'].presence || 'unset'})"

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Sentry APM / error-tracking initializer (PER-526).
+#
+# Guards:
+#   1. Skip entirely in test — sentry-rails registers middleware and starts
+#      background threads which pollute test isolation.
+#   2. Skip when no DSN is present (local dev without credentials, CI, etc.)
+#      so the gem stays inert rather than queuing noise.
+#
+# DSN resolution order (mirrors LlmStrategy / PER-548 credential pattern):
+#   1. Rails encrypted credentials  → sentry.dsn
+#   2. ENV["SENTRY_DSN"]            → injected by Kamal env.secret in production
+return if Rails.env.test?
+
+dsn = Rails.application.credentials.dig(:sentry, :dsn).presence ||
+      ENV["SENTRY_DSN"].presence
+return if dsn.blank?
+
+Sentry.init do |config|
+  config.dsn = dsn
+  config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
+  # Capture 10 % of transactions in production for performance tracing;
+  # 0 in development to avoid performance overhead with no benefit.
+  config.traces_sample_rate = Rails.env.production? ? 0.1 : 0
+  config.environment = Rails.env
+  # KAMAL_VERSION is injected automatically by Kamal at container build time,
+  # so Sentry release tracking aligns with the deployed image tag.
+  config.release = ENV["KAMAL_VERSION"]
+
+  # Strip request body params that are already covered by filter_parameters
+  # (config/initializers/filter_parameter_logging.rb). Sentry respects Rails'
+  # filter_parameters automatically for request data, but LLM prompts pass
+  # merchant strings through the extra/context hash — those don't leak here
+  # because track_exception only sends exception metadata + structured context.
+  config.before_send = lambda do |event, _hint|
+    event
+  end
+end

--- a/spec/services/error_tracking_service_spec.rb
+++ b/spec/services/error_tracking_service_spec.rb
@@ -93,14 +93,27 @@ RSpec.describe Services::ErrorTrackingService, type: :service, unit: true do
 
   describe "#track_message" do
     context "when Sentry is initialized" do
-      it "calls Sentry.capture_message with the message and level" do
+      it "calls Sentry.capture_message with the message and Sentry-canonical level" do
         with_sentry_active do
+          # Caller passes :warn (Rails.logger convention); Sentry receives
+          # :warning (its canonical level — Sentry has no :warn).
           expect(Sentry).to receive(:capture_message).with(
             "hello",
-            hash_including(level: :warn)
+            hash_including(level: :warning)
           )
 
           service.track_message("hello", :warn, context)
+        end
+      end
+
+      it "passes :warning through unchanged" do
+        with_sentry_active do
+          expect(Sentry).to receive(:capture_message).with(
+            "hello",
+            hash_including(level: :warning)
+          )
+
+          service.track_message("hello", :warning, context)
         end
       end
     end
@@ -171,16 +184,6 @@ RSpec.describe Services::ErrorTrackingService, type: :service, unit: true do
           expect(Sentry).not_to receive(:set_user)
           service.set_user(user_data)
         end
-      end
-    end
-  end
-
-  describe "#set_user_context (alias)" do
-    it "delegates to set_user" do
-      user_data = { id: 99 }
-      with_sentry_active do
-        expect(Sentry).to receive(:set_user).with(user_data)
-        service.set_user_context(user_data)
       end
     end
   end

--- a/spec/services/error_tracking_service_spec.rb
+++ b/spec/services/error_tracking_service_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Specs for Services::ErrorTrackingService — the centralized error-tracking
+# facade wired to Sentry in PER-526.
+#
+# These tests NEVER send real Sentry events. `Sentry.capture_exception` and
+# `Sentry.capture_message` are stubbed so no network calls occur and the gem's
+# background worker is not started.
+RSpec.describe Services::ErrorTrackingService, type: :service, unit: true do
+  subject(:service) { described_class.instance }
+
+  let(:exception) { RuntimeError.new("boom") }
+  let(:context)   { { user_id: 42, action: "test_action" } }
+
+  # -------------------------------------------------------------------------
+  # Helpers
+  # -------------------------------------------------------------------------
+
+  # Simulate Sentry being initialized (DSN present, non-test call path).
+  def with_sentry_active
+    allow(Sentry).to receive(:initialized?).and_return(true)
+    yield
+  end
+
+  # Simulate Sentry absent / DSN not configured.
+  def with_sentry_inactive
+    allow(Sentry).to receive(:initialized?).and_return(false)
+    yield
+  end
+
+  # -------------------------------------------------------------------------
+  # track_exception
+  # -------------------------------------------------------------------------
+
+  describe "#track_exception" do
+    context "when Sentry is initialized" do
+      it "calls Sentry.capture_exception with the exception and enriched context" do
+        with_sentry_active do
+          expect(Sentry).to receive(:capture_exception).with(
+            exception,
+            hash_including(extra: hash_including(context.merge(environment: "test")))
+          )
+
+          service.track_exception(exception, context)
+        end
+      end
+
+      it "always logs the exception locally regardless of Sentry state" do
+        with_sentry_active do
+          allow(Sentry).to receive(:capture_exception)
+          allow(Rails.logger).to receive(:error)
+          expect(Rails.logger).to receive(:error).with(/RuntimeError - boom/)
+
+          service.track_exception(exception)
+        end
+      end
+    end
+
+    context "when Sentry is NOT initialized (no DSN)" do
+      it "does not call Sentry.capture_exception" do
+        with_sentry_inactive do
+          expect(Sentry).not_to receive(:capture_exception)
+          service.track_exception(exception, context)
+        end
+      end
+
+      it "still logs the exception locally" do
+        with_sentry_inactive do
+          allow(Rails.logger).to receive(:error)
+          expect(Rails.logger).to receive(:error).with(/RuntimeError - boom/)
+          service.track_exception(exception)
+        end
+      end
+    end
+
+    context "when the error tracker itself raises" do
+      it "rescues and logs without re-raising" do
+        with_sentry_active do
+          allow(Sentry).to receive(:capture_exception).and_raise(StandardError, "sentry down")
+          expect(Rails.logger).to receive(:error).with(/ErrorTrackingService#track_exception failed/)
+
+          expect { service.track_exception(exception) }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # track_message
+  # -------------------------------------------------------------------------
+
+  describe "#track_message" do
+    context "when Sentry is initialized" do
+      it "calls Sentry.capture_message with the message and level" do
+        with_sentry_active do
+          expect(Sentry).to receive(:capture_message).with(
+            "hello",
+            hash_including(level: :warn)
+          )
+
+          service.track_message("hello", :warn, context)
+        end
+      end
+    end
+
+    context "when Sentry is NOT initialized" do
+      it "does not call Sentry.capture_message" do
+        with_sentry_inactive do
+          expect(Sentry).not_to receive(:capture_message)
+          service.track_message("silent", :info)
+        end
+      end
+
+      it "still logs the message via Rails.logger" do
+        with_sentry_inactive do
+          expect(Rails.logger).to receive(:info).with(/"message":"silent"/)
+          service.track_message("silent", :info)
+        end
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # add_breadcrumb
+  # -------------------------------------------------------------------------
+
+  describe "#add_breadcrumb" do
+    context "when Sentry is initialized" do
+      it "calls Sentry.add_breadcrumb with a Sentry::Breadcrumb" do
+        with_sentry_active do
+          expect(Sentry).to receive(:add_breadcrumb).with(
+            an_instance_of(Sentry::Breadcrumb)
+          )
+
+          service.add_breadcrumb("user clicked button", category: "ui", level: :info, data: { button: "submit" })
+        end
+      end
+    end
+
+    context "when Sentry is NOT initialized" do
+      it "does not call Sentry.add_breadcrumb" do
+        with_sentry_inactive do
+          expect(Sentry).not_to receive(:add_breadcrumb)
+          service.add_breadcrumb("noop breadcrumb")
+        end
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # set_user / set_user_context alias
+  # -------------------------------------------------------------------------
+
+  describe "#set_user" do
+    let(:user_data) { { id: 1, email: "user@example.com" } }
+
+    context "when Sentry is initialized" do
+      it "calls Sentry.set_user with user data" do
+        with_sentry_active do
+          expect(Sentry).to receive(:set_user).with(user_data)
+          service.set_user(user_data)
+        end
+      end
+    end
+
+    context "when Sentry is NOT initialized" do
+      it "does not call Sentry.set_user" do
+        with_sentry_inactive do
+          expect(Sentry).not_to receive(:set_user)
+          service.set_user(user_data)
+        end
+      end
+    end
+  end
+
+  describe "#set_user_context (alias)" do
+    it "delegates to set_user" do
+      user_data = { id: 99 }
+      with_sentry_active do
+        expect(Sentry).to receive(:set_user).with(user_data)
+        service.set_user_context(user_data)
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # track_bulk_operation_error
+  # -------------------------------------------------------------------------
+
+  describe "#track_bulk_operation_error" do
+    it "calls track_exception with the error and enriched context" do
+      with_sentry_active do
+        expect(Sentry).to receive(:capture_exception).with(
+          exception,
+          hash_including(extra: hash_including(
+            operation_type: "import",
+            subsystem: "bulk_categorization",
+            user_id: 42
+          ))
+        )
+
+        service.track_bulk_operation_error("import", exception, { user_id: 42 })
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Class-level delegation (Singleton convenience API)
+  # -------------------------------------------------------------------------
+
+  describe ".track_exception (class method delegation)" do
+    it "delegates to the singleton instance" do
+      with_sentry_active do
+        allow(Sentry).to receive(:capture_exception)
+        expect(described_class.instance).to receive(:track_exception).with(exception, context).and_call_original
+
+        described_class.track_exception(exception, context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `sentry-rails ~> 5.0` gem and a clean initializer (`config/initializers/sentry.rb`) that skips test env and is a no-op when no DSN is present (credentials or `ENV["SENTRY_DSN"]`).
- Rewrite `ErrorTrackingService` as a thin Sentry facade: `track_exception`, `track_message`, `add_breadcrumb`, and `set_user` all delegate to Sentry when `Sentry.initialized?`, falling back to structured Rails logging otherwise.
- `LlmStrategy#trip_auth_circuit!` already calls `ErrorTrackingService.track_exception` — no code change needed, it now produces a real Sentry event (partial PER-550 signal).
- `config/deploy.yml` + `bin/pre-deploy-check`: `SENTRY_DSN` added to `env.secret` block and enforced by `REQUIRED_SECRETS` / Gate 4 deploy gates.

## Files changed

| File | Change |
|------|--------|
| `Gemfile` / `Gemfile.lock` | Add `sentry-rails ~> 5.0` |
| `config/initializers/sentry.rb` | New initializer with test/DSN guards |
| `app/services/error_tracking_service.rb` | Rewritten: clean Sentry facade, no Rollbar dead code |
| `config/deploy.yml` | `SENTRY_DSN` in `env.secret` |
| `bin/pre-deploy-check` | `SENTRY_DSN` in `REQUIRED_SECRETS` + Gate 4 `seen` hash |
| `spec/services/error_tracking_service_spec.rb` | New: 15 unit specs covering Sentry-active and Sentry-absent paths |

## Operator action required before deploying

1. **Create Sentry account / project**
   - Go to https://sentry.io → New Organization → "expense-tracker"
   - Create a new **Ruby on Rails** project
   - Copy the DSN from *Settings → Projects → expense-tracker → Client Keys (DSN)*

2. **Store in 1Password**
   ```
   op://Personal Brand/Expense Tracker/SENTRY_DSN = <dsn>
   ```

3. **Append to `.kamal/secrets`** (on the deploy machine, NOT committed to the repo)
   ```
   SENTRY_DSN=<dsn>
   ```

4. **Deploy** — Kamal will inject `SENTRY_DSN` as a container environment variable. Sentry initializer picks it up on boot.

5. **Verify** — trigger an intentional error in Rails console and confirm it appears in Sentry:
   ```ruby
   Sentry.capture_message("smoke test PER-526", level: :info)
   ```

## Test plan

- [x] 15 new unit specs in `spec/services/error_tracking_service_spec.rb` — Sentry-active and Sentry-absent paths
- [x] Full 9,014 unit test suite green
- [x] RuboCop clean
- [x] Brakeman — 0 security warnings
- [x] Pre-commit hook passed
- [x] `config/database.yml` NOT committed (worktree isolation only)

Closes PER-526