### PR TITLE
feat(ops): nightly Postgres backup to Hetzner Storage Box (PER-527)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem "bcrypt", "~> 3.1.22"
 gem "mail"
 gem "net-imap"
 
+# SFTP uploads for off-host backups (PostgresBackupJob → Hetzner Storage Box)
+gem "net-sftp", "~> 4.0"
+
 # Authentication and API
 gem "jwt"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,6 +546,7 @@ DEPENDENCIES
   mail
   memory_profiler
   net-imap
+  net-sftp (~> 4.0)
   pagy
   parallel_tests
   pg (~> 1.6)

--- a/app/jobs/postgres_backup_job.rb
+++ b/app/jobs/postgres_backup_job.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+require "open3"
+require "tempfile"
+require "fileutils"
+require "net/sftp"
+
+# PostgresBackupJob — nightly off-host Postgres backup to Hetzner Storage Box.
+#
+# Scheduled at 02:00 UTC daily via config/recurring.yml.
+#
+# Pipeline:
+#   1. pg_dump --format=custom --no-owner --no-acl → /tmp/<timestamp>.dump
+#   2. GPG symmetric encryption (AES256) with passphrase from credentials
+#   3. SFTP upload to Storage Box: /expense-tracker/YYYY/MM/<filename>.dump.gpg
+#   4. Retention: keep 30 daily + first-of-month for 12 months, delete rest
+#
+# External dependencies (must be installed on the app host):
+#   - pg_dump   (postgresql-client)
+#   - gpg       (gnupg)
+#
+# Required credentials/env vars:
+#   - Rails.application.credentials.dig(:backup, :gpg_passphrase)   OR  BACKUP_GPG_PASSPHRASE
+#   - STORAGE_BOX_HOST   — Hetzner Storage Box hostname (e.g. u123456.your-storagebox.de)
+#   - STORAGE_BOX_USER   — Storage Box SSH username
+#   - STORAGE_BOX_SSH_KEY — Path to private key file (e.g. /run/secrets/storage_box_key)
+#
+# The production Postgres host is personal-blog-db (internal Hetzner network).
+# PGPASSWORD is passed via Open3 env hash so it never appears on the command line.
+class PostgresBackupJob < ApplicationJob
+  queue_as :low
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  # Raised on any unrecoverable backup step failure.
+  class BackupError < StandardError; end
+
+  # Remote root directory inside the Storage Box.
+  REMOTE_ROOT = "expense-tracker"
+
+  # ── public entry point ───────────────────────────────────────────────────
+
+  def perform
+    timestamp  = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+    base_name  = "expense_tracker_production-#{timestamp}"
+    dump_path  = File.join(Dir.tmpdir, "#{base_name}.dump")
+    gpg_path   = "#{dump_path}.gpg"
+
+    Rails.logger.info "[PostgresBackup] Starting backup (timestamp=#{timestamp})"
+
+    begin
+      run_pg_dump(dump_path)
+      run_gpg_encrypt(dump_path, gpg_path)
+      sftp_upload(gpg_path, remote_path(timestamp))
+      apply_retention
+    ensure
+      FileUtils.rm_f(dump_path)
+      FileUtils.rm_f(gpg_path)
+    end
+
+    Rails.logger.info "[PostgresBackup] Backup complete (timestamp=#{timestamp})"
+  rescue BackupError => e
+    Rails.logger.error "[PostgresBackup] Backup failed: #{e.message}"
+    raise
+  rescue StandardError => e
+    Rails.logger.error "[PostgresBackup] Unexpected error: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise
+  end
+
+  private
+
+  # ── pg_dump ──────────────────────────────────────────────────────────────
+
+  def run_pg_dump(output_path)
+    Rails.logger.info "[PostgresBackup] Running pg_dump → #{output_path}"
+
+    cmd = [
+      "pg_dump",
+      "--format=custom",
+      "--no-owner",
+      "--no-acl",
+      "--host=#{pg_host}",
+      "--port=#{pg_port}",
+      "--username=#{pg_user}",
+      "--file=#{output_path}",
+      pg_database
+    ].join(" ")
+
+    env = { "PGPASSWORD" => pg_password }
+
+    stdout, stderr, status = Open3.capture3(env, cmd)
+
+    return if status.success?
+
+    raise BackupError, "pg_dump failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+  end
+
+  # ── GPG symmetric encryption ─────────────────────────────────────────────
+
+  def run_gpg_encrypt(input_path, output_path)
+    Rails.logger.info "[PostgresBackup] Encrypting with GPG → #{output_path}"
+
+    passphrase = resolve_gpg_passphrase
+
+    passphrase_file = Tempfile.new("gpg_passphrase")
+    begin
+      passphrase_file.write(passphrase)
+      passphrase_file.flush
+      passphrase_file.chmod(0o600)
+
+      cmd = [
+        "gpg",
+        "--batch",
+        "--yes",
+        "--symmetric",
+        "--cipher-algo AES256",
+        "--passphrase-file #{passphrase_file.path}",
+        "--output #{output_path}",
+        input_path
+      ].join(" ")
+
+      stdout, stderr, status = Open3.capture3(cmd)
+
+      return if status.success?
+
+      raise BackupError, "gpg encryption failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+    ensure
+      passphrase_file.close!
+    end
+  end
+
+  # ── SFTP upload ───────────────────────────────────────────────────────────
+
+  def sftp_upload(local_path, remote_file_path)
+    remote_dir = File.dirname(remote_file_path)
+    Rails.logger.info "[PostgresBackup] Uploading via SFTP → #{sftp_host}:#{remote_file_path}"
+
+    Net::SFTP.start(sftp_host, sftp_user, keys: [ sftp_key_path ]) do |sftp|
+      sftp_mkdir_p(sftp, remote_dir)
+      sftp.upload!(local_path, remote_file_path)
+    end
+  end
+
+  # Recursively create a remote directory path (equivalent to mkdir -p).
+  # Ignores "already exists" errors so re-runs are idempotent.
+  def sftp_mkdir_p(sftp, path)
+    segments = path.split("/").reject(&:empty?)
+    segments.each_with_index do |_seg, idx|
+      partial = segments[0..idx].join("/")
+      partial = "/#{partial}" if path.start_with?("/")
+      sftp.mkdir!(partial)
+    rescue Net::SFTP::StatusException => e
+      # FX_FAILURE (4) is returned when the directory already exists on many
+      # SFTP servers. FX_PERMISSION_DENIED (3) can also appear on the root.
+      # Re-raise for any other error code.
+      raise unless e.code == Net::SFTP::Constants::StatusCodes::FX_FAILURE ||
+                   e.code == Net::SFTP::Constants::StatusCodes::FX_PERMISSION_DENIED
+    end
+  end
+
+  # ── retention policy ──────────────────────────────────────────────────────
+
+  # Retention rules (applied after each backup):
+  #   - DAILY:   keep all files whose timestamp is within the last 30 days
+  #   - MONTHLY: keep the first backup of each calendar month for the last 12 months
+  #   - DELETE:  everything else
+  #
+  # Retention is evaluated on the remote filename which encodes the timestamp
+  # as YYYYMMDDTHHMMSSZ — lexicographic sort is chronological sort.
+  def apply_retention
+    Rails.logger.info "[PostgresBackup] Applying retention policy"
+
+    Net::SFTP.start(sftp_host, sftp_user, keys: [ sftp_key_path ]) do |sftp|
+      all_files = list_remote_files(sftp)
+      to_delete = files_to_delete(all_files)
+
+      to_delete.each do |filename|
+        remote_path = "#{REMOTE_ROOT}/#{remote_year_month(filename)}/#{filename}"
+        sftp.remove!(remote_path)
+        Rails.logger.info "[PostgresBackup] Deleted #{remote_path}"
+      end
+
+      Rails.logger.info "[PostgresBackup] Retention: kept #{all_files.size - to_delete.size}, deleted #{to_delete.size}"
+    end
+  rescue StandardError => e
+    # Retention failure is not fatal — the backup itself succeeded.
+    Rails.logger.error "[PostgresBackup] Retention pass failed (non-fatal): #{e.message}"
+  end
+
+  # Returns the list of remote filenames (basename only) that should be deleted.
+  # Exposed as a non-private method so specs can call it via `send`.
+  #
+  # Keep set (union):
+  #   - Any file whose parsed timestamp is within 30 days of now (daily window)
+  #   - The oldest file per calendar-month key where that month is within 12
+  #     months of the current month start (monthly anchor)
+  def files_to_delete(all_files)
+    now            = Time.now.utc
+    daily_cutoff   = now - 30.days
+    monthly_cutoff = (now.beginning_of_month - 12.months)
+
+    keep = Set.new
+
+    # Build a month → files map for monthly anchor selection
+    by_month = all_files.group_by { |f| remote_year_month(f) }
+
+    by_month.each do |_month_key, files|
+      sorted = files.sort # lexicographic = chronological for our filename format
+      anchor = sorted.first
+      # Parse the anchor timestamp; keep if within 12-month window
+      ts = parse_filename_timestamp(anchor)
+      keep << anchor if ts && ts.beginning_of_month >= monthly_cutoff
+    end
+
+    all_files.each_with_object([]) do |filename, deletes|
+      ts = parse_filename_timestamp(filename)
+      next if ts.nil? # malformed filename — leave it alone
+
+      # Within 30-day daily window?
+      next keep << filename if ts >= daily_cutoff
+
+      # Already in the monthly keep set?
+      next if keep.include?(filename)
+
+      deletes << filename
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  # Builds the full remote path for a given timestamp string.
+  # e.g. "expense-tracker/2026/05/expense_tracker_production-20260501T020000Z.dump.gpg"
+  def remote_path(timestamp)
+    year  = timestamp[0, 4]
+    month = timestamp[4, 2]
+    "#{REMOTE_ROOT}/#{year}/#{month}/expense_tracker_production-#{timestamp}.dump.gpg"
+  end
+
+  # Returns YYYY/MM from a backup filename.
+  def remote_year_month(filename)
+    m = filename.match(/(\d{4})(\d{2})\d{2}T\d{6}Z/)
+    m ? "#{m[1]}/#{m[2]}" : "unknown"
+  end
+
+  # Parses the timestamp embedded in a backup filename.
+  def parse_filename_timestamp(filename)
+    m = filename.match(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/)
+    return nil unless m
+
+    Time.utc(m[1].to_i, m[2].to_i, m[3].to_i, m[4].to_i, m[5].to_i, m[6].to_i)
+  end
+
+  # Lists all backup filenames across all YYYY/MM subdirectories.
+  def list_remote_files(sftp)
+    files = []
+    sftp.dir.glob("#{REMOTE_ROOT}/*/*", "expense_tracker_production-*.dump.gpg") do |entry|
+      files << File.basename(entry.name)
+    end
+    files
+  end
+
+  # ── configuration accessors ───────────────────────────────────────────────
+
+  def resolve_gpg_passphrase
+    passphrase = Rails.application.credentials.dig(:backup, :gpg_passphrase) ||
+                 ENV["BACKUP_GPG_PASSPHRASE"]
+
+    raise BackupError, "No GPG passphrase configured — set credentials.backup.gpg_passphrase or BACKUP_GPG_PASSPHRASE" if passphrase.blank?
+
+    passphrase
+  end
+
+  def pg_host
+    ENV.fetch("POSTGRES_HOST", "personal-blog-db")
+  end
+
+  def pg_port
+    ENV.fetch("POSTGRES_PORT", "5432")
+  end
+
+  def pg_user
+    ENV.fetch("POSTGRES_USER", "expense_tracker")
+  end
+
+  def pg_password
+    ENV.fetch("POSTGRES_PASSWORD", "")
+  end
+
+  def pg_database
+    "expense_tracker_production"
+  end
+
+  def sftp_host
+    ENV.fetch("STORAGE_BOX_HOST") do
+      raise BackupError, "STORAGE_BOX_HOST is not set — configure it in .kamal/secrets"
+    end
+  end
+
+  def sftp_user
+    ENV.fetch("STORAGE_BOX_USER") do
+      raise BackupError, "STORAGE_BOX_USER is not set — configure it in .kamal/secrets"
+    end
+  end
+
+  def sftp_key_path
+    ENV.fetch("STORAGE_BOX_SSH_KEY") do
+      raise BackupError, "STORAGE_BOX_SSH_KEY is not set — configure it in .kamal/secrets"
+    end
+  end
+end

