### PR TITLE
ci(workflows): skip Claude review job for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip automated review on bot-authored PRs (e.g. Dependabot).
+    # claude-code-action rejects non-human actors and the job fails otherwise.
+    if: github.actor != 'dependabot[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The `claude-review` job fails on **every** Dependabot PR — `claude-code-action` rejects non-human actors with `Workflow initiated by non-human actor: dependabot (type: Bot)`.
- Gate the job on `github.actor != 'dependabot[bot]'` so it is **skipped** (not failed) for bot-authored PRs.
- `claude-review` is not a required status check (the `main` ruleset enforces only a code-owner review), so this is purely cosmetic — it removes the spurious red ✗ that appears on all Dependabot PRs.

## Test plan
- [ ] Dependabot opens/synchronizes a PR → `claude-review` shows as **skipped**, not failed
- [ ] A human-authored PR → `claude-review` runs as before