### PR TITLE
fix(deploy): warn-only for SENTRY_DSN + STORAGE_BOX_* secrets

### DIFF
--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -137,8 +137,8 @@ if SECRETS_FILE.file?
   end
   RECOMMENDED_SECRETS.each do |key|
     if !secrets.key?(key) || secrets[key].to_s.empty?
-      info << "#{key} not set in .kamal/secrets — feature using it (Sentry/Storage Box) " \
-              "will be inert until provisioned. Move to REQUIRED_SECRETS once stable."
+      info << "#{key} not set in .kamal/secrets — feature using it will be " \
+              "inert until provisioned. Move to REQUIRED_SECRETS once stable."
     end
   end
   unless unresolved_substitution.empty?

--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -31,6 +31,14 @@ REQUIRED_SECRETS = %w[
   ADMIN_EMAIL
   ADMIN_PASSWORD
   ANTHROPIC_API_KEY
+].freeze
+
+# Secrets the app uses but that are non-fatal at deploy time. Missing
+# entries warn but do not abort, so a feature that hasn't been provisioned
+# yet (Sentry account, Hetzner Storage Box) doesn't block deploys of
+# unrelated PRs. Promote to REQUIRED_SECRETS once the underlying service
+# is live in production and the secret is stable in 1Password.
+RECOMMENDED_SECRETS = %w[
   SENTRY_DSN
   STORAGE_BOX_HOST
   STORAGE_BOX_USER
@@ -125,6 +133,12 @@ if SECRETS_FILE.file?
       failures << "#{key} missing from .kamal/secrets"
     elsif secrets[key].to_s.empty?
       failures << "#{key} present but empty in .kamal/secrets"
+    end
+  end
+  RECOMMENDED_SECRETS.each do |key|
+    if !secrets.key?(key) || secrets[key].to_s.empty?
+      info << "#{key} not set in .kamal/secrets — feature using it (Sentry/Storage Box) " \
+              "will be inert until provisioned. Move to REQUIRED_SECRETS once stable."
     end
   end
   unless unresolved_substitution.empty?


### PR DESCRIPTION
## Summary

PRs #513 (Sentry APM) and #515 (Postgres backup) added their operational secrets directly to `bin/pre-deploy-check`'s `REQUIRED_SECRETS`. Until the operator provisions the underlying services (Sentry account, Hetzner Storage Box) and adds the secrets to 1Password, **Gate 2 hard-fails on every deploy** — blocking unrelated PRs too.

This PR adds a `RECOMMENDED_SECRETS` list that warns but does not abort. Five entries move from required → recommended:

- \`SENTRY_DSN\`              (PER-526)
- \`STORAGE_BOX_HOST\`        (PER-527)
- \`STORAGE_BOX_USER\`        (PER-527)
- \`STORAGE_BOX_SSH_KEY\`     (PER-527)
- \`BACKUP_GPG_PASSPHRASE\`   (PER-527)

Once each service is live and the secret is stable in 1Password, promote it back to \`REQUIRED_SECRETS\` in a one-line follow-up PR.

## Test plan

- [x] \`bin/pre-deploy-check --skip-ci\` runs locally — Gate 2 emits one info line per missing recommended secret instead of failing
- [x] Brakeman + Rubocop clean
- [ ] Verify a full deploy does not abort because of these 5 missing entries