--- a/app/jobs/postgres_backup_job.rb
+++ b/app/jobs/postgres_backup_job.rb
@@ -29,6 +29,13 @@ require "net/sftp"
 # PGPASSWORD is passed via Open3 env hash so it never appears on the command line.
 class PostgresBackupJob < ApplicationJob
   queue_as :low
+
+  # Prevent overlapping runs. pg_dump can take >10 min as the DB grows; the
+  # nightly schedule, retry_on retries, and a manual postgres_backup:run_now
+  # could otherwise run two pg_dumps and SFTP uploads concurrently against
+  # the shared personal-blog-db host.
+  limits_concurrency key: "postgres_backup", duration: 2.hours
+
   retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   # Raised on any unrecoverable backup step failure.
@@ -57,6 +64,7 @@ class PostgresBackupJob < ApplicationJob
       FileUtils.rm_f(gpg_path)
     end
 
+    Rails.cache.write("postgres_backup.last_success_at", Time.now.utc.iso8601, expires_in: 7.days)
     Rails.logger.info "[PostgresBackup] Backup complete (timestamp=#{timestamp})"
   rescue BackupError => e
     Rails.logger.error "[PostgresBackup] Backup failed: #{e.message}"
@@ -74,25 +82,38 @@ class PostgresBackupJob < ApplicationJob
   def run_pg_dump(output_path)
     Rails.logger.info "[PostgresBackup] Running pg_dump → #{output_path}"
 
-    cmd = [
+    env = { "PGPASSWORD" => pg_password }
+
+    # argv form (no shell) — bypasses /bin/sh -c, immune to metacharacters
+    # in pg_host / pg_user / output_path even if their sources change later.
+    # Each option value is its own argv element (e.g. "--host", pg_host) so
+    # we never interpolate non-literal data into a string.
+    stdout, stderr, status = Open3.capture3(
+      env,
       "pg_dump",
       "--format=custom",
       "--no-owner",
       "--no-acl",
-      "--host=#{pg_host}",
-      "--port=#{pg_port}",
-      "--username=#{pg_user}",
-      "--file=#{output_path}",
+      "--lock-wait-timeout=30000",
+      "--host",     pg_host,
+      "--port",     pg_port,
+      "--username", pg_user,
+      "--file",     output_path,
       pg_database
-    ].join(" ")
+    )
 
-    env = { "PGPASSWORD" => pg_password }
+    unless status.success?
+      raise BackupError, "pg_dump failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+    end
 
-    stdout, stderr, status = Open3.capture3(env, cmd)
+    # 0600 immediately so the plaintext dump is not readable by other UIDs
+    # in the (small) window between pg_dump completing and gpg encrypting.
+    File.chmod(0o600, output_path) if File.exist?(output_path)
 
-    return if status.success?
+    size = File.size?(output_path).to_i
+    raise BackupError, "pg_dump produced empty/missing file at #{output_path}" if size < 512
 
-    raise BackupError, "pg_dump failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+    Rails.logger.info "[PostgresBackup] pg_dump complete (size=#{size} bytes)"
   end
 
   # ── GPG symmetric encryption ─────────────────────────────────────────────
@@ -108,18 +129,16 @@ class PostgresBackupJob < ApplicationJob
       passphrase_file.flush
       passphrase_file.chmod(0o600)
 
-      cmd = [
+      stdout, stderr, status = Open3.capture3(
         "gpg",
         "--batch",
         "--yes",
         "--symmetric",
-        "--cipher-algo AES256",
-        "--passphrase-file #{passphrase_file.path}",
-        "--output #{output_path}",
+        "--cipher-algo", "AES256",
+        "--passphrase-file", passphrase_file.path,
+        "--output", output_path,
         input_path
-      ].join(" ")
-
-      stdout, stderr, status = Open3.capture3(cmd)
+      )
 
       return if status.success?
 
@@ -150,11 +169,11 @@ class PostgresBackupJob < ApplicationJob
       partial = "/#{partial}" if path.start_with?("/")
       sftp.mkdir!(partial)
     rescue Net::SFTP::StatusException => e
-      # FX_FAILURE (4) is returned when the directory already exists on many
-      # SFTP servers. FX_PERMISSION_DENIED (3) can also appear on the root.
-      # Re-raise for any other error code.
-      raise unless e.code == Net::SFTP::Constants::StatusCodes::FX_FAILURE ||
-                   e.code == Net::SFTP::Constants::StatusCodes::FX_PERMISSION_DENIED
+      # FX_FAILURE (4) is returned when the directory already exists on most
+      # SFTP servers. Re-raise FX_PERMISSION_DENIED so an ACL/path misconfig
+      # surfaces with a clear error rather than masquerading as an upload
+      # failure later.
+      raise unless e.code == Net::SFTP::Constants::StatusCodes::FX_FAILURE
     end
   end
 
@@ -197,7 +216,8 @@ class PostgresBackupJob < ApplicationJob
   def files_to_delete(all_files)
     now            = Time.now.utc
     daily_cutoff   = now - 30.days
-    monthly_cutoff = (now.beginning_of_month - 12.months)
+    # Keep 12 monthly anchors total (current month + 11 prior).
+    monthly_cutoff = (now.beginning_of_month - 11.months)
 
     keep = Set.new
 

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -31,6 +31,10 @@ REQUIRED_SECRETS = %w[
   ADMIN_EMAIL
   ADMIN_PASSWORD
   ANTHROPIC_API_KEY
+  STORAGE_BOX_HOST
+  STORAGE_BOX_USER
+  STORAGE_BOX_SSH_KEY
+  BACKUP_GPG_PASSPHRASE
 ].freeze
 
 # Must stay in sync with db/seeds.rb:370 — the production seed guard.
@@ -45,7 +49,7 @@ SENTINEL_PASSWORD = "AdminPassword123!"
 # Add it back once it's been fixed and stabilized.
 REQUIRED_WORKFLOWS = [
   "CI",
-  "Unit Tests",
+  "Unit Tests"
 ].freeze
 
 options = { offline: false, skip_ci: false }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -35,26 +35,6 @@
         "method": "refresh_csrf_token_for_turbo"
       },
       "note": "PER-213 Fix 5: HEAD responses carry no body so the memoized CSRF token is never delivered. Intentionally excluding HEAD from refresh_csrf_token_for_turbo is the desired behavior, not a security flaw."
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "d520ed829a6529c1c22008bb6a34ac184d6c3466f39c711772b176c9f6d2be7f",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/jobs/postgres_backup_job.rb",
-      "line": 91,
-      "note": "PER-527: All interpolated values (pg_host, pg_port, pg_user, pg_database, output_path) come from Rails credentials or fixed constants — never from user input. pg_host/pg_user are ENV vars set at deploy time; output_path is a system tmpdir path composed from a fixed prefix and a UTC timestamp. No user-controlled data enters the command string."
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "bd3cf0ea0cd4364b9b06330b62074562e7a276085dea3f8bd41c85480a3a80ee",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/jobs/postgres_backup_job.rb",
-      "line": 122,
-      "note": "PER-527: The GPG command interpolates output_path (system tmpdir + timestamp), input_path (same), and passphrase_file.path (Tempfile created by the job itself). None of these values are user-controlled. The passphrase is sourced from Rails credentials and written to a mode-600 tempfile; it is never interpolated into the command string."
     }
   ]
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -35,6 +35,26 @@
         "method": "refresh_csrf_token_for_turbo"
       },
       "note": "PER-213 Fix 5: HEAD responses carry no body so the memoized CSRF token is never delivered. Intentionally excluding HEAD from refresh_csrf_token_for_turbo is the desired behavior, not a security flaw."
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "d520ed829a6529c1c22008bb6a34ac184d6c3466f39c711772b176c9f6d2be7f",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/jobs/postgres_backup_job.rb",
+      "line": 91,
+      "note": "PER-527: All interpolated values (pg_host, pg_port, pg_user, pg_database, output_path) come from Rails credentials or fixed constants — never from user input. pg_host/pg_user are ENV vars set at deploy time; output_path is a system tmpdir path composed from a fixed prefix and a UTC timestamp. No user-controlled data enters the command string."
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "bd3cf0ea0cd4364b9b06330b62074562e7a276085dea3f8bd41c85480a3a80ee",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/jobs/postgres_backup_job.rb",
+      "line": 122,
+      "note": "PER-527: The GPG command interpolates output_path (system tmpdir + timestamp), input_path (same), and passphrase_file.path (Tempfile created by the job itself). None of these values are user-controlled. The passphrase is sourced from Rails credentials and written to a mode-600 tempfile; it is never interpolated into the command string."
     }
   ]
 }

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -47,6 +47,16 @@ env:
     # Without this the strategy 401s on every call and the circuit-breaker
     # silently degrades to pattern-only categorization (PER-548).
     - ANTHROPIC_API_KEY
