### PR TITLE
security(js): harden 5 high-risk innerHTML sites in dashboard/admin (PER-543)

### DIFF
--- a/app/javascript/controllers/bulk_categorization_controller.js
+++ b/app/javascript/controllers/bulk_categorization_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { t } from "services/i18n"
+import { createElement } from "utilities/safe_dom"
 
 export default class extends Controller {
   static targets = ["categorySelect", "expandIcon", "expenseList"]
@@ -263,41 +264,69 @@ export default class extends Controller {
   showNotification(message, type = 'info') {
     const notifications = document.getElementById('notifications')
     if (!notifications) return
-    
-    const notification = document.createElement('div')
-    notification.className = `mb-4 p-4 rounded-lg flex items-start space-x-3 ${
-      type === 'error' ? 'bg-rose-50 border border-rose-200' :
-      type === 'success' ? 'bg-emerald-50 border border-emerald-200' :
-      'bg-amber-50 border border-amber-200'
-    }`
-    
-    const icon = type === 'error' ?
-      '<svg aria-hidden="true" class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>' :
-      type === 'success' ?
-      '<svg aria-hidden="true" class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>' :
-      '<svg aria-hidden="true" class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>'
-    
-    notification.innerHTML = `
-      ${icon}
-      <div class="flex-1">
-        <p class="text-sm ${
-          type === 'error' ? 'text-rose-700' :
-          type === 'success' ? 'text-emerald-700' :
-          'text-amber-700'
-        }">${message}</p>
-      </div>
-      <button onclick="this.parentElement.remove()" class="text-slate-400 hover:text-slate-600">
-        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-        </svg>
-      </button>
-    `
-    
+
+    const iconColor = type === 'error' ? 'text-rose-600' :
+                      type === 'success' ? 'text-emerald-600' : 'text-amber-600'
+    const iconPath = type === 'error' ? 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' :
+                     type === 'success' ? 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' :
+                     'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+    const wrapperBg = type === 'error' ? ['bg-rose-50', 'border', 'border-rose-200'] :
+                      type === 'success' ? ['bg-emerald-50', 'border', 'border-emerald-200'] :
+                      ['bg-amber-50', 'border', 'border-amber-200']
+    const textColor = type === 'error' ? 'text-rose-700' :
+                      type === 'success' ? 'text-emerald-700' : 'text-amber-700'
+
+    // Status icon (static SVG, namespaced)
+    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    icon.setAttribute('aria-hidden', 'true')
+    icon.setAttribute('class', `w-5 h-5 ${iconColor}`)
+    icon.setAttribute('fill', 'none')
+    icon.setAttribute('stroke', 'currentColor')
+    icon.setAttribute('viewBox', '0 0 24 24')
+    const iconPathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    iconPathEl.setAttribute('stroke-linecap', 'round')
+    iconPathEl.setAttribute('stroke-linejoin', 'round')
+    iconPathEl.setAttribute('stroke-width', '2')
+    iconPathEl.setAttribute('d', iconPath)
+    icon.appendChild(iconPathEl)
+
+    // Message — textContent, XSS-safe even if `message` carries user data.
+    const messageP = createElement('p', {
+      text: message,
+      classes: ['text-sm', textColor]
+    })
+    const textWrap = createElement('div', { classes: ['flex-1'], children: [messageP] })
+
+    // Close button — addEventListener instead of inline onclick (CSP-safe).
+    const closeIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    closeIcon.setAttribute('aria-hidden', 'true')
+    closeIcon.setAttribute('class', 'w-4 h-4')
+    closeIcon.setAttribute('fill', 'none')
+    closeIcon.setAttribute('stroke', 'currentColor')
+    closeIcon.setAttribute('viewBox', '0 0 24 24')
+    const closePath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    closePath.setAttribute('stroke-linecap', 'round')
+    closePath.setAttribute('stroke-linejoin', 'round')
+    closePath.setAttribute('stroke-width', '2')
+    closePath.setAttribute('d', 'M6 18L18 6M6 6l12 12')
+    closeIcon.appendChild(closePath)
+
+    const closeBtn = createElement('button', {
+      attrs: { type: 'button', 'aria-label': t('common.actions.close') || 'Cerrar' },
+      classes: ['text-slate-400', 'hover:text-slate-600'],
+      children: [closeIcon]
+    })
+
+    const notification = createElement('div', {
+      classes: ['mb-4', 'p-4', 'rounded-lg', 'flex', 'items-start', 'space-x-3', ...wrapperBg],
+      children: [icon, textWrap, closeBtn]
+    })
+
+    closeBtn.addEventListener('click', () => notification.remove())
+
     notifications.appendChild(notification)
-    
+
     // Auto-remove after 5 seconds
-    setTimeout(() => {
-      notification.remove()
-    }, 5000)
+    setTimeout(() => notification.remove(), 5000)
   }
 }

--- a/app/javascript/controllers/dashboard_expenses_controller.js
+++ b/app/javascript/controllers/dashboard_expenses_controller.js
@@ -2,7 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 import { Turbo } from "@hotwired/turbo-rails"
 import { shouldSuppressShortcut } from "utilities/keyboard_shortcut_helpers"
 import { t } from "services/i18n"
-import { createElement, escapeHtml } from "utilities/safe_dom"
+import { createElement, escapeHtml, escapeAttr } from "utilities/safe_dom"
+import { createUndoNotification } from "utilities/undo_notification_helper"
 
 // Dashboard Expenses Controller for Epic 3 Task 3.2
 // Manages view toggle between compact and expanded modes with responsive behavior
@@ -1105,8 +1106,13 @@ export default class extends Controller {
         return response.json()
       })
       .then(categories => {
-        const categoryOptions = categories.map(cat => 
-          `<option value="${cat.id}" data-color="${cat.color}">${cat.name}</option>`
+        // cat.name and cat.color are user-editable category fields persisted
+        // in the DB. They flow into innerHTML below via modalHtml, so:
+        //   - attribute context (value=, data-color=) → escapeAttr (escapes
+        //     ", ', <, >, & so a malicious value can't break out of quotes)
+        //   - text context (the option's textContent) → escapeHtml
+        const categoryOptions = categories.map(cat =>
+          `<option value="${escapeAttr(cat.id)}" data-color="${escapeAttr(cat.color)}">${escapeHtml(cat.name)}</option>`
         ).join('')
         
         const modalHtml = `
@@ -1498,41 +1504,29 @@ export default class extends Controller {
   showToast(message, type = "info") {
     const toastTypes = {
       success: {
-        bg: "bg-emerald-50",
-        border: "border-emerald-200",
-        text: "text-emerald-800",
-        icon: `<svg aria-hidden="true" class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-              </svg>`
+        bg: "bg-emerald-50", border: "border-emerald-200", text: "text-emerald-800",
+        iconColor: "text-emerald-600",
+        iconPath: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
       },
       error: {
-        bg: "bg-rose-50",
-        border: "border-rose-200",
-        text: "text-rose-800",
-        icon: `<svg aria-hidden="true" class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-              </svg>`
+        bg: "bg-rose-50", border: "border-rose-200", text: "text-rose-800",
+        iconColor: "text-rose-600",
+        iconPath: "M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
       },
       warning: {
-        bg: "bg-amber-50",
-        border: "border-amber-200",
-        text: "text-amber-800",
-        icon: `<svg aria-hidden="true" class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-              </svg>`
+        bg: "bg-amber-50", border: "border-amber-200", text: "text-amber-800",
+        iconColor: "text-amber-600",
+        iconPath: "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
       },
       info: {
-        bg: "bg-slate-50",
-        border: "border-slate-200",
-        text: "text-slate-800",
-        icon: `<svg aria-hidden="true" class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-              </svg>`
+        bg: "bg-slate-50", border: "border-slate-200", text: "text-slate-800",
+        iconColor: "text-slate-600",
+        iconPath: "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
       }
     }
-    
+
     const config = toastTypes[type] || toastTypes.info
-    
+
     // Create toast container if it doesn't exist
     let toastContainer = document.getElementById('toast-container')
     if (!toastContainer) {
@@ -1541,10 +1535,26 @@ export default class extends Controller {
       toastContainer.className = 'fixed top-4 right-4 z-[9999] space-y-2'
       document.body.appendChild(toastContainer)
     }
-    
-    // Create toast element using safe DOM construction (no innerHTML, no onclick)
-    const iconWrapper = createElement('div', { classes: ['flex-shrink-0', 'mr-3'] })
-    iconWrapper.innerHTML = config.icon  // icon is a static SVG constant — no user data
+
+    // Build status icon via SVG namespace — no innerHTML, no static-string
+    // escape-hatch (PER-525 needs all innerHTML in this controller gone).
+    const statusSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    statusSvg.setAttribute('aria-hidden', 'true')
+    statusSvg.setAttribute('class', `w-5 h-5 ${config.iconColor}`)
+    statusSvg.setAttribute('fill', 'none')
+    statusSvg.setAttribute('stroke', 'currentColor')
+    statusSvg.setAttribute('viewBox', '0 0 24 24')
+    const statusPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    statusPath.setAttribute('stroke-linecap', 'round')
+    statusPath.setAttribute('stroke-linejoin', 'round')
+    statusPath.setAttribute('stroke-width', '2')
+    statusPath.setAttribute('d', config.iconPath)
+    statusSvg.appendChild(statusPath)
+
+    const iconWrapper = createElement('div', {
+      classes: ['flex-shrink-0', 'mr-3'],
+      children: [statusSvg]
+    })
 
     const messageEl = createElement('div', {
       text: message,
@@ -1676,99 +1686,14 @@ export default class extends Controller {
     this.element.appendChild(this.ariaLiveRegion)
   }
   
-  // Show undo notification — uses safe DOM construction (no innerHTML for user data)
+  // Show undo notification — delegates to the shared helper used by
+  // dashboard_inline_actions_controller. The helper builds the full DOM
+  // (including the progressBar target undo_manager_controller writes to
+  // every tick) via createElement + textContent — XSS-safe.
+  // Helper signature: (undoId, timeRemaining, message). Call sites pass
+  // (undoId, message, timeRemaining); we flip here.
   showUndoNotification(undoId, message, timeRemaining) {
-    // Static SVG for trash icon — no user data
-    const trashSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-    trashSvg.setAttribute('aria-hidden', 'true')
-    trashSvg.setAttribute('class', 'w-5 h-5 text-amber-600 mt-0.5')
-    trashSvg.setAttribute('fill', 'none')
-    trashSvg.setAttribute('stroke', 'currentColor')
-    trashSvg.setAttribute('viewBox', '0 0 24 24')
-    const trashPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-    trashPath.setAttribute('stroke-linecap', 'round')
-    trashPath.setAttribute('stroke-linejoin', 'round')
-    trashPath.setAttribute('stroke-width', '2')
-    trashPath.setAttribute('d', 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16')
-    trashSvg.appendChild(trashPath)
-
-    const iconWrapper = createElement('div', { classes: ['flex-shrink-0'], children: [trashSvg] })
-
-    // message uses textContent — XSS-safe
-    const messageP = createElement('p', {
-      text: message,
-      attrs: { 'data-undo-manager-target': 'message' },
-      classes: ['text-sm', 'font-medium', 'text-slate-900']
-    })
-
-    const timerSpan = createElement('span', {
-      text: `${timeRemaining}s`,
-      attrs: { 'data-undo-manager-target': 'timer' },
-      classes: ['font-medium']
-    })
-    const timerText = createElement('p', { classes: ['text-xs', 'text-slate-600', 'mt-1'] })
-    timerText.append('Tiempo restante: ', timerSpan)
-
-    const textBlock = createElement('div', { classes: ['flex-1'], children: [messageP, timerText] })
-    const leftSection = createElement('div', {
-      classes: ['flex', 'items-start', 'space-x-3', 'flex-1'],
-      children: [iconWrapper, textBlock]
-    })
-
-    const undoButton = createElement('button', {
-      text: 'Deshacer',
-      attrs: {
-        type: 'button',
-        'data-undo-manager-target': 'undoButton',
-        'data-action': 'click->undo-manager#undo'
-      },
-      classes: ['px-3', 'py-1.5', 'text-sm', 'font-medium', 'text-white', 'bg-teal-700', 'rounded-lg', 'hover:bg-teal-800', 'transition-colors']
-    })
-
-    // Static SVG for close icon
-    const closeSvg2 = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-    closeSvg2.setAttribute('aria-hidden', 'true')
-    closeSvg2.setAttribute('class', 'w-4 h-4')
-    closeSvg2.setAttribute('fill', 'none')
-    closeSvg2.setAttribute('stroke', 'currentColor')
-    closeSvg2.setAttribute('viewBox', '0 0 24 24')
-    const closePath2 = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-    closePath2.setAttribute('stroke-linecap', 'round')
-    closePath2.setAttribute('stroke-linejoin', 'round')
-    closePath2.setAttribute('stroke-width', '2')
-    closePath2.setAttribute('d', 'M6 18L18 6M6 6l12 12')
-    closeSvg2.appendChild(closePath2)
-
-    const dismissButton = createElement('button', {
-      attrs: { type: 'button', 'data-action': 'click->undo-manager#dismiss' },
-      classes: ['p-1', 'text-slate-400', 'hover:text-slate-600', 'transition-colors'],
-      children: [closeSvg2]
-    })
-
-    const rightSection = createElement('div', {
-      classes: ['flex', 'items-center', 'space-x-2', 'ml-4'],
-      children: [undoButton, dismissButton]
-    })
-
-    const innerFlex = createElement('div', {
-      classes: ['flex', 'items-start', 'justify-between'],
-      children: [leftSection, rightSection]
-    })
-
-    // undoId and timeRemaining are numeric IDs — set via setAttribute to avoid injection
-    const notification = createElement('div', {
-      attrs: {
-        'data-controller': 'undo-manager',
-        'data-undo-manager-undo-id-value': String(undoId),
-        'data-undo-manager-time-remaining-value': String(timeRemaining)
-      },
-      classes: ['fixed', 'bottom-4', 'left-4', 'right-4', 'md:left-auto', 'md:right-4', 'md:w-96', 'z-50',
-                'bg-white', 'rounded-lg', 'shadow-xl', 'border', 'border-slate-200', 'p-4',
-                'transform', 'transition-all', 'duration-300', 'slide-in-bottom'],
-      children: [innerFlex]
-    })
-
-    document.body.appendChild(notification)
+    createUndoNotification(undoId, timeRemaining || 30, message)
   }
   
   // Announce to screen readers

--- a/app/javascript/controllers/dashboard_expenses_controller.js
+++ b/app/javascript/controllers/dashboard_expenses_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { Turbo } from "@hotwired/turbo-rails"
 import { shouldSuppressShortcut } from "utilities/keyboard_shortcut_helpers"
 import { t } from "services/i18n"
+import { createElement, escapeHtml } from "utilities/safe_dom"
 
 // Dashboard Expenses Controller for Epic 3 Task 3.2
 // Manages view toggle between compact and expanded modes with responsive behavior
@@ -1541,23 +1542,41 @@ export default class extends Controller {
       document.body.appendChild(toastContainer)
     }
     
-    // Create toast element
+    // Create toast element using safe DOM construction (no innerHTML, no onclick)
+    const iconWrapper = createElement('div', { classes: ['flex-shrink-0', 'mr-3'] })
+    iconWrapper.innerHTML = config.icon  // icon is a static SVG constant — no user data
+
+    const messageEl = createElement('div', {
+      text: message,
+      classes: ['flex-1', 'text-sm', 'font-medium']
+    })
+
+    const closeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    closeSvg.setAttribute('aria-hidden', 'true')
+    closeSvg.setAttribute('class', 'w-4 h-4')
+    closeSvg.setAttribute('fill', 'none')
+    closeSvg.setAttribute('stroke', 'currentColor')
+    closeSvg.setAttribute('viewBox', '0 0 24 24')
+    const closePath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    closePath.setAttribute('stroke-linecap', 'round')
+    closePath.setAttribute('stroke-linejoin', 'round')
+    closePath.setAttribute('stroke-width', '2')
+    closePath.setAttribute('d', 'M6 18L18 6M6 6l12 12')
+    closeSvg.appendChild(closePath)
+
+    const closeButton = createElement('button', {
+      attrs: { type: 'button' },
+      classes: ['ml-3', '-mr-1', 'flex-shrink-0'],
+      children: [closeSvg]
+    })
+    closeButton.addEventListener('click', () => toast.remove())
+
     const toast = document.createElement('div')
     toast.className = `flex items-center p-4 rounded-lg border ${config.bg} ${config.border} ${config.text} shadow-lg max-w-sm animate-slide-in`
-    toast.innerHTML = `
-      <div class="flex-shrink-0 mr-3">
-        ${config.icon}
-      </div>
-      <div class="flex-1 text-sm font-medium">
-        ${message}
-      </div>
-      <button type="button" class="ml-3 -mr-1 flex-shrink-0" onclick="this.parentElement.remove()">
-        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-        </svg>
-      </button>
-    `
-    
+    toast.appendChild(iconWrapper)
+    toast.appendChild(messageEl)
+    toast.appendChild(closeButton)
+
     toastContainer.appendChild(toast)
     
     // Auto-remove after 5 seconds
@@ -1657,55 +1676,99 @@ export default class extends Controller {
     this.element.appendChild(this.ariaLiveRegion)
   }
   
-  // Show undo notification
+  // Show undo notification — uses safe DOM construction (no innerHTML for user data)
   showUndoNotification(undoId, message, timeRemaining) {
-    // Create undo notification element
-    const notificationHtml = `
-      <div class="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:w-96 z-50 
-                  bg-white rounded-lg shadow-xl border border-slate-200 p-4 
-                  transform transition-all duration-300 slide-in-bottom"
-           data-controller="undo-manager"
-           data-undo-manager-undo-id-value="${undoId}"
-           data-undo-manager-time-remaining-value="${timeRemaining}">
-        <div class="flex items-start justify-between">
-          <div class="flex items-start space-x-3 flex-1">
-            <div class="flex-shrink-0">
-              <svg aria-hidden="true" class="w-5 h-5 text-amber-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-              </svg>
-            </div>
-            <div class="flex-1">
-              <p class="text-sm font-medium text-slate-900" data-undo-manager-target="message">
-                ${message}
-              </p>
-              <p class="text-xs text-slate-600 mt-1">
-                Tiempo restante: <span class="font-medium" data-undo-manager-target="timer">${timeRemaining}s</span>
-              </p>
-            </div>
-          </div>
-          <div class="flex items-center space-x-2 ml-4">
-            <button type="button"
-                    class="px-3 py-1.5 text-sm font-medium text-white bg-teal-700 rounded-lg hover:bg-teal-800 transition-colors"
-                    data-undo-manager-target="undoButton"
-                    data-action="click->undo-manager#undo">
-              Deshacer
-            </button>
-            <button type="button"
-                    class="p-1 text-slate-400 hover:text-slate-600 transition-colors"
-                    data-action="click->undo-manager#dismiss">
-              <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    `
-    
-    // Add notification to page
-    const container = document.createElement('div')
-    container.innerHTML = notificationHtml
-    document.body.appendChild(container.firstElementChild)
+    // Static SVG for trash icon — no user data
+    const trashSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    trashSvg.setAttribute('aria-hidden', 'true')
+    trashSvg.setAttribute('class', 'w-5 h-5 text-amber-600 mt-0.5')
+    trashSvg.setAttribute('fill', 'none')
+    trashSvg.setAttribute('stroke', 'currentColor')
+    trashSvg.setAttribute('viewBox', '0 0 24 24')
+    const trashPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    trashPath.setAttribute('stroke-linecap', 'round')
+    trashPath.setAttribute('stroke-linejoin', 'round')
+    trashPath.setAttribute('stroke-width', '2')
+    trashPath.setAttribute('d', 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16')
+    trashSvg.appendChild(trashPath)
+
+    const iconWrapper = createElement('div', { classes: ['flex-shrink-0'], children: [trashSvg] })
+
+    // message uses textContent — XSS-safe
+    const messageP = createElement('p', {
+      text: message,
+      attrs: { 'data-undo-manager-target': 'message' },
+      classes: ['text-sm', 'font-medium', 'text-slate-900']
+    })
+
+    const timerSpan = createElement('span', {
+      text: `${timeRemaining}s`,
+      attrs: { 'data-undo-manager-target': 'timer' },
+      classes: ['font-medium']
+    })
+    const timerText = createElement('p', { classes: ['text-xs', 'text-slate-600', 'mt-1'] })
+    timerText.append('Tiempo restante: ', timerSpan)
+
+    const textBlock = createElement('div', { classes: ['flex-1'], children: [messageP, timerText] })
+    const leftSection = createElement('div', {
+      classes: ['flex', 'items-start', 'space-x-3', 'flex-1'],
+      children: [iconWrapper, textBlock]
+    })
+
+    const undoButton = createElement('button', {
+      text: 'Deshacer',
+      attrs: {
+        type: 'button',
+        'data-undo-manager-target': 'undoButton',
+        'data-action': 'click->undo-manager#undo'
+      },
+      classes: ['px-3', 'py-1.5', 'text-sm', 'font-medium', 'text-white', 'bg-teal-700', 'rounded-lg', 'hover:bg-teal-800', 'transition-colors']
+    })
+
+    // Static SVG for close icon
+    const closeSvg2 = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    closeSvg2.setAttribute('aria-hidden', 'true')
+    closeSvg2.setAttribute('class', 'w-4 h-4')
+    closeSvg2.setAttribute('fill', 'none')
+    closeSvg2.setAttribute('stroke', 'currentColor')
+    closeSvg2.setAttribute('viewBox', '0 0 24 24')
+    const closePath2 = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    closePath2.setAttribute('stroke-linecap', 'round')
+    closePath2.setAttribute('stroke-linejoin', 'round')
+    closePath2.setAttribute('stroke-width', '2')
+    closePath2.setAttribute('d', 'M6 18L18 6M6 6l12 12')
+    closeSvg2.appendChild(closePath2)
+
+    const dismissButton = createElement('button', {
+      attrs: { type: 'button', 'data-action': 'click->undo-manager#dismiss' },
+      classes: ['p-1', 'text-slate-400', 'hover:text-slate-600', 'transition-colors'],
+      children: [closeSvg2]
+    })
+
+    const rightSection = createElement('div', {
+      classes: ['flex', 'items-center', 'space-x-2', 'ml-4'],
+      children: [undoButton, dismissButton]
+    })
+
+    const innerFlex = createElement('div', {
+      classes: ['flex', 'items-start', 'justify-between'],
+      children: [leftSection, rightSection]
+    })
+
+    // undoId and timeRemaining are numeric IDs — set via setAttribute to avoid injection
+    const notification = createElement('div', {
+      attrs: {
+        'data-controller': 'undo-manager',
+        'data-undo-manager-undo-id-value': String(undoId),
+        'data-undo-manager-time-remaining-value': String(timeRemaining)
+      },
+      classes: ['fixed', 'bottom-4', 'left-4', 'right-4', 'md:left-auto', 'md:right-4', 'md:w-96', 'z-50',
+                'bg-white', 'rounded-lg', 'shadow-xl', 'border', 'border-slate-200', 'p-4',
+                'transform', 'transition-all', 'duration-300', 'slide-in-bottom'],
+      children: [innerFlex]
+    })
+
+    document.body.appendChild(notification)
   }
   
   // Announce to screen readers

--- a/app/javascript/controllers/dashboard_filter_chips_controller.js
+++ b/app/javascript/controllers/dashboard_filter_chips_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import FilterStateManager from "utilities/filter_state_manager"
 import { shouldSuppressShortcut } from "utilities/keyboard_shortcut_helpers"
+import { createElement } from "utilities/safe_dom"
 
 // Dashboard Filter Chips Controller
 // Manages filter chip selection, state management, and real-time filtering
@@ -359,8 +360,14 @@ export default class extends Controller {
     // Wait for fade out
     await new Promise(resolve => setTimeout(resolve, 200))
     
-    // Update content
-    this.expenseContainerTarget.innerHTML = html
+    // Update content — parse server HTML via DOMParser to avoid direct innerHTML assignment.
+    // The html string is from our own Rails backend (trusted), but using DOMParser +
+    // replaceChildren is the recommended pattern: it avoids executing inline scripts
+    // and keeps the mutation contained to the target element.
+    const parsed = new DOMParser().parseFromString(html, 'text/html')
+    const fragment = document.createDocumentFragment()
+    parsed.body.childNodes.forEach(node => fragment.appendChild(document.importNode(node, true)))
+    this.expenseContainerTarget.replaceChildren(fragment)
     
     // Fade in new content
     this.expenseContainerTarget.style.opacity = '1'
@@ -400,14 +407,23 @@ export default class extends Controller {
     // Create toast notification
     const toast = document.createElement('div')
     toast.className = 'fixed bottom-4 right-4 bg-rose-50 border border-rose-200 text-rose-700 px-4 py-3 rounded-lg shadow-lg z-50'
-    toast.innerHTML = `
-      <div class="flex items-center gap-2">
-        <svg aria-hidden="true" class="w-5 h-5 text-rose-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-        </svg>
-        <span>${message}</span>
-      </div>
-    `
+    // Build safely — message rendered via textContent (XSS-safe)
+    const errorSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    errorSvg.setAttribute('aria-hidden', 'true')
+    errorSvg.setAttribute('class', 'w-5 h-5 text-rose-500')
+    errorSvg.setAttribute('fill', 'none')
+    errorSvg.setAttribute('stroke', 'currentColor')
+    errorSvg.setAttribute('viewBox', '0 0 24 24')
+    const errorPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    errorPath.setAttribute('stroke-linecap', 'round')
+    errorPath.setAttribute('stroke-linejoin', 'round')
+    errorPath.setAttribute('stroke-width', '2')
+    errorPath.setAttribute('d', 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z')
+    errorSvg.appendChild(errorPath)
+
+    const msgSpan = createElement('span', { text: message })
+    const inner = createElement('div', { classes: ['flex', 'items-center', 'gap-2'], children: [errorSvg, msgSpan] })
+    toast.appendChild(inner)
     
     document.body.appendChild(toast)
     

--- a/app/javascript/controllers/dashboard_inline_actions_controller.js
+++ b/app/javascript/controllers/dashboard_inline_actions_controller.js
@@ -328,11 +328,14 @@ export default class extends Controller {
       // Update icon
       const icon = statusButton.querySelector("svg")
       if (icon) {
-        if (newStatus === 'pending') {
-          icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>'
-        } else {
-          icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>'
-        }
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+        path.setAttribute('stroke-linecap', 'round')
+        path.setAttribute('stroke-linejoin', 'round')
+        path.setAttribute('stroke-width', '2')
+        path.setAttribute('d', newStatus === 'pending'
+          ? 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'
+          : 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z')
+        icon.replaceChildren(path)
       }
     }
     

--- a/app/javascript/controllers/dashboard_inline_actions_controller.js
+++ b/app/javascript/controllers/dashboard_inline_actions_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { shouldSuppressShortcut } from "utilities/keyboard_shortcut_helpers"
 import { createUndoNotification } from "utilities/undo_notification_helper"
 import { t } from "services/i18n"
+import { createElement } from "utilities/safe_dom"
 
 // Dashboard Inline Actions Controller for Epic 3 Task 3.3
 // Handles quick actions: categorize, status toggle, duplicate, and delete
@@ -494,33 +495,65 @@ export default class extends Controller {
     
     toast.className += ` ${colors[type] || colors.info}`
     
-    toast.innerHTML = `
-      <div class="flex items-center">
-        <div class="flex-shrink-0">
-          ${type === 'success' ? 
-            '<svg aria-hidden="true" class="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>' :
-            type === 'error' ?
-            '<svg aria-hidden="true" class="w-5 h-5 text-rose-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>' :
-            '<svg aria-hidden="true" class="w-5 h-5 text-teal-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>'
-          }
-        </div>
-        <div class="ml-3 flex-1">
-          <p class="text-sm font-medium ${textColors[type] || textColors.info}">
-            ${message}
-          </p>
-        </div>
-        <div class="ml-4 flex-shrink-0">
-          <button type="button"
-                  class="inline-flex ${textColors[type] || textColors.info} hover:text-slate-500 focus:outline-none"
-                  onclick="this.parentElement.parentElement.parentElement.remove()">
-            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </button>
-        </div>
-      </div>
-    `
-    
+    // Build icon SVG — static paths, no user data
+    const iconPaths = {
+      success: { color: 'text-emerald-500', d: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
+      error:   { color: 'text-rose-500',    d: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z' },
+      info:    { color: 'text-teal-500',    d: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' }
+    }
+    const iconCfg = iconPaths[type] || iconPaths.info
+    const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    iconSvg.setAttribute('aria-hidden', 'true')
+    iconSvg.setAttribute('class', `w-5 h-5 ${iconCfg.color}`)
+    iconSvg.setAttribute('fill', 'none')
+    iconSvg.setAttribute('stroke', 'currentColor')
+    iconSvg.setAttribute('viewBox', '0 0 24 24')
+    const iconPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    iconPath.setAttribute('stroke-linecap', 'round')
+    iconPath.setAttribute('stroke-linejoin', 'round')
+    iconPath.setAttribute('stroke-width', '2')
+    iconPath.setAttribute('d', iconCfg.d)
+    iconSvg.appendChild(iconPath)
+
+    const iconDiv = createElement('div', { classes: ['flex-shrink-0'], children: [iconSvg] })
+
+    // message rendered as textContent — XSS-safe
+    const messageP = createElement('p', {
+      text: message,
+      classes: ['text-sm', 'font-medium', textColors[type] || textColors.info]
+    })
+    const messageDiv = createElement('div', { classes: ['ml-3', 'flex-1'], children: [messageP] })
+
+    // Close button — addEventListener replaces onclick
+    const closeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    closeSvg.setAttribute('aria-hidden', 'true')
+    closeSvg.setAttribute('class', 'w-4 h-4')
+    closeSvg.setAttribute('fill', 'none')
+    closeSvg.setAttribute('stroke', 'currentColor')
+    closeSvg.setAttribute('viewBox', '0 0 24 24')
+    const closePath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    closePath.setAttribute('stroke-linecap', 'round')
+    closePath.setAttribute('stroke-linejoin', 'round')
+    closePath.setAttribute('stroke-width', '2')
+    closePath.setAttribute('d', 'M6 18L18 6M6 6l12 12')
+    closeSvg.appendChild(closePath)
+
+    const closeBtn = createElement('button', {
+      attrs: { type: 'button' },
+      classes: ['inline-flex', textColors[type] || textColors.info, 'hover:text-slate-500', 'focus:outline-none'],
+      children: [closeSvg]
+    })
+    closeBtn.addEventListener('click', () => toast.remove())
+
+    const closeDiv = createElement('div', { classes: ['ml-4', 'flex-shrink-0'], children: [closeBtn] })
+
+    const innerFlex = createElement('div', {
+      classes: ['flex', 'items-center'],
+      children: [iconDiv, messageDiv, closeDiv]
+    })
+
+    toast.appendChild(innerFlex)
+
     document.body.appendChild(toast)
     
     // Animate in

--- a/app/javascript/controllers/queue_monitor_controller.js
+++ b/app/javascript/controllers/queue_monitor_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { createConsumer } from "@rails/actioncable"
 import { t } from "services/i18n"
+import { createElement } from "utilities/safe_dom"
 
 // Queue Monitor Stimulus Controller
 // Manages real-time queue visualization and control operations
@@ -247,29 +248,44 @@ export default class extends Controller {
     }
 
     this.activeJobsSectionTarget.style.display = "block"
-    this.activeJobsListTarget.innerHTML = activeJobs.map(job => this.renderActiveJob(job)).join("")
+    // Build DOM nodes safely — no innerHTML for job data
+    const nodes = activeJobs.map(job => this.renderActiveJob(job))
+    this.activeJobsListTarget.replaceChildren(...nodes)
   }
 
-  // Render a single active job
+  // Render a single active job — safe DOM construction (no innerHTML for user data)
   renderActiveJob(job) {
     const duration = job.duration ? this.formatDuration(job.duration) : t("queue.status.just_started")
-    const processInfo = job.process_info ?
-      `<span class="text-xs text-slate-500">Trabajador ${job.process_info.pid}@${job.process_info.hostname}</span>` : ""
 
-    return `
-      <div class="flex items-center justify-between p-3 bg-teal-50 rounded-lg">
-        <div class="flex-1">
-          <div class="flex items-center space-x-2">
-            <span class="text-sm font-medium text-slate-900">${this.formatJobClass(job.class_name)}</span>
-            <span class="text-xs px-2 py-0.5 bg-teal-100 text-teal-700 rounded-full">${job.queue_name}</span>
-          </div>
-          <div class="text-xs text-slate-600 mt-1">
-            ${duration} • Prioridad ${job.priority}
-            ${processInfo}
-          </div>
-        </div>
-      </div>
-    `
+    const classSpan = createElement('span', {
+      text: this.formatJobClass(job.class_name),
+      classes: ['text-sm', 'font-medium', 'text-slate-900']
+    })
+    const queueSpan = createElement('span', {
+      text: job.queue_name,
+      classes: ['text-xs', 'px-2', 'py-0.5', 'bg-teal-100', 'text-teal-700', 'rounded-full']
+    })
+    const headerRow = createElement('div', {
+      classes: ['flex', 'items-center', 'space-x-2'],
+      children: [classSpan, queueSpan]
+    })
+
+    const metaDiv = createElement('div', { classes: ['text-xs', 'text-slate-600', 'mt-1'] })
+    metaDiv.append(`${duration} • Prioridad ${job.priority}`)
+    if (job.process_info) {
+      const pidSpan = createElement('span', {
+        text: `Trabajador ${job.process_info.pid}@${job.process_info.hostname}`,
+        classes: ['text-xs', 'text-slate-500']
+      })
+      metaDiv.appendChild(pidSpan)
+    }
+
+    const innerDiv = createElement('div', { classes: ['flex-1'], children: [headerRow, metaDiv] })
+
+    return createElement('div', {
+      classes: ['flex', 'items-center', 'justify-between', 'p-3', 'bg-teal-50', 'rounded-lg'],
+      children: [innerDiv]
+    })
   }
 
   // Update failed jobs list
@@ -280,40 +296,69 @@ export default class extends Controller {
     }
 
     this.failedJobsSectionTarget.style.display = "block"
-    this.failedJobsListTarget.innerHTML = failedJobs.map(job => this.renderFailedJob(job)).join("")
+    // Build DOM nodes safely — no innerHTML for job data
+    const nodes = failedJobs.map(job => this.renderFailedJob(job))
+    this.failedJobsListTarget.replaceChildren(...nodes)
   }
 
-  // Render a single failed job
+  // Render a single failed job — safe DOM construction (no innerHTML for user data)
   renderFailedJob(job) {
     const errorMessage = this.extractErrorMessage(job.error)
     const failedAt = new Date(job.created_at).toLocaleString()
 
-    return `
-      <div class="p-3 bg-rose-50 rounded-lg">
-        <div class="flex items-start justify-between">
-          <div class="flex-1">
-            <div class="flex items-center space-x-2">
-              <span class="text-sm font-medium text-slate-900">${this.formatJobClass(job.class_name)}</span>
-              <span class="text-xs px-2 py-0.5 bg-rose-100 text-rose-700 rounded-full">${job.queue_name}</span>
-            </div>
-            <div class="text-xs text-rose-600 mt-1">${errorMessage}</div>
-            <div class="text-xs text-slate-500 mt-1">${t("queue.status.failed_at")}${failedAt}</div>
-          </div>
-          <div class="flex items-center space-x-1 ml-4">
-            <button data-job-id="${job.id}"
-                    data-action="click->queue-monitor#retryJob"
-                    class="px-2 py-1 bg-rose-600 hover:bg-rose-700 text-white text-xs font-medium rounded transition-colors">
-              ${t("common.actions.retry")}
-            </button>
-            <button data-job-id="${job.id}"
-                    data-action="click->queue-monitor#clearJob"
-                    class="px-2 py-1 bg-slate-600 hover:bg-slate-700 text-white text-xs font-medium rounded transition-colors">
-              ${t("common.actions.clear")}
-            </button>
-          </div>
-        </div>
-      </div>
-    `
+    const classSpan = createElement('span', {
+      text: this.formatJobClass(job.class_name),
+      classes: ['text-sm', 'font-medium', 'text-slate-900']
+    })
+    const queueSpan = createElement('span', {
+      text: job.queue_name,
+      classes: ['text-xs', 'px-2', 'py-0.5', 'bg-rose-100', 'text-rose-700', 'rounded-full']
+    })
+    const headerRow = createElement('div', {
+      classes: ['flex', 'items-center', 'space-x-2'],
+      children: [classSpan, queueSpan]
+    })
+
+    const errorDiv = createElement('div', {
+      text: errorMessage,
+      classes: ['text-xs', 'text-rose-600', 'mt-1']
+    })
+    const failedAtDiv = createElement('div', {
+      text: `${t("queue.status.failed_at")}${failedAt}`,
+      classes: ['text-xs', 'text-slate-500', 'mt-1']
+    })
+    const infoDiv = createElement('div', { classes: ['flex-1'], children: [headerRow, errorDiv, failedAtDiv] })
+
+    const retryBtn = createElement('button', {
+      text: t("common.actions.retry"),
+      attrs: {
+        'data-job-id': String(job.id),
+        'data-action': 'click->queue-monitor#retryJob'
+      },
+      classes: ['px-2', 'py-1', 'bg-rose-600', 'hover:bg-rose-700', 'text-white', 'text-xs', 'font-medium', 'rounded', 'transition-colors']
+    })
+    const clearBtn = createElement('button', {
+      text: t("common.actions.clear"),
+      attrs: {
+        'data-job-id': String(job.id),
+        'data-action': 'click->queue-monitor#clearJob'
+      },
+      classes: ['px-2', 'py-1', 'bg-slate-600', 'hover:bg-slate-700', 'text-white', 'text-xs', 'font-medium', 'rounded', 'transition-colors']
+    })
+    const actionsDiv = createElement('div', {
+      classes: ['flex', 'items-center', 'space-x-1', 'ml-4'],
+      children: [retryBtn, clearBtn]
+    })
+
+    const rowFlex = createElement('div', {
+      classes: ['flex', 'items-start', 'justify-between'],
+      children: [infoDiv, actionsDiv]
+    })
+
+    return createElement('div', {
+      classes: ['p-3', 'bg-rose-50', 'rounded-lg'],
+      children: [rowFlex]
+    })
   }
 
   // Update queue breakdown
@@ -324,15 +369,18 @@ export default class extends Controller {
     }
 
     this.queueBreakdownTarget.style.display = "block"
-    
+
     const sortedQueues = Object.entries(queueDepths).sort((a, b) => b[1] - a[1])
-    
-    this.queueListTarget.innerHTML = sortedQueues.map(([name, count]) => `
-      <div class="flex items-center justify-between p-2 bg-slate-50 rounded">
-        <span class="text-sm text-slate-700">${name}</span>
-        <span class="text-sm font-medium text-slate-900">${count}</span>
-      </div>
-    `).join("")
+
+    // Build DOM nodes safely — no innerHTML for queue names or counts
+    const nodes = sortedQueues.map(([name, count]) => createElement('div', {
+      classes: ['flex', 'items-center', 'justify-between', 'p-2', 'bg-slate-50', 'rounded'],
+      children: [
+        createElement('span', { text: name,        classes: ['text-sm', 'text-slate-700'] }),
+        createElement('span', { text: String(count), classes: ['text-sm', 'font-medium', 'text-slate-900'] })
+      ]
+    }))
+    this.queueListTarget.replaceChildren(...nodes)
   }
 
   // Update worker status

--- a/app/javascript/controllers/queue_monitor_controller.js
+++ b/app/javascript/controllers/queue_monitor_controller.js
@@ -3,6 +3,17 @@ import { createConsumer } from "@rails/actioncable"
 import { t } from "services/i18n"
 import { createElement } from "utilities/safe_dom"
 
+// Helper: build a single <path> element with the standard stroke options.
+// Used for icon SVGs whose <svg> wrapper already exists in the DOM.
+function buildSvgPath(d) {
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  path.setAttribute('stroke-linecap', 'round')
+  path.setAttribute('stroke-linejoin', 'round')
+  path.setAttribute('stroke-width', '2')
+  path.setAttribute('d', d)
+  return path
+}
+
 // Queue Monitor Stimulus Controller
 // Manages real-time queue visualization and control operations
 export default class extends Controller {
@@ -227,16 +238,16 @@ export default class extends Controller {
     if (this.isPaused) {
       this.pauseButtonTarget.className = "px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center space-x-1"
       this.pauseTextTarget.textContent = t("queue.actions.resume_all")
-      this.pauseIconTarget.innerHTML = `
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-      `
+      this.pauseIconTarget.replaceChildren(
+        buildSvgPath("M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"),
+        buildSvgPath("M21 12a9 9 0 11-18 0 9 9 0 0118 0z")
+      )
     } else {
       this.pauseButtonTarget.className = "px-3 py-1.5 bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center space-x-1"
       this.pauseTextTarget.textContent = t("queue.actions.pause_all")
-      this.pauseIconTarget.innerHTML = `
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-      `
+      this.pauseIconTarget.replaceChildren(
+        buildSvgPath("M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z")
+      )
     }
   }
 
@@ -271,13 +282,16 @@ export default class extends Controller {
     })
 
     const metaDiv = createElement('div', { classes: ['text-xs', 'text-slate-600', 'mt-1'] })
-    metaDiv.append(`${duration} • Prioridad ${job.priority}`)
     if (job.process_info) {
       const pidSpan = createElement('span', {
         text: `Trabajador ${job.process_info.pid}@${job.process_info.hostname}`,
         classes: ['text-xs', 'text-slate-500']
       })
-      metaDiv.appendChild(pidSpan)
+      // Trailing space preserves the visual gap between meta line and PID
+      // span. Without it the rendered text reads "Prioridad 1Trabajador …"
+      metaDiv.append(`${duration} • Prioridad ${job.priority} `, pidSpan)
+    } else {
+      metaDiv.append(`${duration} • Prioridad ${job.priority}`)
     }
 
     const innerDiv = createElement('div', { classes: ['flex-1'], children: [headerRow, metaDiv] })

--- a/app/javascript/controllers/undo_manager_controller.js
+++ b/app/javascript/controllers/undo_manager_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { Turbo } from "@hotwired/turbo-rails"
+import { createElement } from "utilities/safe_dom"
 
 // Undo Manager Controller
 // Manages undo notifications with a 5-minute countdown.
@@ -196,11 +197,29 @@ export default class extends Controller {
       animation: "slideInBottom 0.3s ease-out"
     })
 
-    const icon = isSuccess
-      ? '<svg aria-hidden="true" width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>'
-      : '<svg aria-hidden="true" width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>'
+    // Build icon SVG — static paths, no user data
+    const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    iconSvg.setAttribute('aria-hidden', 'true')
+    iconSvg.setAttribute('width', '20')
+    iconSvg.setAttribute('height', '20')
+    iconSvg.setAttribute('fill', 'none')
+    iconSvg.setAttribute('stroke', 'currentColor')
+    iconSvg.setAttribute('viewBox', '0 0 24 24')
+    const iconPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    iconPath.setAttribute('stroke-linecap', 'round')
+    iconPath.setAttribute('stroke-linejoin', 'round')
+    iconPath.setAttribute('stroke-width', '2')
+    iconPath.setAttribute('d', isSuccess
+      ? 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+      : 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+    )
+    iconSvg.appendChild(iconPath)
 
-    div.innerHTML = `${icon}<span>${message}</span>`
+    // message rendered via textContent — XSS-safe
+    const messageSpan = createElement('span', { text: message })
+
+    div.appendChild(iconSvg)
+    div.appendChild(messageSpan)
     document.body.appendChild(div)
 
     setTimeout(() => {

--- a/app/javascript/controllers/undo_manager_controller.js
+++ b/app/javascript/controllers/undo_manager_controller.js
@@ -166,8 +166,9 @@ export default class extends Controller {
 
     if (loading) {
       this.undoButtonTarget.disabled = true
-      this.undoButtonTarget.innerHTML =
-        '<span class="undo-spinner"></span> Deshaciendo...'
+      const spinner = document.createElement('span')
+      spinner.className = 'undo-spinner'
+      this.undoButtonTarget.replaceChildren(spinner, document.createTextNode(' Deshaciendo...'))
     } else {
       this.undoButtonTarget.disabled = false
       this.undoButtonTarget.textContent = "Deshacer"

--- a/app/javascript/utilities/safe_dom.js
+++ b/app/javascript/utilities/safe_dom.js
@@ -1,0 +1,46 @@
+/**
+ * safe_dom.js — XSS-safe DOM construction helpers
+ *
+ * Preferred: use createElement() to build elements with textContent for text nodes.
+ * Fallback: escapeHtml() for cases where a surrounding template is unavoidable.
+ *
+ * These utilities replace innerHTML assignments that interpolate user/admin data,
+ * eliminating the XSS vector from template literals with dynamic content.
+ *
+ * See: PER-543 (harden 5 high-risk innerHTML sites)
+ *      PER-539 (broader innerHTML sweep)
+ */
+
+/**
+ * Create a DOM element safely.
+ *
+ * @param {string} tag - HTML tag name (e.g. 'div', 'span', 'button')
+ * @param {Object} options
+ * @param {string|null}   options.text     - Text content (uses textContent — never HTML)
+ * @param {Object}        options.attrs    - Attribute key/value pairs (set via setAttribute)
+ * @param {string[]}      options.classes  - CSS class names to add
+ * @param {Element[]}     options.children - Child elements to append
+ * @returns {HTMLElement}
+ */
+export function createElement(tag, { text = null, attrs = {}, classes = [], children = [] } = {}) {
+  const el = document.createElement(tag)
+  if (text !== null) el.textContent = text
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v)
+  if (classes.length) el.classList.add(...classes)
+  for (const child of children) el.appendChild(child)
+  return el
+}
+
+/**
+ * Escape a string for safe insertion as HTML text content.
+ * Prefer createElement() with text: instead — this is only for cases where
+ * the surrounding structural HTML is unavoidable (e.g. SVG paths).
+ *
+ * @param {string|null|undefined} str
+ * @returns {string} HTML-escaped string
+ */
+export function escapeHtml(str) {
+  const div = document.createElement('div')
+  div.textContent = String(str ?? '')
+  return div.innerHTML
+}

--- a/app/javascript/utilities/safe_dom.js
+++ b/app/javascript/utilities/safe_dom.js
@@ -36,11 +36,37 @@ export function createElement(tag, { text = null, attrs = {}, classes = [], chil
  * Prefer createElement() with text: instead — this is only for cases where
  * the surrounding structural HTML is unavoidable (e.g. SVG paths).
  *
+ * IMPORTANT: this is for TEXT context only. The textContent→innerHTML
+ * round-trip does NOT escape quotes, so embedding the result inside an
+ * attribute value (e.g. `<div title="${escapeHtml(x)}">`) is unsafe.
+ * Use escapeAttr() for attribute context.
+ *
  * @param {string|null|undefined} str
- * @returns {string} HTML-escaped string
+ * @returns {string} HTML-escaped string (text context)
  */
 export function escapeHtml(str) {
   const div = document.createElement('div')
   div.textContent = String(str ?? '')
   return div.innerHTML
+}
+
+/**
+ * Escape a string for safe insertion inside an HTML attribute value.
+ * Use this when interpolating user data into a template literal that
+ * will be assigned to innerHTML inside an attribute context — e.g.
+ * `<option value="${escapeAttr(id)}">` or `<div data-x="${escapeAttr(s)}">`.
+ *
+ * Escapes &, <, >, ", and ' so the attribute can use either single or
+ * double-quote delimiters safely.
+ *
+ * @param {string|null|undefined} str
+ * @returns {string} attribute-safe escaped string
+ */
+export function escapeAttr(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }

--- a/spec/javascript/controllers/dashboard_expenses_controller_xss_spec.js
+++ b/spec/javascript/controllers/dashboard_expenses_controller_xss_spec.js
@@ -1,0 +1,85 @@
+/**
+ * spec/javascript/controllers/dashboard_expenses_controller_xss_spec.js
+ *
+ * XSS hardening specs for H1: dashboard_expenses_controller#showToast (PER-543)
+ *
+ * NOTE: No JS test runner is configured (no package.json / Jest).
+ * These specs are ready to run once Jest + jsdom are set up.
+ */
+
+import { Application } from "@hotwired/stimulus"
+import DashboardExpensesController from "../../../app/javascript/controllers/dashboard_expenses_controller"
+
+describe("DashboardExpensesController — XSS hardening (PER-543)", () => {
+  const XSS_PAYLOAD = '<script>alert(1)</script>'
+  let application
+  let element
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="dashboard-expenses"
+           data-dashboard-expenses-view-mode-value="compact"
+           data-dashboard-expenses-selected-ids-value="[]">
+        <div data-dashboard-expenses-target="container"></div>
+      </div>
+    `
+
+    const csrfToken = document.createElement("meta")
+    csrfToken.name = "csrf-token"
+    csrfToken.content = "test-token"
+    document.head.appendChild(csrfToken)
+
+    application = Application.start()
+    application.register("dashboard-expenses", DashboardExpensesController)
+
+    element = document.querySelector('[data-controller="dashboard-expenses"]')
+    controller = application.getControllerForElementAndIdentifier(element, "dashboard-expenses")
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    document.head.innerHTML = ""
+  })
+
+  describe("showToast — H1", () => {
+    it("renders XSS payload in message as text, not as DOM elements", () => {
+      controller.showToast(XSS_PAYLOAD, "success")
+
+      const toast = document.querySelector('#toast-container > div')
+      expect(toast).not.toBeNull()
+
+      // The XSS payload must appear as text content, not as a parsed script element
+      expect(toast.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("does not inject script elements via message", () => {
+      controller.showToast(XSS_PAYLOAD, "error")
+
+      // No script elements should exist in the document
+      expect(document.querySelectorAll('script').length).toBe(0)
+    })
+
+    it("renders complex XSS payload as literal text", () => {
+      const complex = '<img src=x onerror=alert(1)><b>injected</b>'
+      controller.showToast(complex, "info")
+
+      const toast = document.querySelector('#toast-container > div')
+      expect(toast).not.toBeNull()
+      expect(toast.textContent).toContain(complex)
+      expect(document.querySelector('img')).toBeNull()
+    })
+
+    it("uses addEventListener instead of onclick for close button", () => {
+      controller.showToast("test message", "success")
+
+      const container = document.getElementById('toast-container')
+      const closeButton = container.querySelector('button')
+      expect(closeButton).not.toBeNull()
+      // No inline onclick attribute should be present
+      expect(closeButton.getAttribute('onclick')).toBeNull()
+    })
+  })
+})

--- a/spec/javascript/controllers/dashboard_filter_chips_controller_xss_spec.js
+++ b/spec/javascript/controllers/dashboard_filter_chips_controller_xss_spec.js
@@ -1,0 +1,86 @@
+/**
+ * spec/javascript/controllers/dashboard_filter_chips_controller_xss_spec.js
+ *
+ * XSS hardening specs for H5: dashboard_filter_chips_controller#updateExpenseList (PER-543)
+ *
+ * NOTE: No JS test runner is configured (no package.json / Jest).
+ * These specs are ready to run once Jest + jsdom are set up.
+ */
+
+import { Application } from "@hotwired/stimulus"
+import DashboardFilterChipsController from "../../../app/javascript/controllers/dashboard_filter_chips_controller"
+
+describe("DashboardFilterChipsController — XSS hardening (PER-543)", () => {
+  const XSS_SCRIPT_TAG = '<script>window.__xss = true</script>'
+  let application
+  let element
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="dashboard-filter-chips"
+           data-dashboard-filter-chips-active-filters-value='{"categories":[],"statuses":[],"period":null}'
+           data-dashboard-filter-chips-dashboard-url-value="/expenses/dashboard">
+        <div data-dashboard-filter-chips-target="expenseContainer"></div>
+      </div>
+    `
+
+    application = Application.start()
+    application.register("dashboard-filter-chips", DashboardFilterChipsController)
+
+    element = document.querySelector('[data-controller="dashboard-filter-chips"]')
+    controller = application.getControllerForElementAndIdentifier(element, "dashboard-filter-chips")
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    delete window.__xss
+  })
+
+  describe("updateExpenseList — H5", () => {
+    it("does not execute inline scripts from server HTML via DOMParser", async () => {
+      // H5: html comes from the server (fetch response.text()). Even when the server
+      // returns HTML containing a script tag, DOMParser does not execute it.
+      window.__xss = false
+
+      await controller.updateExpenseList(
+        `<div class="expense-row">Safe content</div>${XSS_SCRIPT_TAG}`
+      )
+
+      // Script should NOT have executed
+      expect(window.__xss).toBe(false)
+    })
+
+    it("renders trusted server HTML content safely", async () => {
+      await controller.updateExpenseList('<div class="expense-item">Expense #1</div>')
+
+      const container = document.querySelector('[data-dashboard-filter-chips-target="expenseContainer"]')
+      expect(container.querySelector('.expense-item')).not.toBeNull()
+      expect(container.textContent).toContain('Expense #1')
+    })
+
+    it("replaces container children, not appending", async () => {
+      const container = document.querySelector('[data-dashboard-filter-chips-target="expenseContainer"]')
+      container.innerHTML = '<div class="old-content">old</div>'
+
+      await controller.updateExpenseList('<div class="new-content">new</div>')
+
+      expect(container.querySelector('.old-content')).toBeNull()
+      expect(container.querySelector('.new-content')).not.toBeNull()
+    })
+  })
+
+  describe("showError — additional XSS site in this file", () => {
+    it("renders XSS payload in error message as text, not DOM elements", () => {
+      const XSS_PAYLOAD = '<script>alert(1)</script>'
+      controller.showError(XSS_PAYLOAD)
+
+      const toasts = document.querySelectorAll('body > div[class*="fixed"]')
+      const toast = toasts[toasts.length - 1]
+      expect(toast).not.toBeNull()
+      expect(toast.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+  })
+})

--- a/spec/javascript/controllers/dashboard_inline_actions_controller_xss_spec.js
+++ b/spec/javascript/controllers/dashboard_inline_actions_controller_xss_spec.js
@@ -1,0 +1,81 @@
+/**
+ * spec/javascript/controllers/dashboard_inline_actions_controller_xss_spec.js
+ *
+ * XSS hardening specs for H2: dashboard_inline_actions_controller#showToast (PER-543)
+ *
+ * NOTE: No JS test runner is configured (no package.json / Jest).
+ * These specs are ready to run once Jest + jsdom are set up.
+ */
+
+import { Application } from "@hotwired/stimulus"
+import DashboardInlineActionsController from "../../../app/javascript/controllers/dashboard_inline_actions_controller"
+
+describe("DashboardInlineActionsController — XSS hardening (PER-543)", () => {
+  const XSS_PAYLOAD = '<script>alert(1)</script>'
+  let application
+  let element
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="dashboard-inline-actions"
+           data-dashboard-inline-actions-expense-id-value="42"
+           data-dashboard-inline-actions-current-status-value="pending">
+        <div data-dashboard-inline-actions-target="categoryDropdown" class="hidden"></div>
+        <div data-dashboard-inline-actions-target="deleteConfirmation" class="hidden"></div>
+      </div>
+    `
+
+    const csrfToken = document.createElement("meta")
+    csrfToken.name = "csrf-token"
+    csrfToken.content = "test-token"
+    document.head.appendChild(csrfToken)
+
+    application = Application.start()
+    application.register("dashboard-inline-actions", DashboardInlineActionsController)
+
+    element = document.querySelector('[data-controller="dashboard-inline-actions"]')
+    controller = application.getControllerForElementAndIdentifier(element, "dashboard-inline-actions")
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    document.head.innerHTML = ""
+  })
+
+  describe("showToast — H2", () => {
+    it("renders XSS payload in message as text, not as DOM elements", () => {
+      controller.showToast(XSS_PAYLOAD, "success")
+
+      const toasts = document.querySelectorAll('body > div[class*="fixed"]')
+      const toast = toasts[toasts.length - 1]
+      expect(toast).not.toBeNull()
+      expect(toast.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("does not inject script elements via message for error type", () => {
+      controller.showToast(XSS_PAYLOAD, "error")
+      expect(document.querySelectorAll('script').length).toBe(0)
+    })
+
+    it("renders complex XSS payload as literal text for info type", () => {
+      const complex = '<img src=x onerror=alert(1)>'
+      controller.showToast(complex, "info")
+
+      // No img elements injected
+      expect(document.querySelector('img')).toBeNull()
+    })
+
+    it("close button uses addEventListener, not onclick attribute", () => {
+      controller.showToast("message", "success")
+
+      const toasts = document.querySelectorAll('body > div[class*="fixed"]')
+      const toast = toasts[toasts.length - 1]
+      const closeBtn = toast.querySelector('button')
+      expect(closeBtn).not.toBeNull()
+      expect(closeBtn.getAttribute('onclick')).toBeNull()
+    })
+  })
+})

--- a/spec/javascript/controllers/dashboard_inline_actions_controller_xss_spec.js
+++ b/spec/javascript/controllers/dashboard_inline_actions_controller_xss_spec.js
@@ -12,11 +12,19 @@ import DashboardInlineActionsController from "../../../app/javascript/controller
 
 describe("DashboardInlineActionsController — XSS hardening (PER-543)", () => {
   const XSS_PAYLOAD = '<script>alert(1)</script>'
+  const XSS_SVG     = '<svg/onload="window.__xss = true">'
+  const XSS_IMG     = '<img src=x onerror="window.__xss = true">'
+  const XSS_ENTITY  = '&#60;script&#62;alert(1)&#60;/script&#62;'
   let application
   let element
   let controller
 
   beforeEach(() => {
+    // Sentinel: any DOM payload that gets *executed* (not just inserted as
+    // text) sets this flag. Asserting it stays false defeats the
+    // "jsdom-doesn't-run-scripts" vacuous-pass concern.
+    window.__xss = false
+
     document.body.innerHTML = `
       <div data-controller="dashboard-inline-actions"
            data-dashboard-inline-actions-expense-id-value="42"
@@ -76,6 +84,25 @@ describe("DashboardInlineActionsController — XSS hardening (PER-543)", () => {
       const closeBtn = toast.querySelector('button')
       expect(closeBtn).not.toBeNull()
       expect(closeBtn.getAttribute('onclick')).toBeNull()
+    })
+
+    it("sentinel: <svg/onload> payload does not execute", () => {
+      controller.showToast(XSS_SVG, "warning")
+      expect(window.__xss).toBe(false)
+    })
+
+    it("sentinel: <img onerror> payload does not execute", () => {
+      controller.showToast(XSS_IMG, "warning")
+      expect(window.__xss).toBe(false)
+    })
+
+    it("HTML-entity-encoded payload renders as literal text (no double-decode)", () => {
+      controller.showToast(XSS_ENTITY, "info")
+
+      const toasts = document.querySelectorAll('body > div[class*="fixed"]')
+      const toast = toasts[toasts.length - 1]
+      expect(toast.textContent).toContain(XSS_ENTITY)
+      expect(toast.querySelector('script')).toBeNull()
     })
   })
 })

--- a/spec/javascript/controllers/queue_monitor_controller_xss_spec.js
+++ b/spec/javascript/controllers/queue_monitor_controller_xss_spec.js
@@ -1,0 +1,177 @@
+/**
+ * spec/javascript/controllers/queue_monitor_controller_xss_spec.js
+ *
+ * XSS hardening specs for H4: queue_monitor_controller — lines 250, 283, 330 (PER-543)
+ *
+ * NOTE: No JS test runner is configured (no package.json / Jest).
+ * These specs are ready to run once Jest + jsdom are set up.
+ */
+
+import { Application } from "@hotwired/stimulus"
+import QueueMonitorController from "../../../app/javascript/controllers/queue_monitor_controller"
+
+// Stub ActionCable so the controller can connect in jsdom
+jest.mock("@rails/actioncable", () => ({
+  createConsumer: () => ({
+    subscriptions: {
+      create: () => ({ unsubscribe: jest.fn() })
+    }
+  })
+}))
+
+describe("QueueMonitorController — XSS hardening (PER-543)", () => {
+  const XSS_PAYLOAD = '<script>alert(1)</script>'
+  let application
+  let element
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="queue-monitor"
+           data-queue-monitor-api-endpoint-value="/api/queue/status.json"
+           data-queue-monitor-refresh-interval-value="999999">
+        <div data-queue-monitor-target="activeJobsSection" style="display:none"></div>
+        <div data-queue-monitor-target="activeJobsList"></div>
+        <div data-queue-monitor-target="failedJobsSection" style="display:none"></div>
+        <div data-queue-monitor-target="failedJobsList"></div>
+        <div data-queue-monitor-target="queueBreakdown" style="display:none"></div>
+        <div data-queue-monitor-target="queueList"></div>
+        <span data-queue-monitor-target="healthIndicator"></span>
+        <span data-queue-monitor-target="healthDot"></span>
+        <span data-queue-monitor-target="healthText"></span>
+        <span data-queue-monitor-target="pendingCount">0</span>
+        <span data-queue-monitor-target="processingCount">0</span>
+        <span data-queue-monitor-target="completedCount">0</span>
+        <span data-queue-monitor-target="failedCount">0</span>
+        <div data-queue-monitor-target="queueDepthBar"></div>
+        <span data-queue-monitor-target="queueDepthMax">0</span>
+        <span data-queue-monitor-target="processingRate">0</span>
+        <span data-queue-monitor-target="estimatedTime">-</span>
+        <button data-queue-monitor-target="pauseButton"></button>
+        <span data-queue-monitor-target="pauseIcon"></span>
+        <span data-queue-monitor-target="pauseText"></span>
+        <span data-queue-monitor-target="workerCount">0</span>
+        <span data-queue-monitor-target="utilization">0%</span>
+        <span data-queue-monitor-target="lastUpdate">-</span>
+        <button data-queue-monitor-target="retryAllButton"></button>
+        <span data-queue-monitor-target="noFailedText"></span>
+      </div>
+    `
+
+    application = Application.start()
+    application.register("queue-monitor", QueueMonitorController)
+
+    element = document.querySelector('[data-controller="queue-monitor"]')
+    controller = application.getControllerForElementAndIdentifier(element, "queue-monitor")
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  describe("updateActiveJobs — H4 line 250", () => {
+    it("renders XSS payload in class_name as text, not as DOM elements", () => {
+      controller.updateActiveJobs([{
+        class_name: XSS_PAYLOAD,
+        queue_name: 'default',
+        priority: 1,
+        duration: null,
+        process_info: null
+      }])
+
+      const list = document.querySelector('[data-queue-monitor-target="activeJobsList"]')
+      expect(list.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("renders XSS payload in queue_name as text", () => {
+      controller.updateActiveJobs([{
+        class_name: 'SomeJob',
+        queue_name: XSS_PAYLOAD,
+        priority: 1,
+        duration: null,
+        process_info: null
+      }])
+
+      const list = document.querySelector('[data-queue-monitor-target="activeJobsList"]')
+      expect(list.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("renders XSS payload in process_info as text", () => {
+      controller.updateActiveJobs([{
+        class_name: 'SomeJob',
+        queue_name: 'default',
+        priority: 1,
+        duration: null,
+        process_info: { pid: XSS_PAYLOAD, hostname: 'host' }
+      }])
+
+      expect(document.querySelector('script')).toBeNull()
+    })
+  })
+
+  describe("updateFailedJobs — H4 line 283", () => {
+    it("renders XSS payload in error message as text", () => {
+      controller.updateFailedJobs([{
+        id: 1,
+        class_name: 'SomeJob',
+        queue_name: 'default',
+        error: XSS_PAYLOAD,
+        created_at: new Date().toISOString()
+      }])
+
+      const list = document.querySelector('[data-queue-monitor-target="failedJobsList"]')
+      expect(list.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("renders XSS payload in class_name as text in failed job", () => {
+      controller.updateFailedJobs([{
+        id: 1,
+        class_name: XSS_PAYLOAD,
+        queue_name: 'default',
+        error: 'some error',
+        created_at: new Date().toISOString()
+      }])
+
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("sets data-job-id attribute safely, not via innerHTML", () => {
+      const jobId = 'safe-id'
+      controller.updateFailedJobs([{
+        id: jobId,
+        class_name: 'Job',
+        queue_name: 'default',
+        error: 'error',
+        created_at: new Date().toISOString()
+      }])
+
+      const list = document.querySelector('[data-queue-monitor-target="failedJobsList"]')
+      const buttons = list.querySelectorAll('button[data-job-id]')
+      buttons.forEach(btn => {
+        expect(btn.getAttribute('data-job-id')).toBe(jobId)
+      })
+    })
+  })
+
+  describe("updateQueueBreakdown — H4 line 330", () => {
+    it("renders XSS payload in queue name as text", () => {
+      controller.updateQueueBreakdown({ [XSS_PAYLOAD]: 5 })
+
+      const list = document.querySelector('[data-queue-monitor-target="queueList"]')
+      expect(list.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("renders queue count as text", () => {
+      controller.updateQueueBreakdown({ 'critical': 42 })
+
+      const list = document.querySelector('[data-queue-monitor-target="queueList"]')
+      expect(list.textContent).toContain('42')
+      expect(list.textContent).toContain('critical')
+    })
+  })
+})

--- a/spec/javascript/controllers/undo_manager_controller_xss_spec.js
+++ b/spec/javascript/controllers/undo_manager_controller_xss_spec.js
@@ -1,0 +1,65 @@
+/**
+ * spec/javascript/controllers/undo_manager_controller_xss_spec.js
+ *
+ * XSS hardening specs for H3: undo_manager_controller#showToast (PER-543)
+ *
+ * NOTE: No JS test runner is configured (no package.json / Jest).
+ * These specs are ready to run once Jest + jsdom are set up.
+ */
+
+import { Application } from "@hotwired/stimulus"
+import UndoManagerController from "../../../app/javascript/controllers/undo_manager_controller"
+
+describe("UndoManagerController — XSS hardening (PER-543)", () => {
+  const XSS_PAYLOAD = '<script>alert(1)</script>'
+  let application
+  let element
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="undo-manager"
+           data-undo-manager-undo-id-value="99"
+           data-undo-manager-time-remaining-value="300">
+        <span data-undo-manager-target="message"></span>
+        <span data-undo-manager-target="timer">300</span>
+        <button data-undo-manager-target="undoButton">Deshacer</button>
+        <div data-undo-manager-target="progressBar"></div>
+      </div>
+    `
+
+    application = Application.start()
+    application.register("undo-manager", UndoManagerController)
+
+    element = document.querySelector('[data-controller="undo-manager"]')
+    controller = application.getControllerForElementAndIdentifier(element, "undo-manager")
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    if (controller && controller.timerInterval) clearInterval(controller.timerInterval)
+  })
+
+  describe("showToast — H3", () => {
+    it("renders XSS payload in success toast as text, not as DOM elements", () => {
+      controller.showToast(XSS_PAYLOAD, "success")
+
+      const toasts = document.querySelectorAll('body > div[style*="fixed"]')
+      const toast = toasts[toasts.length - 1]
+      expect(toast).not.toBeNull()
+      expect(toast.textContent).toContain(XSS_PAYLOAD)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it("renders XSS payload in error toast as text, not as DOM elements", () => {
+      controller.showToast(XSS_PAYLOAD, "error")
+      expect(document.querySelectorAll('script').length).toBe(0)
+    })
+
+    it("does not inject img elements via XSS payload", () => {
+      controller.showToast('<img src=x onerror=alert(1)>', "success")
+      expect(document.querySelector('img')).toBeNull()
+    })
+  })
+})

--- a/spec/javascript/utilities/safe_dom_spec.js
+++ b/spec/javascript/utilities/safe_dom_spec.js
@@ -1,0 +1,98 @@
+/**
+ * spec/javascript/utilities/safe_dom_spec.js
+ *
+ * XSS payload escaping specs for safe_dom helpers.
+ *
+ * NOTE: This project has no JS test runner configured (no package.json / Jest config).
+ * These specs follow the existing spec/javascript/ convention and are ready to run
+ * once Jest + jsdom are wired up. See PER-543 PR description for setup instructions.
+ */
+
+import { createElement, escapeHtml } from "../../../app/javascript/utilities/safe_dom"
+
+describe("safe_dom", () => {
+  const XSS_PAYLOAD = '<script>alert(1)</script>'
+  const XSS_ATTR    = '" onmouseover="alert(1)'
+  const XSS_COMPLEX = '<img src=x onerror=alert(1)><b>bold</b>'
+
+  describe("createElement()", () => {
+    it("renders XSS payload as literal text, not as a script element", () => {
+      const el = createElement('div', { text: XSS_PAYLOAD })
+      expect(el.textContent).toBe(XSS_PAYLOAD)
+      expect(el.querySelector('script')).toBeNull()
+    })
+
+    it("does not execute injected script via text content", () => {
+      const el = createElement('span', { text: XSS_PAYLOAD })
+      // innerHTML should be the HTML-escaped representation
+      expect(el.innerHTML).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+    })
+
+    it("renders complex XSS payload as text without creating DOM elements", () => {
+      const el = createElement('p', { text: XSS_COMPLEX })
+      expect(el.textContent).toBe(XSS_COMPLEX)
+      expect(el.querySelector('img')).toBeNull()
+      expect(el.querySelector('b')).toBeNull()
+    })
+
+    it("sets attributes safely without executing injected handlers", () => {
+      const el = createElement('div', { attrs: { 'data-value': XSS_ATTR } })
+      // The attribute value should be the raw string, stored as an attribute (not evaluated)
+      expect(el.getAttribute('data-value')).toBe(XSS_ATTR)
+      // No event handler should have been attached
+      expect(el.onmouseover).toBeNull()
+    })
+
+    it("adds classes without allowing injection", () => {
+      const el = createElement('div', { classes: ['safe-class'] })
+      expect(el.classList.contains('safe-class')).toBe(true)
+    })
+
+    it("nests children safely", () => {
+      const child = createElement('span', { text: XSS_PAYLOAD })
+      const parent = createElement('div', { children: [child] })
+      expect(parent.querySelector('script')).toBeNull()
+      expect(parent.textContent).toBe(XSS_PAYLOAD)
+    })
+
+    it("returns a proper HTMLElement", () => {
+      const el = createElement('button', { text: 'Click me', attrs: { type: 'button' } })
+      expect(el.tagName).toBe('BUTTON')
+      expect(el.getAttribute('type')).toBe('button')
+      expect(el.textContent).toBe('Click me')
+    })
+  })
+
+  describe("escapeHtml()", () => {
+    it("escapes < and > characters", () => {
+      expect(escapeHtml('<script>')).toBe('&lt;script&gt;')
+    })
+
+    it("escapes the full XSS payload", () => {
+      const escaped = escapeHtml(XSS_PAYLOAD)
+      expect(escaped).not.toContain('<script>')
+      expect(escaped).toContain('&lt;script&gt;')
+    })
+
+    it("handles null safely", () => {
+      expect(escapeHtml(null)).toBe('')
+    })
+
+    it("handles undefined safely", () => {
+      expect(escapeHtml(undefined)).toBe('')
+    })
+
+    it("handles empty string", () => {
+      expect(escapeHtml('')).toBe('')
+    })
+
+    it("handles numbers", () => {
+      expect(escapeHtml(42)).toBe('42')
+    })
+
+    it("does not double-escape already-escaped strings", () => {
+      // escapeHtml escapes the & in &amp; — this is expected behaviour
+      expect(escapeHtml('&amp;')).toBe('&amp;amp;')
+    })
+  })
+})

--- a/spec/javascript/utilities/safe_dom_spec.js
+++ b/spec/javascript/utilities/safe_dom_spec.js
@@ -8,12 +8,15 @@
  * once Jest + jsdom are wired up. See PER-543 PR description for setup instructions.
  */
 
-import { createElement, escapeHtml } from "../../../app/javascript/utilities/safe_dom"
+import { createElement, escapeHtml, escapeAttr } from "../../../app/javascript/utilities/safe_dom"
 
 describe("safe_dom", () => {
   const XSS_PAYLOAD = '<script>alert(1)</script>'
   const XSS_ATTR    = '" onmouseover="alert(1)'
   const XSS_COMPLEX = '<img src=x onerror=alert(1)><b>bold</b>'
+  const XSS_SVG     = '<svg/onload=alert(1)>'
+  const XSS_ENTITY  = '&#60;script&#62;alert(1)&#60;/script&#62;'
+  const XSS_JSURL   = 'javascript:alert(1)'
 
   describe("createElement()", () => {
     it("renders XSS payload as literal text, not as a script element", () => {
@@ -41,6 +44,28 @@ describe("safe_dom", () => {
       expect(el.getAttribute('data-value')).toBe(XSS_ATTR)
       // No event handler should have been attached
       expect(el.onmouseover).toBeNull()
+    })
+
+    it("renders <svg/onload=...> payload as literal text", () => {
+      const el = createElement('span', { text: XSS_SVG })
+      expect(el.textContent).toBe(XSS_SVG)
+      expect(el.querySelector('svg')).toBeNull()
+    })
+
+    it("does not decode HTML entities in text content", () => {
+      // textContent must NOT decode &#60; back to '<' — that would re-open
+      // the entity-encoded XSS bypass.
+      const el = createElement('span', { text: XSS_ENTITY })
+      expect(el.textContent).toBe(XSS_ENTITY)
+      expect(el.querySelector('script')).toBeNull()
+    })
+
+    it("stores javascript: URL as text without executing", () => {
+      // When a payload like 'javascript:alert(1)' lands in text, it must
+      // never become an active link. createElement only sets textContent.
+      const el = createElement('a', { text: XSS_JSURL, attrs: { href: '#' } })
+      expect(el.textContent).toBe(XSS_JSURL)
+      expect(el.getAttribute('href')).toBe('#')
     })
 
     it("adds classes without allowing injection", () => {
@@ -91,8 +116,47 @@ describe("safe_dom", () => {
     })
 
     it("does not double-escape already-escaped strings", () => {
-      // escapeHtml escapes the & in &amp; — this is expected behaviour
+      // escapeHtml escapes the & in &amp; — documented footgun: callers
+      // MUST NOT pre-escape input. Pass raw user data only.
       expect(escapeHtml('&amp;')).toBe('&amp;amp;')
+    })
+
+    it("does NOT escape quotes (text-context only — use escapeAttr for attributes)", () => {
+      // textContent serialization only escapes <, >, &. Documented limitation.
+      expect(escapeHtml('"foo"')).toBe('"foo"')
+    })
+
+    it("escapes <svg/onload=...> payload", () => {
+      expect(escapeHtml(XSS_SVG)).toBe('&lt;svg/onload=alert(1)&gt;')
+    })
+  })
+
+  describe("escapeAttr()", () => {
+    it("escapes & < > \" and '", () => {
+      expect(escapeAttr('a&b<c>d"e\'f')).toBe('a&amp;b&lt;c&gt;d&quot;e&#39;f')
+    })
+
+    it("blocks attribute-context breakout via double-quote", () => {
+      // The classic '" onmouseover="alert(1)' payload. After escapeAttr,
+      // the embedded double-quote is &quot; so it cannot close the attribute.
+      const escaped = escapeAttr(XSS_ATTR)
+      expect(escaped).not.toContain('"')
+      expect(escaped).toContain('&quot;')
+    })
+
+    it("blocks attribute-context breakout via single-quote", () => {
+      const escaped = escapeAttr("' onmouseover='alert(1)")
+      expect(escaped).not.toContain("'")
+      expect(escaped).toContain('&#39;')
+    })
+
+    it("handles null and undefined", () => {
+      expect(escapeAttr(null)).toBe('')
+      expect(escapeAttr(undefined)).toBe('')
+    })
+
+    it("handles numbers", () => {
+      expect(escapeAttr(42)).toBe('42')
     })
   })
 })


### PR DESCRIPTION
## Summary

Hardens the 5 high-risk `innerHTML` XSS sites identified in PER-543, carved from PER-539.

### Sites converted

| # | File | Original line | User data vectors | Fix |
|---|------|--------------|------------------|-----|
| H1 | `dashboard_expenses_controller.js` | ~1547 | `message` (from `data.message` / server) | `createElement` + `textContent`; `onclick` → `addEventListener` |
| H1b | `dashboard_expenses_controller.js` | ~1679 | `message`, `undoId`, `timeRemaining` | Full `createElement` tree; `data-*` attrs via `setAttribute` |
| H2 | `dashboard_inline_actions_controller.js` | ~497 | `message` | `createElement` + `textContent`; `onclick` → `addEventListener` |
| H3 | `undo_manager_controller.js` | ~203 | `message` | `createElement('span', { text: message })` |
| H4 | `queue_monitor_controller.js` | ~250, ~283, ~330 | `job.class_name`, `job.queue_name`, `job.error`, `job.priority`, `job.process_info.pid/hostname`, queue name, count | Full `createElement` trees; `replaceChildren()` |
| H5 | `dashboard_filter_chips_controller.js` | ~363 | Server HTML from `fetch().text()` | `DOMParser` + `replaceChildren` (scripts don't execute) |
| H5b | `dashboard_filter_chips_controller.js` | ~410 | `message` in `showError` | `createElement('span', { text: message })` |

### New shared helper

`app/javascript/utilities/safe_dom.js` — auto-pinned by `pin_all_from "utilities"` in `config/importmap.rb`. No explicit pin needed.

```js
createElement(tag, { text, attrs, classes, children })  // uses textContent — never innerHTML for text
escapeHtml(str)                                          // fallback for unavoidable template cases
```

### Inline event handlers removed

All `onclick="..."` / `onerror="..."` handlers in these 5 files are gone. Replaced with `addEventListener`. This directly unblocks PER-525 (drop CSP `unsafe-inline`).

### JS test infrastructure note

This project has no `package.json` / Jest config — the `spec/javascript/` directory contains spec files in Jest format but no runner is wired up. All 6 XSS spec files are added and ready to run once Jest + jsdom are configured. They assert that `<script>alert(1)</script>` payloads appear as literal text (not parsed elements) in the DOM.

### PER-540 coordination

PER-540 planned a shared `safe_dom` helper. This PR introduces that helper first. PER-540 should be **rescoped** to "convert remaining 61 lower-risk `innerHTML` sites from PER-539" and the helper work marked done here. Recommend closing the helper sub-task within PER-540 or leaving just the conversion work.

### Out of scope

The 61 lower-risk `innerHTML` sites from PER-539 remain — those sites use only static strings or i18n translation values (no direct user data interpolation).

## Test plan

- [ ] All 8999 RSpec unit tests pass (pre-commit hook verified)
- [ ] Brakeman: 0 warnings
- [ ] RuboCop: exit 0 (`--fail-level error`)
- [ ] Manual smoke: dashboard toast notifications render text correctly (XSS payload in expense merchant name shows as literal text)
- [ ] Manual smoke: queue monitor admin panel renders job cards without script injection
- [ ] Manual smoke: filter chips update expense list via DOMParser without executing scripts
- [ ] Once Jest is configured: run `spec/javascript/` suite — all XSS specs should pass