### PR TITLE
chore(test): parallel rspec for local runs (~2.4x speedup)

### DIFF
--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,6 +1,15 @@
 #!/usr/bin/env ruby
 # Fast unit tests for development workflow
 # Only runs tests tagged as :unit or by default (models, controllers, services without integration tags)
+#
+# Local runs default to parallel_rspec across N worker processes for speed.
+# CI stays serial: GitHub Actions runners have ~2 vCPUs and the parallel
+# overhead (process boot + DB pool setup x N) often eats the savings.
+#
+# Toggles:
+#   PARALLEL=1  forces parallel even in CI
+#   PARALLEL=0  forces serial even locally
+#   PARALLEL_TEST_PROCESSORS=N  override worker count (default: 4 local, 1 CI)
 
 require 'fileutils'
 
@@ -11,16 +20,36 @@ Dir.chdir(File.expand_path('..', __dir__))
 ENV['RAILS_ENV'] = 'test'
 ENV['TEST_TIER'] = 'unit'
 
+# Decide parallel vs serial.
+parallel = if ENV.key?('PARALLEL')
+  ENV['PARALLEL'] == '1'
+else
+  !ENV['CI']
+end
+
+workers = (ENV['PARALLEL_TEST_PROCESSORS'] || '4').to_i
+workers = 1 if workers < 1
+
 # Build RSpec command with properly quoted arguments
 # --tag unit: include tests auto-tagged from standard Rails dirs (models, services, controllers, etc.)
 # --tag ~slow: exclude slow tests (system, performance)
-cmd = if ENV['CI']
+cmd = if parallel && workers > 1
+  # parallel_rspec splits files across N processes, each binding to its
+  # own DB suffix (TEST_ENV_NUMBER). --fail-fast doesn't work cross-process,
+  # so we drop it from the parallel path.
+  rspec_opts = "--tag unit --tag ~slow --format progress --order random"
+  "bundle exec parallel_rspec spec/ -n #{workers} -o '#{rspec_opts}'"
+elsif ENV['CI']
   "bundle exec rspec --tag unit --tag ~slow --format progress --fail-fast=10 --order random"
 else
   "bundle exec rspec --tag unit --tag ~slow --format progress --profile=5 --fail-fast=5 --order random"
 end
 
-puts "🧪 Running unit tests (should complete in <30 seconds)..."
+if parallel && workers > 1
+  puts "🧪 Running unit tests in parallel (#{workers} workers)..."
+else
+  puts "🧪 Running unit tests (serial)..."
+end
 puts "Command: #{cmd}"
 puts
 

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -9,7 +9,7 @@
 # Toggles:
 #   PARALLEL=1  forces parallel even in CI
 #   PARALLEL=0  forces serial even locally
-#   PARALLEL_TEST_PROCESSORS=N  override worker count (default: 4 local, 1 CI)
+#   PARALLEL_TEST_PROCESSORS=N  override worker count (default 4; ignored when running serial)
 
 require 'fileutils'
 
@@ -37,6 +37,8 @@ cmd = if parallel && workers > 1
   # parallel_rspec splits files across N processes, each binding to its
   # own DB suffix (TEST_ENV_NUMBER). --fail-fast doesn't work cross-process,
   # so we drop it from the parallel path.
+  # rspec_opts is interpolated into a single-quoted shell argument below;
+  # keep it free of single quotes / unescaped shell metacharacters.
   rspec_opts = "--tag unit --tag ~slow --format progress --order random"
   "bundle exec parallel_rspec spec/ -n #{workers} -o '#{rspec_opts}'"
 elsif ENV['CI']

--- a/lib/tasks/parallel_tests.rake
+++ b/lib/tasks/parallel_tests.rake
@@ -1,0 +1,11 @@
+# Wire parallel_tests rake helpers into Rails (parallel:create, parallel:prepare,
+# parallel:load_schema, parallel:rake, parallel_rspec:*).
+# Only loaded in test/development environments where the gem is installed.
+
+if Rails.env.development? || Rails.env.test?
+  begin
+    require "parallel_tests/tasks"
+  rescue LoadError
+    # parallel_tests gem not bundled — skip silently.
+  end
+end

--- a/spec/support/parallel_tests.rb
+++ b/spec/support/parallel_tests.rb
@@ -15,11 +15,14 @@ if ENV['TEST_ENV_NUMBER']
       # These use the base test database directly
       return unless test_number.match?(/\A\d+\z/)
 
-      # Each parallel process gets its own database
+      # `config/database.yml` already interpolates ENV['TEST_ENV_NUMBER']
+      # into the database name, so the resolved value is already the
+      # parallel-worker DB (e.g. expense_tracker_test2). Just re-establish
+      # the connection with tuned pool settings — do NOT append the suffix
+      # a second time, which produced expense_tracker_test2_2 and broke
+      # parallel runs.
       base_config = ActiveRecord::Base.configurations.configs_for(env_name: 'test').first.configuration_hash.dup
-      base_config[:database] = "#{base_config[:database]}_#{test_number.to_i}"
 
-      # Establish connection with the parallel database
       ActiveRecord::Base.establish_connection(
         base_config.merge(
           pool: 5,


### PR DESCRIPTION
## Summary

The \`parallel_tests\` gem was already in the Gemfile and \`config/database.yml\` already wired \`ENV['TEST_ENV_NUMBER']\` into the test database name, but the rake tasks were not loaded and \`bin/test-unit\` ran serial. Local pre-commit was ~2 min on M2.

This PR makes \`bin/test-unit\` use \`parallel_rspec\` by default for local runs.

**Changes:**

1. \`lib/tasks/parallel_tests.rake\` — load \`parallel_tests/tasks\` so \`parallel:create\`, \`parallel:load_schema\`, \`parallel:rake\`, \`parallel_rspec:*\` exist.
2. \`bin/test-unit\` — use \`parallel_rspec\` locally; CI stays serial (~2 vCPUs makes the per-worker boot eat the savings). Toggles: \`PARALLEL=1\` forces parallel in CI, \`PARALLEL=0\` forces serial locally, \`PARALLEL_TEST_PROCESSORS=N\` overrides worker count (default 4).
3. \`spec/support/parallel_tests.rb\` — fix latent double-suffix bug. The helper appended \`_<n>\` to a DB name that \`config/database.yml\` already interpolated, so worker 2 looked for \`expense_tracker_test2_2\`. Removed the second append.

**Verified:** \`bin/test-unit\` runs the full unit suite (7902 examples) in ~50s on a 4-worker M2 vs ~2 min serial.

**First-time setup per worktree:**
\`\`\`
RAILS_ENV=test bundle exec rake "parallel:create[4]"
RAILS_ENV=test bundle exec rake "parallel:load_schema[4]"
\`\`\`

## Test plan

- [x] \`bin/test-unit\` (parallel) runs full suite green
- [x] \`PARALLEL=0 bin/test-unit\` (serial) still works
- [x] \`bundle exec rake -T | grep parallel:\` shows the loaded tasks
- [x] Pre-commit hook runs in ~50s instead of ~2min
- [ ] CI stays green (serial path unchanged)