+    # Hetzner Storage Box credentials for nightly Postgres backup (PER-527).
+    # STORAGE_BOX_HOST:    u<id>.your-storagebox.de
+    # STORAGE_BOX_USER:    u<id> (the Storage Box username)
+    # STORAGE_BOX_SSH_KEY: path to the private key inside the container
+    #                      (mount via kamal volumes or write via env)
+    # BACKUP_GPG_PASSPHRASE: symmetric GPG passphrase for .dump.gpg files
+    - STORAGE_BOX_HOST
+    - STORAGE_BOX_USER
+    - STORAGE_BOX_SSH_KEY
+    - BACKUP_GPG_PASSPHRASE
   clear:
     RAILS_ENV: production
     POSTGRES_USER: expense_tracker

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -102,6 +102,16 @@ default: &default
     schedule: every day at 6am
     description: "Pull latest monthly budget from each active external source"
 
+  # Nightly Postgres backup to Hetzner Storage Box.
+  # Runs pg_dump → GPG-encrypts → uploads via SFTP. Applies 30-day daily +
+  # 12-month monthly retention after each run (PER-527).
+  postgres_nightly_backup:
+    class: PostgresBackupJob
+    queue: low
+    priority: 10
+    schedule: every day at 2am
+    description: "Nightly Postgres backup to Hetzner Storage Box with encryption and retention (PER-527)"
+
 development:
   <<: *default
   # In development, run metrics calculation more frequently for testing

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -105,12 +105,18 @@ default: &default
   # Nightly Postgres backup to Hetzner Storage Box.
   # Runs pg_dump → GPG-encrypts → uploads via SFTP. Applies 30-day daily +
   # 12-month monthly retention after each run (PER-527).
+  #
+  # NOTE: Solid Queue parses recurring schedules in Rails Time.zone (not UTC
+  # by default). config/application.rb sets time_zone = "Central America"
+  # (UTC-6, no DST), so we use a cron expression with explicit UTC framing
+  # to keep "02:00 UTC" stable regardless of TZ config drift.
   postgres_nightly_backup:
     class: PostgresBackupJob
     queue: low
     priority: 10
-    schedule: every day at 2am
-    description: "Nightly Postgres backup to Hetzner Storage Box with encryption and retention (PER-527)"
+    schedule: "0 2 * * *"
+    time_zone: "UTC"
+    description: "Nightly Postgres backup to Hetzner Storage Box with encryption and retention (PER-527, 02:00 UTC)"
 
 development:
   <<: *default

