### PR TITLE
feat(security): encrypt Expense#raw_email_content (PER-533)

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -13,6 +13,15 @@ class Expense < ApplicationRecord
   has_many :pattern_learning_events, dependent: :destroy
   has_many :bulk_operation_items, dependent: :destroy
 
+  # PER-533: raw_email_content holds bank PII (amounts, merchants, account
+  # refs, recipient addresses, transaction times). Encrypt at rest to match
+  # PER-496 parity with EmailParsingFailure.
+  # support_unencrypted_data: true keeps existing plaintext rows readable
+  # until the backfill rake task (encrypt:expense_raw_email) has been run.
+  # TODO(PER-534): Remove support_unencrypted_data once all rows are encrypted
+  # (30+ days after this PR reaches production).
+  encrypts :raw_email_content, support_unencrypted_data: true
+
   # Enums
   enum :currency, { crc: 0, usd: 1, eur: 2 }
   enum :status, { pending: 0, processed: 1, failed: 2, duplicate: 3 }

--- a/lib/tasks/encrypt_expense_raw_email.rake
+++ b/lib/tasks/encrypt_expense_raw_email.rake
@@ -6,15 +6,14 @@
 # Usage:
 #   bin/rails encrypt:expense_raw_email
 #
-# This task is idempotent — re-running it safely skips already-encrypted rows.
-# A row is considered already encrypted when its raw column value starts with
-# the ActiveRecord::Encryption header prefix "{".
+# Idempotent — re-running it scans only plaintext rows (filtered at the SQL
+# layer, no per-row probe) and is a no-op once everything is encrypted.
 #
-# It processes rows in batches of 1000 with a small sleep between batches to
-# avoid saturating the database in production.
+# Includes soft-deleted rows (Expense.unscoped). Soft-deleted expenses still
+# carry the same bank PII; encryption parity covers them too.
 #
 # TODO(PER-534): Once all rows are confirmed encrypted (30+ days after this
-# rake task runs in production), remove support_unencrypted_data: true from
+# task runs in production), remove support_unencrypted_data: true from
 # Expense#raw_email_content and delete this task.
 
 namespace :encrypt do
@@ -25,61 +24,56 @@ namespace :encrypt do
 
     total     = 0
     encrypted = 0
-    skipped   = 0
     errored   = 0
 
     start_time = Time.current
     Rails.logger.info "[PER-533] Starting Expense#raw_email_content encryption backfill"
     puts "[PER-533] Starting Expense#raw_email_content encryption backfill"
 
-    # Query the raw column via SQL to identify truly plaintext rows.
-    # An already-encrypted row's raw column value begins with the JSON header
-    # that ActiveRecord::Encryption writes (e.g. {"p":"..."}). We check for
-    # rows where the raw value does NOT start with "{" — those are plaintext.
-    Expense.in_batches(of: batch_size) do |batch|
-      batch.each do |expense|
-        total += 1
+    # Pre-filter at the DB layer: only rows whose raw column value is
+    # plaintext. AR::Encryption ciphertext serializes as a JSON envelope
+    # starting with `{"p":` (the payload header). A NOT LIKE check on the
+    # short prefix is sargable enough and lets re-runs short-circuit at the
+    # WHERE clause instead of probing every row. unscoped covers
+    # soft-deleted expenses whose default_scope would otherwise hide them.
+    Expense.unscoped
+           .where.not(raw_email_content: nil)
+           .where("raw_email_content NOT LIKE ?", '{"p":%')
+           .find_each(batch_size: batch_size) do |expense|
+      total += 1
 
-        raw_value = ActiveRecord::Base.connection.execute(
-          "SELECT raw_email_content FROM expenses WHERE id = #{expense.id}"
-        ).first&.fetch("raw_email_content", nil)
+      # AR Encryption with support_unencrypted_data: true returns the
+      # plaintext for legacy rows on read. Re-assign and save with
+      # validate: false to:
+      #   - go through the AR Encryption write path (correct ciphertext
+      #     envelope produced by the attribute type)
+      #   - skip validations (legacy rows may fail rules added later;
+      #     we don't want them to orphan plaintext)
+      #   - run callbacks (no-ops here: clear_dashboard_cache and
+      #     trigger_metrics_refresh both gate on columns we aren't
+      #     touching, and the before_save normalizers are idempotent)
+      plaintext = expense.raw_email_content
+      expense.raw_email_content = plaintext
+      expense.send(:raw_email_content_will_change!)
+      expense.save(validate: false)
+      encrypted += 1
 