--- a/docs/deploys/postgres-backup-restore.md
+++ b/docs/deploys/postgres-backup-restore.md
@@ -1,0 +1,109 @@
+# Postgres Backup & Restore Runbook (PER-527)
+
+The `PostgresBackupJob` runs nightly at **02:00 UTC** via Solid Queue
+(`config/recurring.yml`). It dumps `expense_tracker_production` with
+`pg_dump --format=custom`, GPG-encrypts the dump (AES256, symmetric), uploads
+it to the Hetzner Storage Box via SFTP, and applies retention.
+
+## RTO / RPO targets
+
+- **RPO** (data loss tolerance): up to 24h. The backup runs once nightly.
+  An incident at 23:59 UTC would lose ~24h of expenses/categorizations.
+- **RTO** (recovery time): ~30 min for the data restore itself, plus
+  whatever time is needed to redeploy the app on a fresh host.
+
+## Retention
+
+- **Daily**: every backup whose timestamp is within the last 30 days
+- **Monthly**: the first-of-month anchor for 12 months total (current month
+  + 11 prior)
+- Anything else is deleted by `apply_retention` immediately after each
+  successful upload.
+
+## Required secrets (production)
+
+Set in 1Password vault `Personal Brand → Expense Tracker` and synced via
+`.kamal/secrets`:
+
+- `STORAGE_BOX_HOST` — e.g. `u123456.your-storagebox.de`
+- `STORAGE_BOX_USER` — Storage Box SSH username
+- `STORAGE_BOX_SSH_KEY` — path to private key inside the container
+  (e.g. `/run/secrets/storage_box_key`)
+- `BACKUP_GPG_PASSPHRASE` — symmetric encryption passphrase (≥32 chars)
+
+`bin/pre-deploy-check` enforces all four are present before deploy.
+
+## Operator commands
+
+```bash
+bin/rails postgres_backup:run_now        # kick off a backup immediately
+bin/rails postgres_backup:list_remote    # list what's in the Storage Box
+bin/rails 'postgres_backup:restore[FILENAME]'   # download + decrypt
+```
+
+The `restore` task validates the filename against the strict pattern
+`expense_tracker_production-YYYYMMDDTHHMMSSZ.dump.gpg` and writes the
+decrypted dump to a private tmpdir (override with `OUTPUT_DIR=`).
+
+## Restore procedure (full DR)
+
+1. **Pick a backup**: `bin/rails postgres_backup:list_remote` — copy the
+   most recent (or most recent monthly anchor for point-in-time recovery).
+2. **Download + decrypt** on the new host:
+   ```bash
+   bin/rails 'postgres_backup:restore[expense_tracker_production-YYYYMMDDTHHMMSSZ.dump.gpg]'
+   ```
+   The task prints the path to the decrypted `.dump` file.
+3. **Restore into a fresh database**:
+   ```bash
+   createdb expense_tracker_restore_test
+   pg_restore --clean --if-exists --no-owner --no-acl \
+     -d expense_tracker_restore_test \
+     /path/to/decrypted.dump
+   ```
+4. **Verify** the restore (row counts, latest expense ID, latest sync_session)
+   before pointing app config at it.
+5. **Switch over** by updating `DATABASE_URL` (or the production credentials)
+   and running `kamal deploy`.
+6. **Clean up**: `rm` the decrypted dump file. It contains plaintext bank PII.
+
+## Quarterly drill checklist
+
+Run on the first weekend of each quarter and record completion in this file
+(or your ops journal). Untested backups are not backups.
+
+- [ ] `bin/rails postgres_backup:list_remote` — confirm last backup is
+      ≤ 24h old and that you see ~30 daily files plus 12 monthly anchors.
+- [ ] Pick a backup ≥ 7 days old (not just last night's).
+- [ ] Decrypt it via `postgres_backup:restore[FILENAME]` on a non-production
+      host (laptop or scratch VPS).
+- [ ] `pg_restore` it into a fresh local database.
+- [ ] Spot-check: `SELECT COUNT(*) FROM expenses;`, `SELECT MAX(created_at)
+      FROM expenses;`, plus one ML-categorized row to confirm encrypted
+      columns decrypt correctly with the production credentials.
+- [ ] `rm` the decrypted dump.
+
+## Failure-mode runbook
+
+| Symptom | First check | Likely fix |
+| --- | --- | --- |
+| `list_remote` empty for >24h | Solid Queue dispatcher up? `kamal app logs --grep PostgresBackup` | Restart Puma; investigate why the recurring task didn't fire |
+| `BackupError: pg_dump failed` | Postgres host reachable from app container? Disk full on the DB host? | Operational — check `personal-blog-db` |
+| `BackupError: gpg encryption failed` | Disk space in `/tmp` of app container | `df -h` inside container; free up `/tmp` |
+| `Net::SSH::AuthenticationFailed` | SSH key path correct? `STORAGE_BOX_SSH_KEY` points at a valid file inside the container? | Re-mount key via `.kamal/secrets`; verify perms 0600 |
+| Retention pass logs failure | Storage Box quota exhausted? | Free space manually via SFTP, then re-run `postgres_backup:run_now` |
+| Backup completed but no `last_success_at` cache entry | Solid Cache writable? | Inspect `Rails.cache.read("postgres_backup.last_success_at")`; check `cache:` DB |
+
+## Observability
+
+After each successful run, `Rails.cache.write("postgres_backup.last_success_at", iso8601, expires_in: 7.days)`.
+A future PR can wire this into the admin dashboard or `/up` healthcheck so a
+multi-day backup gap surfaces without log diving.
+
+## Related work
+
+- **PER-527** (this PR) — initial implementation
+- **PER-523** — recurring-job heartbeat + alert on liveness gap (broader
+  monitoring; will replace the cache-write approach above)
+- **PER-528** — pre-prod load test (will exercise dump size against
+  retention assumptions)

--- a/lib/tasks/postgres_backup.rake
+++ b/lib/tasks/postgres_backup.rake
@@ -56,6 +56,14 @@ namespace :postgres_backup do
     filename = args[:filename]
     abort "Usage: bin/rails 'postgres_backup:restore[FILENAME]'" if filename.blank?
 
+    # Strict allowlist on filename — operator-supplied input flows into a
+    # remote SFTP path and a gpg argv. The anchored regex blocks shell-meta,
+    # path traversal (../), and any deviation from the timestamped naming
+    # written by PostgresBackupJob.
+    unless filename.match?(/\Aexpense_tracker_production-\d{8}T\d{6}Z\.dump\.gpg\z/)
+      abort "Invalid filename. Expected: expense_tracker_production-YYYYMMDDTHHMMSSZ.dump.gpg"
+    end
+
     # Resolve credentials
     passphrase = Rails.application.credentials.dig(:backup, :gpg_passphrase) ||
                  ENV["BACKUP_GPG_PASSPHRASE"]
@@ -65,12 +73,15 @@ namespace :postgres_backup do
     user     = ENV.fetch("STORAGE_BOX_USER") { abort "STORAGE_BOX_USER not set" }
     key_path = ENV.fetch("STORAGE_BOX_SSH_KEY") { abort "STORAGE_BOX_SSH_KEY not set" }
 
-    # Derive the remote path from the filename
+    # Derive the remote path from the filename (regex-validated above).
     m = filename.match(/(\d{4})(\d{2})\d{2}T/)
-    abort "Cannot parse YYYY/MM from filename: #{filename}" unless m
     remote_path = "expense-tracker/#{m[1]}/#{m[2]}/#{filename}"
 
-    local_gpg  = File.join(Dir.pwd, filename)
+    # Decrypted dump contains plaintext bank PII. Drop it in a private tmpdir
+    # rather than Dir.pwd so it can't accidentally land in a Docker image
+    # build context or git status.
+    output_dir = ENV["OUTPUT_DIR"] || Dir.mktmpdir("postgres_backup_restore_")
+    local_gpg  = File.join(output_dir, filename)
     local_dump = local_gpg.sub(/\.gpg\z/, "")
 
     puts "[postgres_backup:restore] Downloading #{remote_path}..."
@@ -86,16 +97,14 @@ namespace :postgres_backup do
       passphrase_file.flush
       passphrase_file.chmod(0o600)
 
-      cmd = [
+      stdout, stderr, status = Open3.capture3(
         "gpg",
         "--batch",
         "--yes",
-        "--passphrase-file #{passphrase_file.path}",
-        "--output #{local_dump}",
-        "--decrypt #{local_gpg}"
-      ].join(" ")
-
-      stdout, stderr, status = Open3.capture3(cmd)
+        "--passphrase-file", passphrase_file.path,
+        "--output",          local_dump,
+        "--decrypt",         local_gpg
+      )
       unless status.success?
         abort "gpg decryption failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
       end
@@ -109,7 +118,9 @@ namespace :postgres_backup do
     puts "To restore into a local database run:"
     puts "  pg_restore --clean --if-exists -d <DBNAME> #{local_dump}"
     puts ""
-    puts "NOTE: this does NOT auto-load the dump. Run pg_restore manually and verify the result."
+    puts "NOTE: this does NOT auto-load the dump. Run pg_restore manually."
+    puts "      The decrypted dump contains plaintext bank PII — delete it"
+    puts "      with 'rm #{local_dump}' (or 'rm -rf #{output_dir}') after use."
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/lib/tasks/postgres_backup.rake
+++ b/lib/tasks/postgres_backup.rake
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# lib/tasks/postgres_backup.rake
+#
+# Operator tasks for the nightly Postgres backup pipeline (PER-527).
+#
+# Usage:
+#   bin/rails postgres_backup:run_now          # kick off a backup immediately
+#   bin/rails postgres_backup:list_remote      # list what's in the Storage Box
+#   bin/rails postgres_backup:restore[FILE]    # download + decrypt a backup
+#
+# All tasks require STORAGE_BOX_HOST, STORAGE_BOX_USER, STORAGE_BOX_SSH_KEY,
+# and either Rails.application.credentials.backup.gpg_passphrase or
+# BACKUP_GPG_PASSPHRASE to be set.
+
+namespace :postgres_backup do
+  desc "Run a Postgres backup immediately (same as the nightly job)"
+  task run_now: :environment do
+    puts "[postgres_backup:run_now] Starting backup..."
+    PostgresBackupJob.perform_now
+    puts "[postgres_backup:run_now] Done."
+  end
+
+  desc "List remote backup files in the Hetzner Storage Box"
+  task list_remote: :environment do
+    require "net/sftp"
+
+    host     = ENV.fetch("STORAGE_BOX_HOST") { abort "STORAGE_BOX_HOST not set" }
+    user     = ENV.fetch("STORAGE_BOX_USER") { abort "STORAGE_BOX_USER not set" }
+    key_path = ENV.fetch("STORAGE_BOX_SSH_KEY") { abort "STORAGE_BOX_SSH_KEY not set" }
+
+    puts "[postgres_backup:list_remote] Connecting to #{host}..."
+
+    files = []
+    Net::SFTP.start(host, user, keys: [ key_path ]) do |sftp|
+      sftp.dir.glob("expense-tracker/*/*", "expense_tracker_production-*.dump.gpg") do |entry|
+        files << entry.name
+      end
+    end
+
+    if files.empty?
+      puts "  (no backups found)"
+    else
+      files.sort.each { |f| puts "  #{f}" }
+      puts "\nTotal: #{files.size} backup(s)"
+    end
+  end
+
+  # rubocop:disable Metrics/BlockLength
+  desc "Download and decrypt a remote backup. Usage: bin/rails 'postgres_backup:restore[FILENAME]'"
+  task :restore, [ :filename ] => :environment do |_t, args|
+    require "net/sftp"
+    require "tempfile"
+    require "open3"
+
+    filename = args[:filename]
+    abort "Usage: bin/rails 'postgres_backup:restore[FILENAME]'" if filename.blank?
+
+    # Resolve credentials
+    passphrase = Rails.application.credentials.dig(:backup, :gpg_passphrase) ||
+                 ENV["BACKUP_GPG_PASSPHRASE"]
+    abort "No GPG passphrase — set credentials.backup.gpg_passphrase or BACKUP_GPG_PASSPHRASE" if passphrase.blank?
+
+    host     = ENV.fetch("STORAGE_BOX_HOST") { abort "STORAGE_BOX_HOST not set" }
+    user     = ENV.fetch("STORAGE_BOX_USER") { abort "STORAGE_BOX_USER not set" }
+    key_path = ENV.fetch("STORAGE_BOX_SSH_KEY") { abort "STORAGE_BOX_SSH_KEY not set" }
+
+    # Derive the remote path from the filename
+    m = filename.match(/(\d{4})(\d{2})\d{2}T/)
+    abort "Cannot parse YYYY/MM from filename: #{filename}" unless m
+    remote_path = "expense-tracker/#{m[1]}/#{m[2]}/#{filename}"
+
+    local_gpg  = File.join(Dir.pwd, filename)
+    local_dump = local_gpg.sub(/\.gpg\z/, "")
+
+    puts "[postgres_backup:restore] Downloading #{remote_path}..."
+    Net::SFTP.start(host, user, keys: [ key_path ]) do |sftp|
+      sftp.download!(remote_path, local_gpg)
+    end
+    puts "  Saved to: #{local_gpg}"
+
+    puts "[postgres_backup:restore] Decrypting..."
+    passphrase_file = Tempfile.new("gpg_restore_pass")
+    begin
+      passphrase_file.write(passphrase)
+      passphrase_file.flush
+      passphrase_file.chmod(0o600)
+
+      cmd = [
+        "gpg",
+        "--batch",
+        "--yes",
+        "--passphrase-file #{passphrase_file.path}",
+        "--output #{local_dump}",
+        "--decrypt #{local_gpg}"
+      ].join(" ")
+
+      stdout, stderr, status = Open3.capture3(cmd)
+      unless status.success?
+        abort "gpg decryption failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+      end
+    ensure
+      passphrase_file.close!
+    end
+
+    File.delete(local_gpg)
+    puts "  Decrypted dump: #{local_dump}"
+    puts ""
+    puts "To restore into a local database run:"
+    puts "  pg_restore --clean --if-exists -d <DBNAME> #{local_dump}"
+    puts ""
+    puts "NOTE: this does NOT auto-load the dump. Run pg_restore manually and verify the result."
+  end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/spec/jobs/postgres_backup_job_spec.rb
+++ b/spec/jobs/postgres_backup_job_spec.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Unit tests for PostgresBackupJob.
+#
+# All subprocess execution (pg_dump, gpg) and network I/O (net-sftp) are
+# stubbed so the suite runs without a Postgres server, GPG binary, or a
+# reachable Storage Box.
+#
+# Design: the before block stubs everything to a "happy path" default.
+# Individual tests override the stub and/or assert against captured call args.
+RSpec.describe PostgresBackupJob, type: :job, unit: true do
+  subject(:job) { described_class.new }
+
+  # ── shared fake objects ───────────────────────────────────────────────────
+
+  let(:fake_sftp_dir) do
+    # double: glob yields nothing (empty Storage Box) by default
+    dbl = double("Net::SFTP::Operations::Dir")  # rubocop:disable RSpec/VerifiedDoubles
+    allow(dbl).to receive(:glob)
+    dbl
+  end
+
+  let(:sftp_session) do
+    # Use plain double — Net::SFTP::Session doesn't expose mkdir_p!.
+    # Our job implements sftp_mkdir_p as a helper that calls mkdir! per segment.
+    dbl = double("Net::SFTP::Session")  # rubocop:disable RSpec/VerifiedDoubles
+    allow(dbl).to receive(:mkdir!).and_return(nil)
+    allow(dbl).to receive(:upload!)
+    allow(dbl).to receive(:dir).and_return(fake_sftp_dir)
+    allow(dbl).to receive(:remove!)
+    dbl
+  end
+
+  let(:ok_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  let(:frozen_time) { Time.zone.parse("2026-05-01T02:00:00Z") }
+
+  # Captured call args — populated by the before-block stubs
+  let(:pg_dump_call_args) { [] }
+  let(:gpg_call_args)     { [] }
+  let(:sftp_upload_args)  { [] }
+
+  before do
+    travel_to(frozen_time)
+
+    # Credentials
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:backup, :gpg_passphrase)
+      .and_return("test-passphrase-from-credentials")
+
+    # Required Storage Box env vars
+    stub_const("ENV", ENV.to_hash.merge(
+      "STORAGE_BOX_HOST"    => "u000000.your-storagebox.de",
+      "STORAGE_BOX_USER"    => "u000000",
+      "STORAGE_BOX_SSH_KEY" => "/run/secrets/storage_box_key"
+    ))
+
+    # Capture pg_dump call args
+    allow(Open3).to receive(:capture3)
+      .with(hash_including("PGPASSWORD"), a_string_starting_with("pg_dump")) do |env_hash, cmd|
+        pg_dump_call_args.replace([ env_hash, cmd ])
+        [ "", "", ok_status ]
+      end
+
+    # Capture gpg call args
+    allow(Open3).to receive(:capture3)
+      .with(a_string_including("gpg")) do |cmd|
+        gpg_call_args.replace([ cmd ])
+        [ "", "", ok_status ]
+      end
+
+    # Capture SFTP upload args
+    allow(sftp_session).to receive(:upload!) do |local, remote|
+      sftp_upload_args.replace([ local, remote ])
+    end
+
+    # SFTP.start
+    allow(Net::SFTP).to receive(:start).and_yield(sftp_session)
+
+    # Tempfile for passphrase
+    fake_tf = instance_double(Tempfile,
+      path: "/tmp/fake_pass_file",
+      close!: nil, write: nil, flush: nil, chmod: nil)
+    allow(Tempfile).to receive(:new).with("gpg_passphrase").and_return(fake_tf)
+
+    # FileUtils.rm_f
+    allow(FileUtils).to receive(:rm_f)
+  end
+
+  after { travel_back }
+
+  # ── job configuration ────────────────────────────────────────────────────
+
+  describe "job configuration" do
+    it "uses the low-priority queue" do
+      expect(described_class.new.queue_name).to eq("low")
+    end
+  end
+
+  # ── pg_dump command composition ──────────────────────────────────────────
+
+  describe "pg_dump command composition" do
+    before { job.perform }
+
+    it "passes PGPASSWORD via the Open3 env hash (never on the command line)" do
+      expect(pg_dump_call_args[0]).to include("PGPASSWORD")
+    end
+
+    it "does NOT embed PGPASSWORD in the command string" do
+      expect(pg_dump_call_args[1]).not_to include("PGPASSWORD")
+    end
+
+    it "uses --format=custom" do
+      expect(pg_dump_call_args[1]).to include("--format=custom")
+    end
+
+    it "uses --no-owner" do
+      expect(pg_dump_call_args[1]).to include("--no-owner")
+    end
+
+    it "uses --no-acl" do
+      expect(pg_dump_call_args[1]).to include("--no-acl")
+    end
+
+    it "targets expense_tracker_production" do
+      expect(pg_dump_call_args[1]).to include("expense_tracker_production")
+    end
+
+    it "raises BackupError when pg_dump exits non-zero" do
+      bad_status = instance_double(Process::Status, success?: false, exitstatus: 1)
+      allow(Open3).to receive(:capture3)
+        .with(hash_including("PGPASSWORD"), a_string_starting_with("pg_dump"))
+        .and_return([ "", "connection refused", bad_status ])
+
+      expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /pg_dump failed/)
+    end
+  end
+
+  # ── GPG encryption command composition ───────────────────────────────────
+
+  describe "GPG encryption command composition" do
+    before { job.perform }
+
+    it "invokes gpg" do
+      expect(gpg_call_args[0]).to include("gpg")
+    end
+
+    it "uses --symmetric" do
+      expect(gpg_call_args[0]).to include("--symmetric")
+    end
+
+    it "uses AES256 cipher" do
+      expect(gpg_call_args[0]).to include("AES256")
+    end
+
+    it "uses --batch (non-interactive)" do
+      expect(gpg_call_args[0]).to include("--batch")
+    end
+
+    it "passes passphrase via --passphrase-file (not on command line)" do
+      expect(gpg_call_args[0]).to include("--passphrase-file")
+      expect(gpg_call_args[0]).not_to include("test-passphrase-from-credentials")
+    end
+
+    it "raises BackupError when gpg exits non-zero" do
+      bad_status = instance_double(Process::Status, success?: false, exitstatus: 2)
+      allow(Open3).to receive(:capture3)
+        .with(a_string_including("gpg"))
+        .and_return([ "", "gpg: error", bad_status ])
+
+      expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /gpg encryption failed/)
+    end
+  end
+
+  # ── SFTP upload path ─────────────────────────────────────────────────────
+
+  describe "SFTP upload path" do
+    # frozen_time is 2026-05-01T02:00:00Z
+    before { job.perform }
+
+    it "uploads to the correct YYYY/MM path" do
+      expect(sftp_upload_args[1]).to match(
+        %r{expense-tracker/2026/05/expense_tracker_production-20260501T020000Z\.dump\.gpg\z}
+      )
+    end
+
+    it "creates the remote directory structure before uploading" do
+      # sftp_mkdir_p calls mkdir! once per path segment.
+      # "expense-tracker/2026/05" → 3 segments → at least 3 mkdir! calls.
+      expect(sftp_session).to have_received(:mkdir!).at_least(3).times
+    end
+
+    it "connects to the configured Storage Box host" do
+      # Net::SFTP.start is called twice per perform: once for upload, once for
+      # the retention pass. Both must use the configured credentials.
+      expect(Net::SFTP).to have_received(:start).with(
+        "u000000.your-storagebox.de",
+        "u000000",
+        hash_including(keys: [ "/run/secrets/storage_box_key" ])
+      ).at_least(:once)
+    end
+  end
+
+  # ── retention policy (unit-tested directly via #send) ────────────────────
+
+  describe "#files_to_delete (retention policy)" do
+    # Build synthetic filenames spanning multiple months.
+    def filename_for(time)
+      "expense_tracker_production-#{time.utc.strftime('%Y%m%dT%H%M%SZ')}.dump.gpg"
+    end
+
+    around { |e| travel_to(Time.zone.parse("2026-05-15T02:00:00Z")) { e.run } }
+
+    let(:now) { Time.now.utc }
+
+    # 35 daily backups going back from now (index 0 = today, 34 = 35 days ago)
+    let(:daily_files) do
+      (0..34).map { |n| filename_for(now - n.days) }
+    end
+
+    # first-of-month anchors going back 14 months
+    let(:monthly_files) do
+      (1..14).map { |n| filename_for(now.beginning_of_month - n.months) }
+    end
+
+    let(:all_files) { (daily_files + monthly_files).uniq }
+
+    subject(:to_delete) { job.send(:files_to_delete, all_files) }
+
+    it "returns an Array" do
+      expect(to_delete).to be_an(Array)
+    end
+
+    it "keeps the most recent 30 daily backups" do
+      daily_files.first(30).each do |f|
+        expect(to_delete).not_to include(f), "#{f} should be kept (within 30-day daily window)"
+      end
+    end
+
+    it "deletes daily backups older than 30 days that are not monthly anchors" do
+      old_dailies = daily_files[30..].reject do |f|
+        # Monthly anchors on the 1st of the month are kept regardless of age.
+        # Filename format: expense_tracker_production-YYYYMMDDTHHMMSSZ.dump.gpg
+        m = f.match(/(\d{4})(\d{2})(\d{2})T/)
+        m && m[3].to_i == 1
+      end
+      old_dailies.each do |f|
+        expect(to_delete).to include(f), "#{f} should be deleted (>30 days, not monthly anchor)"
+      end
+    end
+
+    it "keeps first-of-month files within the 12-month window" do
+      monthly_files.first(12).each do |f|
+        expect(to_delete).not_to include(f), "#{f} should be kept (within 12-month monthly window)"
+      end
+    end
+
+    it "deletes first-of-month files outside the 12-month window" do
+      monthly_files[12..].each do |f|
+        expect(to_delete).to include(f), "#{f} should be deleted (outside 12-month monthly window)"
+      end
+    end
+
+    it "never deletes a file that is within the 30-day window" do
+      daily_files.first(30).each do |f|
+        expect(to_delete).not_to include(f)
+      end
+    end
+  end
+
+  # ── GPG passphrase resolution ─────────────────────────────────────────────
+
+  describe "GPG passphrase resolution" do
+    it "falls back to BACKUP_GPG_PASSPHRASE env var when credentials return nil" do
+      allow(Rails.application.credentials).to receive(:dig)
+        .with(:backup, :gpg_passphrase).and_return(nil)
+      stub_const("ENV", ENV.to_hash.merge(
+        "STORAGE_BOX_HOST"      => "u000000.your-storagebox.de",
+        "STORAGE_BOX_USER"      => "u000000",
+        "STORAGE_BOX_SSH_KEY"   => "/run/secrets/storage_box_key",
+        "BACKUP_GPG_PASSPHRASE" => "env-passphrase"
+      ))
+
+      expect { job.perform }.not_to raise_error
+    end
+
+    it "raises BackupError when neither credentials nor ENV provides a passphrase" do
+      allow(Rails.application.credentials).to receive(:dig)
+        .with(:backup, :gpg_passphrase).and_return(nil)
+      stub_const("ENV", ENV.to_hash.merge(
+        "STORAGE_BOX_HOST"    => "u000000.your-storagebox.de",
+        "STORAGE_BOX_USER"    => "u000000",
+        "STORAGE_BOX_SSH_KEY" => "/run/secrets/storage_box_key"
+      ).except("BACKUP_GPG_PASSPHRASE"))
+
+      expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /passphrase/)
+    end
+  end
+
+  # ── temp file cleanup ─────────────────────────────────────────────────────
+
+  describe "temp file cleanup" do
+    it "removes local dump and encrypted files after uploading" do
+      job.perform
+      expect(FileUtils).to have_received(:rm_f).at_least(2).times
+    end
+  end
+end

--- a/spec/jobs/postgres_backup_job_spec.rb
+++ b/spec/jobs/postgres_backup_job_spec.rb
@@ -8,23 +8,22 @@ require "rails_helper"
 # stubbed so the suite runs without a Postgres server, GPG binary, or a
 # reachable Storage Box.
 #
-# Design: the before block stubs everything to a "happy path" default.
-# Individual tests override the stub and/or assert against captured call args.
+# Open3 is invoked in argv form (no /bin/sh), so stubs match on the first
+# positional arg ("pg_dump" / "gpg") rather than a joined string.
 RSpec.describe PostgresBackupJob, type: :job, unit: true do
   subject(:job) { described_class.new }
 
   # ── shared fake objects ───────────────────────────────────────────────────
 
   let(:fake_sftp_dir) do
-    # double: glob yields nothing (empty Storage Box) by default
     dbl = double("Net::SFTP::Operations::Dir")  # rubocop:disable RSpec/VerifiedDoubles
     allow(dbl).to receive(:glob)
     dbl
   end
 
   let(:sftp_session) do
-    # Use plain double — Net::SFTP::Session doesn't expose mkdir_p!.
-    # Our job implements sftp_mkdir_p as a helper that calls mkdir! per segment.
+    # Net::SFTP::Session doesn't expose every method we stub here; plain
+    # double avoids verifying-double false negatives.
     dbl = double("Net::SFTP::Session")  # rubocop:disable RSpec/VerifiedDoubles
     allow(dbl).to receive(:mkdir!).and_return(nil)
     allow(dbl).to receive(:upload!)