-        # Skip rows with no raw email content
-        if raw_value.nil?
-          skipped += 1
-          next
-        end
-
-        # Skip rows that already have ciphertext (header starts with "{")
-        if raw_value.start_with?("{")
-          skipped += 1
-          next
-        end
-
-        # Re-assign the attribute so AR Encryption marks it dirty and writes
-        # the ciphertext on save. Without this, AR skips the column update
-        # because the decrypted value matches what's already in memory.
-        # We reload first to ensure AR reads the plaintext from the raw column
-        # before we reassign, then force the attribute change via clear_attribute_change.
-        expense.reload
-        expense.raw_email_content = raw_value
-        # Mark as changed even if the decoded value appears identical —
-        # AR Encryption may otherwise skip the write because the String
-        # objects compare equal.
-        expense.send(:raw_email_content_will_change!)
-        expense.save!
-        encrypted += 1
-      rescue StandardError => e
-        errored += 1
-        Rails.logger.error "[PER-533] Error encrypting Expense id=#{expense.id}: #{e.message}"
+      if total % batch_size == 0
+        progress = "[PER-533] processed=#{total} encrypted=#{encrypted} errored=#{errored}"
+        Rails.logger.info progress
+        puts progress
+        sleep(sleep_seconds) if sleep_seconds > 0
       end
-
-      sleep(sleep_seconds) if sleep_seconds > 0
+    rescue StandardError => e
+      errored += 1
+      # Log only the exception class — `e.message` may interpolate the
+      # column value (PG::ValueTooLong, custom validation messages),
+      # which would echo plaintext bank PII into production.log.
+      Rails.logger.error "[PER-533] Error encrypting Expense id=#{expense&.id}: #{e.class}"
     end
 
     elapsed = (Time.current - start_time).round(1)
-    summary = "[PER-533] Done. total=#{total} encrypted=#{encrypted} " \
-              "skipped=#{skipped} errored=#{errored} elapsed=#{elapsed}s"
+    summary = "[PER-533] Done. total=#{total} encrypted=#{encrypted} errored=#{errored} elapsed=#{elapsed}s"
     Rails.logger.info summary
     puts summary
   end

--- a/lib/tasks/encrypt_expense_raw_email.rake
+++ b/lib/tasks/encrypt_expense_raw_email.rake
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# PER-533: Backfill rake task to encrypt Expense#raw_email_content rows that
+# were written as plaintext before the encrypts declaration was deployed.
+#
+# Usage:
+#   bin/rails encrypt:expense_raw_email
+#
+# This task is idempotent — re-running it safely skips already-encrypted rows.
+# A row is considered already encrypted when its raw column value starts with
+# the ActiveRecord::Encryption header prefix "{".
+#
+# It processes rows in batches of 1000 with a small sleep between batches to
+# avoid saturating the database in production.
+#
+# TODO(PER-534): Once all rows are confirmed encrypted (30+ days after this
+# rake task runs in production), remove support_unencrypted_data: true from
+# Expense#raw_email_content and delete this task.
+
+namespace :encrypt do
+  desc "Backfill encryption for Expense#raw_email_content (PER-533)"
+  task expense_raw_email: :environment do
+    batch_size    = 1_000
+    sleep_seconds = 0.1
+
+    total     = 0
+    encrypted = 0
+    skipped   = 0
+    errored   = 0
+
+    start_time = Time.current
+    Rails.logger.info "[PER-533] Starting Expense#raw_email_content encryption backfill"
+    puts "[PER-533] Starting Expense#raw_email_content encryption backfill"
+
+    # Query the raw column via SQL to identify truly plaintext rows.
+    # An already-encrypted row's raw column value begins with the JSON header
+    # that ActiveRecord::Encryption writes (e.g. {"p":"..."}). We check for
+    # rows where the raw value does NOT start with "{" — those are plaintext.
+    Expense.in_batches(of: batch_size) do |batch|
+      batch.each do |expense|
+        total += 1
+
+        raw_value = ActiveRecord::Base.connection.execute(
+          "SELECT raw_email_content FROM expenses WHERE id = #{expense.id}"
+        ).first&.fetch("raw_email_content", nil)
+
+        # Skip rows with no raw email content
+        if raw_value.nil?
+          skipped += 1
+          next
+        end
+
+        # Skip rows that already have ciphertext (header starts with "{")
+        if raw_value.start_with?("{")
+          skipped += 1
+          next
+        end
+
+        # Re-assign the attribute so AR Encryption marks it dirty and writes
+        # the ciphertext on save. Without this, AR skips the column update
+        # because the decrypted value matches what's already in memory.
+        # We reload first to ensure AR reads the plaintext from the raw column
+        # before we reassign, then force the attribute change via clear_attribute_change.
+        expense.reload
+        expense.raw_email_content = raw_value
+        # Mark as changed even if the decoded value appears identical —
+        # AR Encryption may otherwise skip the write because the String
+        # objects compare equal.
+        expense.send(:raw_email_content_will_change!)
+        expense.save!
+        encrypted += 1
+      rescue StandardError => e
+        errored += 1
+        Rails.logger.error "[PER-533] Error encrypting Expense id=#{expense.id}: #{e.message}"
+      end
+
+      sleep(sleep_seconds) if sleep_seconds > 0
+    end
+
+    elapsed = (Time.current - start_time).round(1)
+    summary = "[PER-533] Done. total=#{total} encrypted=#{encrypted} " \
+              "skipped=#{skipped} errored=#{errored} elapsed=#{elapsed}s"
+    Rails.logger.info summary
+    puts summary
+  end
+end