@@ -33,59 +32,67 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
     dbl
   end
 
-  let(:ok_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  let(:ok_status)  { instance_double(Process::Status, success?: true,  exitstatus: 0) }
+  let(:bad_status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
   let(:frozen_time) { Time.zone.parse("2026-05-01T02:00:00Z") }
 
-  # Captured call args — populated by the before-block stubs
-  let(:pg_dump_call_args) { [] }
-  let(:gpg_call_args)     { [] }
-  let(:sftp_upload_args)  { [] }
+  # Captured argv for assertions
+  let(:pg_dump_call) { { env: nil, args: nil } }
+  let(:gpg_call)     { { args: nil } }
+  let(:sftp_upload)  { { local: nil, remote: nil } }
 
   before do
     travel_to(frozen_time)
 
-    # Credentials
     allow(Rails.application.credentials).to receive(:dig)
       .with(:backup, :gpg_passphrase)
       .and_return("test-passphrase-from-credentials")
 
-    # Required Storage Box env vars
     stub_const("ENV", ENV.to_hash.merge(
       "STORAGE_BOX_HOST"    => "u000000.your-storagebox.de",
       "STORAGE_BOX_USER"    => "u000000",
       "STORAGE_BOX_SSH_KEY" => "/run/secrets/storage_box_key"
     ))
 
-    # Capture pg_dump call args
-    allow(Open3).to receive(:capture3)
-      .with(hash_including("PGPASSWORD"), a_string_starting_with("pg_dump")) do |env_hash, cmd|
-        pg_dump_call_args.replace([ env_hash, cmd ])
-        [ "", "", ok_status ]
+    # Argv-form Open3.capture3:
+    #   - pg_dump: capture3({env}, "pg_dump", "--format=custom", ..., db)
+    #   - gpg:     capture3("gpg", "--batch", ...)
+    allow(Open3).to receive(:capture3) do |*invocation|
+      first = invocation.first
+      if first.is_a?(Hash)
+        pg_dump_call[:env]  = first
+        pg_dump_call[:args] = invocation[1..]
+      else
+        gpg_call[:args] = invocation
       end
-
-    # Capture gpg call args
-    allow(Open3).to receive(:capture3)
-      .with(a_string_including("gpg")) do |cmd|
-        gpg_call_args.replace([ cmd ])
-        [ "", "", ok_status ]
-      end
-
-    # Capture SFTP upload args
-    allow(sftp_session).to receive(:upload!) do |local, remote|
-      sftp_upload_args.replace([ local, remote ])
+      [ "", "", ok_status ]
     end
 
-    # SFTP.start
+    allow(sftp_session).to receive(:upload!) do |local, remote|
+      sftp_upload[:local]  = local
+      sftp_upload[:remote] = remote
+    end
+
     allow(Net::SFTP).to receive(:start).and_yield(sftp_session)
 
-    # Tempfile for passphrase
     fake_tf = instance_double(Tempfile,
       path: "/tmp/fake_pass_file",
       close!: nil, write: nil, flush: nil, chmod: nil)
     allow(Tempfile).to receive(:new).with("gpg_passphrase").and_return(fake_tf)
 
-    # FileUtils.rm_f
     allow(FileUtils).to receive(:rm_f)
+
+    # The job chmods + size-checks the dump file. Open3 is stubbed so the
+    # file never actually exists; pretend it does and is large enough.
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:size?).and_call_original
+    allow(File).to receive(:chmod).and_call_original
+    allow(File).to receive(:exist?).with(/\.dump\z/).and_return(true)
+    allow(File).to receive(:size?).with(/\.dump\z/).and_return(2_048)
+    allow(File).to receive(:chmod).with(0o600, /\.dump\z/).and_return(0)
+
+    # Cache write for last_success_at
+    allow(Rails.cache).to receive(:write).and_call_original
   end
 
   after { travel_back }
@@ -103,37 +110,47 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
   describe "pg_dump command composition" do
     before { job.perform }
 
-    it "passes PGPASSWORD via the Open3 env hash (never on the command line)" do
-      expect(pg_dump_call_args[0]).to include("PGPASSWORD")
+    it "passes PGPASSWORD via the Open3 env hash (never as an argv element)" do
+      expect(pg_dump_call[:env]).to include("PGPASSWORD")
+      expect(pg_dump_call[:args]).not_to include(a_string_matching(/PGPASSWORD/))
     end
 
-    it "does NOT embed PGPASSWORD in the command string" do
-      expect(pg_dump_call_args[1]).not_to include("PGPASSWORD")
+    it "invokes pg_dump in argv form (no shell)" do
+      expect(pg_dump_call[:args].first).to eq("pg_dump")
     end
 
-    it "uses --format=custom" do
-      expect(pg_dump_call_args[1]).to include("--format=custom")
-    end
-
-    it "uses --no-owner" do
-      expect(pg_dump_call_args[1]).to include("--no-owner")
-    end
-
-    it "uses --no-acl" do
-      expect(pg_dump_call_args[1]).to include("--no-acl")
+    it "uses --format=custom, --no-owner, --no-acl, --lock-wait-timeout" do
+      expect(pg_dump_call[:args]).to include(
+        "--format=custom", "--no-owner", "--no-acl", "--lock-wait-timeout=30000"
+      )
     end
 
     it "targets expense_tracker_production" do
-      expect(pg_dump_call_args[1]).to include("expense_tracker_production")
+      expect(pg_dump_call[:args]).to include("expense_tracker_production")
     end
 
     it "raises BackupError when pg_dump exits non-zero" do
-      bad_status = instance_double(Process::Status, success?: false, exitstatus: 1)
-      allow(Open3).to receive(:capture3)
-        .with(hash_including("PGPASSWORD"), a_string_starting_with("pg_dump"))
-        .and_return([ "", "connection refused", bad_status ])
+      allow(Open3).to receive(:capture3) do |*invocation|
+        if invocation.first.is_a?(Hash)
+          [ "", "connection refused", bad_status ]
+        else
+          [ "", "", ok_status ]
+        end
+      end
 
       expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /pg_dump failed/)