--- a/spec/models/expense_encryption_spec.rb
+++ b/spec/models/expense_encryption_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# PER-533: raw_email_content contains bank PII (amounts, merchants, account
+# refs, transaction times) — must be encrypted at rest, matching PER-496 for
+# EmailParsingFailure.
+RSpec.describe Expense, :unit, type: :model do
+  describe "encryption of raw_email_content" do
+    it "declares raw_email_content as an encrypted attribute" do
+      expect(described_class.type_for_attribute(:raw_email_content).class).to be(
+        ActiveRecord::Encryption::EncryptedAttributeType
+      )
+    end
+
+    it "round-trips plaintext through encrypt/decrypt transparently" do
+      expense = create(:expense, :with_raw_email,
+                       raw_email_content: "BAC: Cargo por ₡12345.67 a SUPERMERCADO")
+      expense.reload
+      expect(expense.raw_email_content).to eq("BAC: Cargo por ₡12345.67 a SUPERMERCADO")
+    end
+
+    it "stores ciphertext in the underlying column (not plaintext)" do
+      plaintext = "sensitive bank content #{SecureRandom.hex(8)}"
+      expense = create(:expense, :with_raw_email, raw_email_content: plaintext)
+
+      raw_row = ActiveRecord::Base.connection.execute(
+        "SELECT raw_email_content FROM expenses WHERE id = #{expense.id}"
+      ).first
+      expect(raw_row["raw_email_content"]).not_to include(plaintext)
+      expect(raw_row["raw_email_content"]).to be_present
+    end
+
+    # support_unencrypted_data: true keeps legacy plaintext rows readable while
+    # the backfill runs. Raw SQL bypasses the AR Encryption layer, simulating
+    # a row written to the database before the encrypts declaration was deployed.
+    it "reads existing plaintext rows via support_unencrypted_data: true" do
+      expense = create(:expense, :with_raw_email)
+      ActiveRecord::Base.connection.execute(
+        "UPDATE expenses SET raw_email_content = 'legacy plaintext body' WHERE id = #{expense.id}"
+      )
+
+      expect(expense.reload.raw_email_content).to eq("legacy plaintext body")
+    end
+
+    # MonitoringService#email_processing_metrics (line 781) queries:
+    #   Expense.where(...).where.not(raw_email_content: nil).count
+    # Non-deterministic encryption writes non-null ciphertext, so this presence
+    # check must still return a truthy count after encryption.
+    it "presence query .where.not(raw_email_content: nil) still counts encrypted rows" do
+      email_account = create(:email_account)
+      user = email_account.user
+
+      # Create two expenses — one with content, one without
+      create(:expense, email_account:, user:, raw_email_content: "bank email body #{SecureRandom.hex}")
+      create(:expense, email_account:, user:, raw_email_content: nil)
+
+      count = described_class
+                .where(user_id: user.id)
+                .where.not(raw_email_content: nil)
+                .count
+
+      expect(count).to eq(1)
+    end
+  end
+end

--- a/spec/tasks/encrypt_expense_raw_email_rake_spec.rb
+++ b/spec/tasks/encrypt_expense_raw_email_rake_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "encrypt:expense_raw_email", :unit, type: :task do
     Rake.application = rake_app
     Rake::Task.define_task(:environment)
     load Rails.root.join("lib/tasks/encrypt_expense_raw_email.rake")
-    allow(Rake::Task["encrypt:expense_raw_email"]).to receive(:reenable).and_call_original
   end
 
   after { Rake::Task.clear }
@@ -24,43 +23,55 @@ RSpec.describe "encrypt:expense_raw_email", :unit, type: :task do
   end
 
   def raw_column_value(expense)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql([
+        "SELECT raw_email_content FROM expenses WHERE id = ?", expense.id
+      ])
+    )
+  end
+
+  def seed_plaintext(expense, plaintext)
+    # Bypass AR Encryption with raw SQL to simulate a legacy plaintext row
+    # written before the encrypts declaration shipped.
     ActiveRecord::Base.connection.execute(
-      "SELECT raw_email_content FROM expenses WHERE id = #{expense.id}"
-    ).first["raw_email_content"]
+      ActiveRecord::Base.sanitize_sql([
+        "UPDATE expenses SET raw_email_content = ? WHERE id = ?", plaintext, expense.id
+      ])
+    )
   end
 
   it "encrypts plaintext rows on first run" do
     expense = create(:expense)
-    # Bypass AR Encryption with raw SQL to simulate a row written before the
-    # encrypts declaration (i.e. a legacy plaintext production row).
-    ActiveRecord::Base.connection.execute(
-      "UPDATE expenses SET raw_email_content = 'plaintext body content' WHERE id = #{expense.id}"
-    )
+    seed_plaintext(expense, "plaintext body content")
 
     expect { run_task }.not_to raise_error
 
-    # After the task runs, the raw column should contain ciphertext
     raw = raw_column_value(expense.reload)
-    expect(raw).to start_with("{")
-    # And the model should still decrypt it transparently
+    expect(raw).to start_with('{"p":')
+    # AR transparently decrypts on read
     expect(expense.reload.raw_email_content).to eq("plaintext body content")
   end
 
-  it "is idempotent — running twice leaves already-encrypted rows untouched" do
-    expense = create(:expense, :with_raw_email, raw_email_content: "email body #{SecureRandom.hex}")
+  it "is idempotent — first run encrypts, second run skips at the SQL filter (no DB writes)" do
+    expense = create(:expense)
+    seed_plaintext(expense, "email body #{SecureRandom.hex}")
 
     run_task # first run — encrypts the row
 
     raw_after_first = raw_column_value(expense.reload)
-    expect(raw_after_first).to start_with("{")
+    expect(raw_after_first).to start_with('{"p":')
 
-    run_task # second run — must not alter the ciphertext
+    # Second run must NOT touch the row (it's filtered out at the WHERE
+    # clause: `raw_email_content NOT LIKE '{"p":%'`). Ciphertext stays
+    # byte-equal because non-deterministic encryption would produce a
+    # different value if the task re-encrypted.
+    run_task
 
     raw_after_second = raw_column_value(expense.reload)
     expect(raw_after_second).to eq(raw_after_first)
   end
 
-  it "skips rows where raw_email_content is NULL" do
+  it "leaves NULL raw_email_content rows alone (filtered at the WHERE clause)" do
     expense = create(:expense, raw_email_content: nil)
 
     expect { run_task }.not_to raise_error
@@ -69,8 +80,22 @@ RSpec.describe "encrypt:expense_raw_email", :unit, type: :task do
     expect(raw).to be_nil
   end
 
+  it "encrypts soft-deleted rows too (Expense.unscoped covers them)" do
+    # Soft-deleted expenses still hold bank PII — backfill must reach them.
+    expense = create(:expense)
+    seed_plaintext(expense, "soft-deleted plaintext")
+    expense.update_columns(deleted_at: Time.current)
+    expect(Expense.where(id: expense.id).count).to eq(0) # default_scope hides it
+
+    run_task
+
+    raw = raw_column_value(expense)
+    expect(raw).to start_with('{"p":')
+  end
+
   it "reports progress to STDOUT" do
-    create(:expense, :with_raw_email, raw_email_content: "some body")
+    expense = create(:expense)
+    seed_plaintext(expense, "some body")
 
     expect { run_task }.to output(/\[PER-533\]/).to_stdout
   end