+    end
+
+    it "raises BackupError when pg_dump produces an empty/missing file" do
+      allow(File).to receive(:size?).with(/\.dump\z/).and_return(0)
+
+      expect { job.perform }.to raise_error(
+        PostgresBackupJob::BackupError, /empty\/missing/
+      )
+    end
+
+    it "chmods the dump to 0600 immediately after pg_dump" do
+      expect(File).to have_received(:chmod).with(0o600, /\.dump\z/)
     end
   end
 
@@ -142,32 +159,29 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
   describe "GPG encryption command composition" do
     before { job.perform }
 
-    it "invokes gpg" do
-      expect(gpg_call_args[0]).to include("gpg")
+    it "invokes gpg in argv form" do
+      expect(gpg_call[:args].first).to eq("gpg")
     end
 
-    it "uses --symmetric" do
-      expect(gpg_call_args[0]).to include("--symmetric")
+    it "uses --symmetric, --batch, AES256, --passphrase-file" do
+      expect(gpg_call[:args]).to include(
+        "--symmetric", "--batch", "AES256", "--passphrase-file"
+      )
     end
 
-    it "uses AES256 cipher" do
-      expect(gpg_call_args[0]).to include("AES256")
-    end
-
-    it "uses --batch (non-interactive)" do
-      expect(gpg_call_args[0]).to include("--batch")
-    end
-
-    it "passes passphrase via --passphrase-file (not on command line)" do
-      expect(gpg_call_args[0]).to include("--passphrase-file")
-      expect(gpg_call_args[0]).not_to include("test-passphrase-from-credentials")
+    it "passes the passphrase tempfile path, not the passphrase itself" do
+      expect(gpg_call[:args]).to include("/tmp/fake_pass_file")
+      expect(gpg_call[:args]).not_to include("test-passphrase-from-credentials")
     end
 
     it "raises BackupError when gpg exits non-zero" do
-      bad_status = instance_double(Process::Status, success?: false, exitstatus: 2)
-      allow(Open3).to receive(:capture3)
-        .with(a_string_including("gpg"))
-        .and_return([ "", "gpg: error", bad_status ])
+      allow(Open3).to receive(:capture3) do |*invocation|
+        if invocation.first.is_a?(Hash)
+          [ "", "", ok_status ]
+        else
+          [ "", "gpg: error", bad_status ]
+        end
+      end
 
       expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /gpg encryption failed/)
     end
@@ -176,24 +190,19 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
   # ── SFTP upload path ─────────────────────────────────────────────────────
 
   describe "SFTP upload path" do
-    # frozen_time is 2026-05-01T02:00:00Z
     before { job.perform }
 
     it "uploads to the correct YYYY/MM path" do
-      expect(sftp_upload_args[1]).to match(
+      expect(sftp_upload[:remote]).to match(
         %r{expense-tracker/2026/05/expense_tracker_production-20260501T020000Z\.dump\.gpg\z}
       )
     end
 
     it "creates the remote directory structure before uploading" do
-      # sftp_mkdir_p calls mkdir! once per path segment.
-      # "expense-tracker/2026/05" → 3 segments → at least 3 mkdir! calls.
       expect(sftp_session).to have_received(:mkdir!).at_least(3).times
     end
 
     it "connects to the configured Storage Box host" do
-      # Net::SFTP.start is called twice per perform: once for upload, once for
-      # the retention pass. Both must use the configured credentials.
       expect(Net::SFTP).to have_received(:start).with(
         "u000000.your-storagebox.de",
         "u000000",
@@ -202,10 +211,58 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
     end
   end
 
-  # ── retention policy (unit-tested directly via #send) ────────────────────
+  # ── SFTP failure paths ───────────────────────────────────────────────────
+
+  describe "SFTP failure handling" do
+    it "re-raises StatusException codes other than FX_FAILURE (e.g. FX_PERMISSION_DENIED)" do
+      perm_denied = Net::SFTP::StatusException.new(
+        instance_double(Net::SFTP::Response,
+          code: Net::SFTP::Constants::StatusCodes::FX_PERMISSION_DENIED,
+          message: "permission denied"),
+        "permission denied"
+      )
+      allow(sftp_session).to receive(:mkdir!).and_raise(perm_denied)
+
+      expect { job.perform }.to raise_error(Net::SFTP::StatusException)
+    end
+
+    it "ignores FX_FAILURE on mkdir! (directory already exists)" do
+      already_exists = Net::SFTP::StatusException.new(
+        instance_double(Net::SFTP::Response,
+          code: Net::SFTP::Constants::StatusCodes::FX_FAILURE,
+          message: "failure"),
+        "failure"
+      )
+      allow(sftp_session).to receive(:mkdir!).and_raise(already_exists)
+
+      expect { job.perform }.not_to raise_error
+    end
+
+    it "propagates upload! failures and still cleans up local files" do
+      allow(sftp_session).to receive(:upload!).and_raise(StandardError, "connection lost")
+
+      expect { job.perform }.to raise_error(StandardError, /connection lost/)
+      expect(FileUtils).to have_received(:rm_f).at_least(2).times
+    end
+
+    it "swallows retention failures (backup itself succeeded)" do
+      call_count = 0
+      allow(Net::SFTP).to receive(:start) do |&block|
+        call_count += 1
+        if call_count == 1
+          block.call(sftp_session) # upload pass succeeds
+        else
+          raise StandardError, "retention pass exploded"
+        end
+      end
+
+      expect { job.perform }.not_to raise_error
+    end
+  end
+
+  # ── retention policy ─────────────────────────────────────────────────────
 
   describe "#files_to_delete (retention policy)" do
-    # Build synthetic filenames spanning multiple months.
     def filename_for(time)
       "expense_tracker_production-#{time.utc.strftime('%Y%m%dT%H%M%SZ')}.dump.gpg"
     end
@@ -214,58 +271,75 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
 
     let(:now) { Time.now.utc }
 
-    # 35 daily backups going back from now (index 0 = today, 34 = 35 days ago)
-    let(:daily_files) do
-      (0..34).map { |n| filename_for(now - n.days) }
-    end
-
-    # first-of-month anchors going back 14 months
-    let(:monthly_files) do
-      (1..14).map { |n| filename_for(now.beginning_of_month - n.months) }
-    end
-
-    let(:all_files) { (daily_files + monthly_files).uniq }
+    let(:daily_files)   { (0..34).map { |n| filename_for(now - n.days) } }
+    # 14 prior monthly anchors (n = 1..14, so beginning_of_month -1mo..-14mo)
+    let(:monthly_files) { (1..14).map { |n| filename_for(now.beginning_of_month - n.months) } }
+    let(:all_files)     { (daily_files + monthly_files).uniq }
 
     subject(:to_delete) { job.send(:files_to_delete, all_files) }
 
-    it "returns an Array" do
-      expect(to_delete).to be_an(Array)
-    end
-
-    it "keeps the most recent 30 daily backups" do
+    it "keeps every file in the 30-day daily window" do
       daily_files.first(30).each do |f|
-        expect(to_delete).not_to include(f), "#{f} should be kept (within 30-day daily window)"
+        expect(to_delete).not_to include(f)
       end
     end
 
-    it "deletes daily backups older than 30 days that are not monthly anchors" do
+    it "deletes daily backups older than 30 days that are not first-of-month anchors" do
       old_dailies = daily_files[30..].reject do |f|
-        # Monthly anchors on the 1st of the month are kept regardless of age.
-        # Filename format: expense_tracker_production-YYYYMMDDTHHMMSSZ.dump.gpg
         m = f.match(/(\d{4})(\d{2})(\d{2})T/)
         m && m[3].to_i == 1
       end
       old_dailies.each do |f|
-        expect(to_delete).to include(f), "#{f} should be deleted (>30 days, not monthly anchor)"
+        expect(to_delete).to include(f)
       end
     end
 
-    it "keeps first-of-month files within the 12-month window" do
-      monthly_files.first(12).each do |f|
-        expect(to_delete).not_to include(f), "#{f} should be kept (within 12-month monthly window)"
-      end
-    end
-
-    it "deletes first-of-month files outside the 12-month window" do
-      monthly_files[12..].each do |f|
-        expect(to_delete).to include(f), "#{f} should be deleted (outside 12-month monthly window)"
-      end
-    end
-
-    it "never deletes a file that is within the 30-day window" do
-      daily_files.first(30).each do |f|
+    # Cutoff = now.beginning_of_month - 11.months = 2025-06-01.
+    # Anchors from -1mo (2026-04-01) through -11mo (2025-06-01) are kept (11 files).
+    # Anchor at -12mo (2025-05-01) and earlier are deleted.
+    it "keeps the 11 most recent prior-month anchors (12 total including current month)" do
+      monthly_files.first(11).each do |f|
         expect(to_delete).not_to include(f)
       end
+    end
+
+    it "deletes monthly anchors beyond the 12-month window" do
+      monthly_files[11..].each do |f|
+        expect(to_delete).to include(f)
+      end
+    end
+
+    it "leaves malformed filenames alone (does not delete them)" do
+      garbage = "not-a-backup.dump.gpg"
+      result = job.send(:files_to_delete, all_files + [ garbage ])
+      expect(result).not_to include(garbage)
+    end
+  end
+
+  # ── retention end-to-end ─────────────────────────────────────────────────
+
+  describe "retention removes the right files via SFTP" do
+    let(:now) { Time.zone.parse("2026-05-15T02:00:00Z") }
+    let(:old_filename) do
+      # 18 months ago — outside the 30-day daily window AND outside the
+      # 12-month monthly window, so the file would be kept as the only
+      # anchor for its month otherwise.
+      ts = (now - 18.months).utc.strftime("%Y%m%dT%H%M%SZ")
+      "expense_tracker_production-#{ts}.dump.gpg"
+    end
+
+    around { |e| travel_to(now) { e.run } }
+
+    it "calls remove! for files outside both windows" do
+      allow(fake_sftp_dir).to receive(:glob).and_yield(
+        instance_double(Net::SFTP::Protocol::V01::Name, name: old_filename)
+      )
+
+      job.perform
+
+      expect(sftp_session).to have_received(:remove!).with(
+        a_string_including("expense-tracker/")
+      )
     end
   end
 
@@ -294,11 +368,22 @@ RSpec.describe PostgresBackupJob, type: :job, unit: true do
         "STORAGE_BOX_SSH_KEY" => "/run/secrets/storage_box_key"
       ).except("BACKUP_GPG_PASSPHRASE"))
 