--- a/spec/tasks/encrypt_expense_raw_email_rake_spec.rb
+++ b/spec/tasks/encrypt_expense_raw_email_rake_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# PER-533: Spec for the encrypt:expense_raw_email backfill rake task.
+# Verifies idempotency and batch behaviour without exercising the full
+# in_batches sleep loop (we stub it to keep the spec fast).
+RSpec.describe "encrypt:expense_raw_email", :unit, type: :task do
+  let(:rake_app) { Rake::Application.new }
+
+  before do
+    Rake.application = rake_app
+    Rake::Task.define_task(:environment)
+    load Rails.root.join("lib/tasks/encrypt_expense_raw_email.rake")
+    allow(Rake::Task["encrypt:expense_raw_email"]).to receive(:reenable).and_call_original
+  end
+
+  after { Rake::Task.clear }
+
+  def run_task
+    Rake::Task["encrypt:expense_raw_email"].reenable
+    Rake::Task["encrypt:expense_raw_email"].invoke
+  end
+
+  def raw_column_value(expense)
+    ActiveRecord::Base.connection.execute(
+      "SELECT raw_email_content FROM expenses WHERE id = #{expense.id}"
+    ).first["raw_email_content"]
+  end
+
+  it "encrypts plaintext rows on first run" do
+    expense = create(:expense)
+    # Bypass AR Encryption with raw SQL to simulate a row written before the
+    # encrypts declaration (i.e. a legacy plaintext production row).
+    ActiveRecord::Base.connection.execute(
+      "UPDATE expenses SET raw_email_content = 'plaintext body content' WHERE id = #{expense.id}"
+    )
+
+    expect { run_task }.not_to raise_error
+
+    # After the task runs, the raw column should contain ciphertext
+    raw = raw_column_value(expense.reload)
+    expect(raw).to start_with("{")
+    # And the model should still decrypt it transparently
+    expect(expense.reload.raw_email_content).to eq("plaintext body content")
+  end
+
+  it "is idempotent — running twice leaves already-encrypted rows untouched" do
+    expense = create(:expense, :with_raw_email, raw_email_content: "email body #{SecureRandom.hex}")
+
+    run_task # first run — encrypts the row
+
+    raw_after_first = raw_column_value(expense.reload)
+    expect(raw_after_first).to start_with("{")
+
+    run_task # second run — must not alter the ciphertext
+
+    raw_after_second = raw_column_value(expense.reload)
+    expect(raw_after_second).to eq(raw_after_first)
+  end
+
+  it "skips rows where raw_email_content is NULL" do
+    expense = create(:expense, raw_email_content: nil)
+
+    expect { run_task }.not_to raise_error
+
+    raw = raw_column_value(expense.reload)
+    expect(raw).to be_nil
+  end
+
+  it "reports progress to STDOUT" do
+    create(:expense, :with_raw_email, raw_email_content: "some body")
+
+    expect { run_task }.to output(/\[PER-533\]/).to_stdout
+  end
+end


### PR DESCRIPTION
## Summary

- Encrypts `Expense#raw_email_content` at the application layer using Active Record Encryption, matching the PER-496 pattern applied to `EmailParsingFailure`
- Adds `support_unencrypted_data: true` so existing plaintext rows remain readable during the 30-day backfill window
- Adds backfill rake task `encrypt:expense_raw_email` to idempotently re-encrypt plaintext rows in batches of 1000
- Adds 9 specs: 5 model encryption specs + 4 rake task specs

## Why

`Expense#raw_email_content` holds the same bank PII (amounts, merchants, account refs, transaction times) as `EmailParsingFailure#raw_email_content`, which was encrypted in PR #428 (PER-496). This PR closes the parity gap.

## Files changed

| File | Change |
|------|--------|
| `app/models/expense.rb` | `encrypts :raw_email_content, support_unencrypted_data: true` |
| `lib/tasks/encrypt_expense_raw_email.rake` | New — backfill task |
| `spec/models/expense_encryption_spec.rb` | New — 5 model specs |
| `spec/tasks/encrypt_expense_raw_email_rake_spec.rb` | New — 4 rake specs |

## Notes

- **No migration needed.** AR Encryption is application-layer; the column type stays `text`.
- **`MonitoringService:781`** — `Expense.where(...).where.not(raw_email_content: nil).count` — non-deterministic encryption writes non-null ciphertext, so the presence count is unaffected. Verified by spec.
- **View transparent.** `app/views/expenses/show.html.erb:166` calls `expense.raw_email_content` — AR decrypts transparently, no view change needed.
- **`support_unencrypted_data: true`** stays until PER-534 (30-day soak), which removes it and this rake task.

## Operator action after deploy

1. Run the backfill:
   ```
   bin/rails encrypt:expense_raw_email
   ```
   This is safe to re-run (idempotent). Progress is logged with `[PER-533]` prefix.

2. Monitor the output for `errored=0`. If errors appear, check `log/production.log` for `[PER-533] Error encrypting Expense id=...` lines.

3. After 30 days, open PER-534 to remove `support_unencrypted_data: true` and delete the rake task.

## Test plan

- [x] `bundle exec rspec spec/models/expense_encryption_spec.rb spec/tasks/encrypt_expense_raw_email_rake_spec.rb` — 9 examples, 0 failures
- [x] `bundle exec rspec --tag unit` — 9008 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec brakeman` — 0 security warnings