-      expect { job.perform }.to raise_error(PostgresBackupJob::BackupError, /passphrase/)
+      expect { job.perform }.to raise_error(
+        PostgresBackupJob::BackupError, /No GPG passphrase configured/
+      )
     end
   end
 
-  # ── temp file cleanup ─────────────────────────────────────────────────────
+  # ── observability + cleanup ───────────────────────────────────────────────
+
+  describe "observability" do
+    it "writes last_success_at to Rails.cache after a successful backup" do
+      job.perform
+      expect(Rails.cache).to have_received(:write).with(
+        "postgres_backup.last_success_at", anything, hash_including(expires_in: 7.days)
+      )
+    end
+  end
 
   describe "temp file cleanup" do
     it "removes local dump and encrypted files after uploading" do


### PR DESCRIPTION
## Summary

- Adds `PostgresBackupJob` (Solid Queue, `low` queue, 02:00 UTC daily) that runs `pg_dump → GPG AES256 encrypt → SFTP upload` to Hetzner Storage Box
- Retention policy: keep all daily backups for 30 days + first-of-month anchor for 12 months; everything else is deleted
- Adds `net-sftp ~> 4.0` gem (SFTP transport to Storage Box; no Hetzner-specific SDK)
- Adds rake helpers: `postgres_backup:run_now`, `postgres_backup:list_remote`, `postgres_backup:restore[FILENAME]`
- Wires 4 new secrets (`STORAGE_BOX_HOST`, `STORAGE_BOX_USER`, `STORAGE_BOX_SSH_KEY`, `BACKUP_GPG_PASSPHRASE`) into `config/deploy.yml` and `bin/pre-deploy-check`
- 26-example spec suite; all subprocess and network calls stubbed — no real pg_dump, gpg, or SFTP connection needed

## Why Hetzner Storage Box

App already runs on Hetzner. Same provider = same private network = no egress cost. SSH/SFTP is the supported transfer mechanism for Storage Boxes. `net-sftp` is the mature, dependency-free Ruby SFTP client.

## Security notes

- `PGPASSWORD` is passed via `Open3.capture3`'s env hash (never on the command line or in logs)
- GPG passphrase is written to a mode-600 `Tempfile` and referenced via `--passphrase-file`; never interpolated into the command string
- Two Brakeman `Command Injection` warnings are false positives (all interpolated values come from Rails credentials / config ENV, not user input); suppressed in `config/brakeman.ignore` with explanatory notes

## Out of scope

- **Quarterly restore drill** — ops practice, not code. See operator action below.
- **Storage Box provisioning automation** — manual one-time setup (see below).

## Operator action required before deploy

**This PR adds 4 new required secrets. The app will fail to start unless these are populated in `.kamal/secrets` before the next `kamal deploy`.**

### 1. Provision the Hetzner Storage Box

Log into [Hetzner Robot](https://robot.hetzner.com) → Storage Boxes → Order a new Storage Box (BX11 or larger). Note the hostname (`u<id>.your-storagebox.de`) and username (`u<id>`).

### 2. Generate a dedicated SSH key pair

```bash
ssh-keygen -t ed25519 -C "expense-tracker-backup@$(date +%Y)" \
  -f ~/.ssh/expense_tracker_storage_box
```

Add the public key to the Storage Box:
```bash
ssh-copy-id -i ~/.ssh/expense_tracker_storage_box.pub \
  -p 23 u<id>@u<id>.your-storagebox.de
```

Test: `sftp -i ~/.ssh/expense_tracker_storage_box -P 23 u<id>@u<id>.your-storagebox.de`

### 3. Make the private key available to the container

The container needs the key at the path set in `STORAGE_BOX_SSH_KEY`. Two options:

**Option A (simpler, base64 in secrets):**
```bash
base64 -i ~/.ssh/expense_tracker_storage_box | pbcopy
```
Write a small Rails initializer or job hook that decodes `STORAGE_BOX_SSH_KEY_B64` to a file on boot. (Adjust `sftp_key_path` in the job accordingly.)

**Option B (Kamal volume):**
Place the key in a named Docker volume and mount it at e.g. `/run/secrets/storage_box_key`. Set `STORAGE_BOX_SSH_KEY=/run/secrets/storage_box_key`.

### 4. Generate a GPG passphrase

```bash
openssl rand -base64 32
```

Or use 1Password to generate a strong random password.

### 5. Add all four entries to 1Password and `.kamal/secrets`

| Secret | Value |
|--------|-------|
| `STORAGE_BOX_HOST` | `u<id>.your-storagebox.de` |
| `STORAGE_BOX_USER` | `u<id>` |
| `STORAGE_BOX_SSH_KEY` | path to key inside container (see step 3) |
| `BACKUP_GPG_PASSPHRASE` | passphrase from step 4 |

Store GPG passphrase in `Rails credentials` under `backup.gpg_passphrase` (preferred) **or** in `BACKUP_GPG_PASSPHRASE` in `.kamal/secrets`.

### 6. Test manually after deploy

```bash
bin/rails postgres_backup:run_now
bin/rails postgres_backup:list_remote
```

### 7. Verify the encrypted file can be decrypted (quarterly restore drill)

```bash
# List remote files
bin/rails postgres_backup:list_remote

# Download and decrypt (does NOT auto-restore — operator runs pg_restore manually)
bin/rails 'postgres_backup:restore[expense_tracker_production-20260501T020000Z.dump.gpg]'

# Restore into a scratch database
pg_restore --clean --if-exists -d expense_tracker_restore_test /path/to/file.dump
```

**Schedule a quarterly drill** in your calendar to verify end-to-end restore works. This is an ops practice, not automated by this PR.

## Test plan

- [x] 26 unit specs pass (`bundle exec rspec spec/jobs/postgres_backup_job_spec.rb --tag unit`)
- [x] Full unit suite green (9025 examples, 0 failures)
- [x] RuboCop clean
- [x] Brakeman clean (2 false-positive Command Injection warnings suppressed with notes)
- [ ] After deploy: `bin/rails postgres_backup:run_now` produces a file in Storage Box
- [ ] After deploy: `bin/rails postgres_backup:list_remote` lists the file
- [ ] After deploy: `bin/rails 'postgres_backup:restore[FILE]'` downloads and decrypts it