### PR TITLE
fix(security): close API IDOR gaps and stop leaking PII/internals

### DIFF
--- a/app/controllers/api/client_errors_controller.rb
+++ b/app/controllers/api/client_errors_controller.rb
@@ -9,18 +9,23 @@ module Api
     # POST /api/client_errors
     # Receives error reports from client-side JavaScript
     # Requires a valid user session to prevent unauthenticated log flooding
+    # Cap on any single client-supplied string written to logs/DB.
+    MAX_FIELD_LENGTH = 2_000
+
     def create
-      # Parse error data
+      # Parse error data. Client-supplied strings are sanitized to strip control
+      # characters (CR/LF) — otherwise an attacker could inject forged lines into
+      # the production log — and truncated to bound log volume (CWE-117).
       error_data = {
-        message: params[:message],
-        data: params[:data],
-        session_id: params[:sessionId],
-        timestamp: params[:timestamp],
-        user_agent: params[:userAgent],
-        url: params[:url],
+        message: sanitize_field(params[:message]),
+        data: sanitize_field(params[:data]),
+        session_id: sanitize_field(params[:sessionId]),
+        timestamp: sanitize_field(params[:timestamp]),
+        user_agent: sanitize_field(params[:userAgent]),
+        url: sanitize_field(params[:url]),
         error_count: params[:errorCount],
-        polling_mode: params[:pollingMode],
-        connection_state: params[:connectionState],
+        polling_mode: sanitize_field(params[:pollingMode]),
+        connection_state: sanitize_field(params[:connectionState]),
         ip_address: request.remote_ip,
         reported_at: Time.current
       }
@@ -60,6 +65,14 @@ module Api
       return if user_signed_in?
 
       render json: { error: "Authentication required" }, status: :unauthorized
+    end
+
+    # Strip control characters (including CR/LF to prevent log injection) and
+    # truncate. Non-string values are coerced to string first; nil stays nil.
+    def sanitize_field(value)
+      return nil if value.nil?
+
+      value.to_s.gsub(/[[:cntrl:]]/, " ").truncate(MAX_FIELD_LENGTH)
     end
   end
 end

--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -66,9 +66,10 @@ module Api
 
       render json: metrics, status: :ok
     rescue => e
+      # Log internals server-side; never echo exception text to the client.
+      Rails.logger.error "[HEALTH] Failed to collect metrics: #{e.class}: #{e.message}"
       render json: {
-        error: "Failed to collect metrics",
-        message: e.message
+        error: "Failed to collect metrics"
       }, status: :internal_server_error
     end
 

--- a/app/controllers/api/sync_sessions_controller.rb
+++ b/app/controllers/api/sync_sessions_controller.rb
@@ -67,15 +67,13 @@ module Api
         return true
       end
 
-      # Check IP address for recent sessions (when no token)
+      # Legacy fallback for token-less sessions: match on the originating IP.
+      # PER-security: a missing stored IP must NOT grant access — that previously
+      # let anyone poll a recent session by guessing its sequential id and leaked
+      # the account email/bank. Require a stored IP that matches the requester.
       if @sync_session.created_at > 24.hours.ago
         stored_ip = @sync_session.metadata&.dig("ip_address")
-        current_ip = request.remote_ip
-
-        # Allow if no IP stored (backward compatibility) OR if stored IP matches current
-        if stored_ip.nil? || stored_ip == current_ip
-          return true
-        end
+        return true if stored_ip.present? && stored_ip == request.remote_ip
       end
 
       false

--- a/app/controllers/api/v1/categorization_controller.rb
+++ b/app/controllers/api/v1/categorization_controller.rb
@@ -36,11 +36,13 @@ module Api
         validate_feedback_params!
 
         expense = Expense.for_user(current_api_user).find(feedback_params[:expense_id])
-        category = Category.find(feedback_params[:category_id])
+        # PER-security: scope category and pattern to what the token owner can see,
+        # so feedback cannot reference (and poison learning from) another tenant's data.
+        category = CategoryPolicy.visible_scope(current_api_user).find(feedback_params[:category_id])
 
         # Find the pattern that was used (if any)
         pattern = if feedback_params[:pattern_id].present?
-                    CategorizationPattern.find_by(id: feedback_params[:pattern_id])
+                    CategorizationPattern.usable_by(current_api_user).find_by(id: feedback_params[:pattern_id])
         end
 
         # Record the feedback

--- a/app/controllers/api/v1/categorization_controller.rb
+++ b/app/controllers/api/v1/categorization_controller.rb
@@ -85,23 +85,26 @@ module Api
 
       # GET /api/v1/categorization/statistics
       def statistics
-        # CategorizationPattern is global reference data (shared across users,
-        # same posture as Category). PatternFeedback holds per-user signals
-        # (PR 9 added user_id), so it must be scoped to the token owner.
+        # PER-security: scope pattern aggregates to what the token owner can see
+        # (shared + own, via category ownership). Patterns can be tenant-owned
+        # (a user creates one on a personal category), so global counts would
+        # leak the existence/shape of other tenants' patterns. PatternFeedback
+        # holds per-user signals and is scoped to the token owner.
+        patterns = CategorizationPattern.usable_by(current_api_user)
         user_feedback = PatternFeedback.for_user(current_api_user)
 
         stats = {
-          total_patterns: CategorizationPattern.count,
-          active_patterns: CategorizationPattern.active.count,
-          user_created_patterns: CategorizationPattern.user_created.count,
-          high_confidence_patterns: CategorizationPattern.high_confidence.count,
-          successful_patterns: CategorizationPattern.successful.count,
-          frequently_used_patterns: CategorizationPattern.frequently_used.count,
+          total_patterns: patterns.count,
+          active_patterns: patterns.active.count,
+          user_created_patterns: patterns.user_created.count,
+          high_confidence_patterns: patterns.high_confidence.count,
+          successful_patterns: patterns.successful.count,
+          frequently_used_patterns: patterns.frequently_used.count,
           recent_feedback_count: user_feedback.where(created_at: 7.days.ago..).count,
           feedback_by_type: user_feedback.group(:feedback_type).count,
-          average_success_rate: CategorizationPattern.active.average(:success_rate)&.round(3) || 0,
-          patterns_by_type: CategorizationPattern.group(:pattern_type).count,
-          top_categories: top_categorized_categories
+          average_success_rate: patterns.active.average(:success_rate)&.round(3) || 0,
+          patterns_by_type: patterns.group(:pattern_type).count,
+          top_categories: top_categorized_categories(current_api_user)
         }
 
         render_success({ statistics: stats })
@@ -240,8 +243,9 @@ module Api
         CategorizationSerializer.feedback(feedback)
       end
 
-      def top_categorized_categories(limit = 5)
+      def top_categorized_categories(user, limit = 5)
         Category
+          .visible_to(user)
           .joins("LEFT JOIN categorization_patterns ON categorization_patterns.category_id = categories.id")
           .group("categories.id", "categories.name")
           .order("COUNT(categorization_patterns.id) DESC")

--- a/app/controllers/api/v1/patterns_controller.rb
+++ b/app/controllers/api/v1/patterns_controller.rb
@@ -13,7 +13,8 @@ module Api
       def index
         # PER-security: only patterns whose category the token owner can see
         # (shared or owned). Prevents cross-tenant pattern enumeration.
-        patterns = CategorizationPattern.usable_by(current_api_user).includes(:category)
+        # PatternSerializer.collection preloads :category, so no .includes here.
+        patterns = CategorizationPattern.usable_by(current_api_user)
 
         # Apply filters
         patterns = filter_patterns(patterns)
@@ -56,8 +57,9 @@ module Api
       # POST /api/v1/patterns
       def create
         # PER-security: a user may only attach a pattern to a category they can
-        # see (shared or owned), preventing writes against another tenant's category.
-        unless category_usable?(pattern_params[:category_id])
+        # see, preventing writes against another tenant's category. Uses the
+        # canonical CategoryPolicy.visible_scope (same helper as #feedback).
+        unless CategoryPolicy.visible_scope(current_api_user).exists?(id: pattern_params[:category_id])
           return render_error("Invalid category", [ "Category not found" ], status: :not_found)
         end
 
@@ -113,16 +115,6 @@ module Api
         # PER-security: scope by category ownership so show/update/destroy cannot
         # reach another tenant's pattern. Not-found is handled by BaseController.
         @pattern = CategorizationPattern.usable_by(current_api_user).find(params[:id])
-      end
-
-      # True when the category is shared (user_id NULL) or owned by the token owner.
-      def category_usable?(category_id)
-        return false if category_id.blank?
-
-        category = Category.find_by(id: category_id)
-        return false unless category
-
-        category.user_id.nil? || category.user_id == current_api_user&.id
       end
 
       def pattern_params

--- a/app/controllers/api/v1/patterns_controller.rb
+++ b/app/controllers/api/v1/patterns_controller.rb
@@ -11,7 +11,9 @@ module Api
 
       # GET /api/v1/patterns
       def index
-        patterns = CategorizationPattern.includes(:category)
+        # PER-security: only patterns whose category the token owner can see
+        # (shared or owned). Prevents cross-tenant pattern enumeration.
+        patterns = CategorizationPattern.usable_by(current_api_user).includes(:category)
 
         # Apply filters
         patterns = filter_patterns(patterns)
@@ -53,6 +55,12 @@ module Api
 
       # POST /api/v1/patterns
       def create
+        # PER-security: a user may only attach a pattern to a category they can
+        # see (shared or owned), preventing writes against another tenant's category.
+        unless category_usable?(pattern_params[:category_id])
+          return render_error("Invalid category", [ "Category not found" ], status: :not_found)
+        end
+
         pattern = CategorizationPattern.new(pattern_params)
         pattern.user_created = true
         pattern.confidence_weight ||= 1.0
@@ -102,7 +110,19 @@ module Api
       private
 
       def set_pattern
-        @pattern = CategorizationPattern.find(params[:id])
+        # PER-security: scope by category ownership so show/update/destroy cannot
+        # reach another tenant's pattern. Not-found is handled by BaseController.
+        @pattern = CategorizationPattern.usable_by(current_api_user).find(params[:id])
+      end
+
+      # True when the category is shared (user_id NULL) or owned by the token owner.
+      def category_usable?(category_id)
+        return false if category_id.blank?
+
+        category = Category.find_by(id: category_id)
+        return false unless category
+
+        category.user_id.nil? || category.user_id == current_api_user&.id
       end
 
       def pattern_params

--- a/app/jobs/process_email_job.rb
+++ b/app/jobs/process_email_job.rb
@@ -21,7 +21,9 @@ class ProcessEmailJob < ApplicationJob
     end
 
     Rails.logger.info "Processing individual email for: #{email_account.email}"
-    Rails.logger.debug "Email data: #{email_data.inspect}"
+    # Do NOT log email_data.inspect — the :body contains plaintext bank PII and is
+    # a plain Hash, so filter_parameters/filter_attributes do not redact it.
+    Rails.logger.debug "Email data: subject=#{email_data&.dig(:subject).inspect}, message_id=#{email_data&.dig(:message_id).inspect}"
 
     # Use explicit sync session ID instead of global lookup
     sync_session = sync_session_id ? SyncSession.find_by(id: sync_session_id) : nil

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -41,8 +41,10 @@ class ApiToken < ApplicationRecord
   def self.authenticate(token_string)
     return nil unless token_string.present?
 
-    # Short-lived cache for successful authentications
-    cache_key = "api_token:#{Digest::SHA256.hexdigest(token_string)[0..CACHE_KEY_LENGTH]}"
+    # Short-lived cache for successful authentications. Key on the FULL SHA256
+    # digest: a truncated key risked two distinct tokens colliding to the same
+    # cache entry and authenticating as the wrong account.
+    cache_key = "api_token:#{Digest::SHA256.hexdigest(token_string)}"
 
     Rails.cache.fetch(cache_key, expires_in: CACHE_EXPIRY) do
       # Use token_hash for quick lookup, then verify with BCrypt

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -3,7 +3,6 @@ require "digest"
 class ApiToken < ApplicationRecord
   # Configuration constants
   TOKEN_LENGTH = 32
-  CACHE_KEY_LENGTH = 16
   CACHE_EXPIRY = 1.minute
   attr_accessor :token
 

--- a/spec/controllers/api/client_errors_controller_spec.rb
+++ b/spec/controllers/api/client_errors_controller_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe Api::ClientErrorsController, type: :controller, unit: true do
         expect(details).to be_present
         expect(details).not_to include("\n")
         expect(details).not_to include("\r")
+        # Positive assertion: the legitimate content survives (control chars -> spaces).
+        expect(details).to include("legit")
+        expect(details).to include("forged admin line")
       end
 
       it 'truncates very long fields' do

--- a/spec/controllers/api/client_errors_controller_spec.rb
+++ b/spec/controllers/api/client_errors_controller_spec.rb
@@ -101,6 +101,34 @@ RSpec.describe Api::ClientErrorsController, type: :controller, unit: true do
       post :create, params: error_params, format: :json
     end
 
+    context 'with malicious / oversized input (log injection)' do
+      it 'strips control characters (CR/LF) from logged fields' do
+        logged = []
+        allow(Rails.logger).to receive(:error) { |msg| logged << msg }
+
+        post :create,
+             params: { message: "legit\r\n[CLIENT_ERROR] forged admin line", data: "x" },
+             format: :json
+
+        expect(response).to have_http_status(:ok)
+        details = logged.find { |m| m.include?('Details:') }
+        expect(details).to be_present
+        expect(details).not_to include("\n")
+        expect(details).not_to include("\r")
+      end
+
+      it 'truncates very long fields' do
+        logged = []
+        allow(Rails.logger).to receive(:error) { |msg| logged << msg }
+
+        post :create, params: { message: 'A' * 10_000, data: 'x' }, format: :json
+
+        expect(response).to have_http_status(:ok)
+        # The message field is capped well below its raw 10k length.
+        expect(logged.any? { |m| m.include?('A' * 9_000) }).to be false
+      end
+    end
+
     context 'with minimal parameters' do
       it 'still accepts the error report' do
         post :create, params: { message: 'Test error' }, format: :json

--- a/spec/controllers/api/health_controller_spec.rb
+++ b/spec/controllers/api/health_controller_spec.rb
@@ -257,15 +257,17 @@ RSpec.describe Api::HealthController, type: :controller, unit: true do
       expect(system["database_pool"]["idle"]).to eq(1)
     end
 
-    it "handles metrics collection errors gracefully" do
+    it "handles metrics collection errors gracefully without leaking the exception message" do
       allow(controller).to receive(:collect_metrics).and_raise(StandardError, "Metrics error")
+      expect(Rails.logger).to receive(:error).with(/Metrics error/)
 
       get :metrics
 
       expect(response).to have_http_status(:internal_server_error)
       json_response = JSON.parse(response.body)
       expect(json_response["error"]).to eq("Failed to collect metrics")
-      expect(json_response["message"]).to eq("Metrics error")
+      # Security: internal exception text must not be echoed to the client.
+      expect(json_response).not_to have_key("message")
     end
 
     context "authentication" do

--- a/spec/controllers/api/sync_sessions_controller_spec.rb
+++ b/spec/controllers/api/sync_sessions_controller_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe Api::SyncSessionsController, type: :controller, integration: true
 
           expect(response).to have_http_status(:unauthorized)
         end
+
+        it 'denies access when no IP was stored (no anonymous fallback)' do
+          # Security: a missing stored IP must NOT grant access. Previously this
+          # let anyone poll a recent session by id and leak account email/bank.
+          sync_session_no_token.update_columns(created_at: 1.hour.ago, metadata: {})
+
+          get :status, params: { id: sync_session_no_token.id }, format: :json
+
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
 

--- a/spec/controllers/api/sync_sessions_controller_unit_spec.rb
+++ b/spec/controllers/api/sync_sessions_controller_unit_spec.rb
@@ -285,16 +285,16 @@ RSpec.describe Api::SyncSessionsController, type: :controller, unit: true do
           end
         end
 
-        context "with no stored IP (backward compatibility)" do
+        context "with no stored IP" do
           before do
             allow(session).to receive(:[]).with(:sync_session_id).and_return(nil)
             allow(sync_session).to receive(:created_at).and_return(1.hour.ago)
             allow(sync_session).to receive(:metadata).and_return(nil)
           end
 
-          it "returns true" do
+          it "returns false (no anonymous fallback — prevents IDOR)" do
             result = controller.send(:can_access_sync_session?)
-            expect(result).to be true
+            expect(result).to be false
           end
         end
 

--- a/spec/controllers/api/v1/categorization_controller_unit_spec.rb
+++ b/spec/controllers/api/v1/categorization_controller_unit_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Api::V1::CategorizationController, type: :controller, unit: true 
       expense_scope = double("ExpenseScope")
       allow(Expense).to receive(:for_user).with(user_double).and_return(expense_scope)
       allow(expense_scope).to receive(:find).and_return(expense)
-      allow(Category).to receive(:find).and_return(category)
+      # Category is now resolved through the user-visible scope for tenant isolation.
+      category_scope = double("CategoryScope")
+      allow(CategoryPolicy).to receive(:visible_scope).with(user_double).and_return(category_scope)
+      allow(category_scope).to receive(:find).and_return(category)
       allow(PatternFeedback).to receive(:record_feedback).and_return(double(improvement_suggestion: "Test"))
       allow(categorization_service).to receive(:learn_from_feedback)
       allow(controller).to receive(:serialize_feedback).and_return({})

--- a/spec/controllers/api/v1/patterns_controller_unit_spec.rb
+++ b/spec/controllers/api/v1/patterns_controller_unit_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Api::V1::PatternsController, type: :controller, unit: true do
     # Return the class itself so the existing .find/.includes stubs below still apply.
     allow(CategorizationPattern).to receive(:usable_by).and_return(CategorizationPattern)
 
+    # #create validates the category through CategoryPolicy.visible_scope(...).exists?.
+    # Default to visible so the create happy-path stubs below exercise the save flow.
+    allow(CategoryPolicy).to receive(:visible_scope).and_return(double("CategoryScope", exists?: true))
+
     # Mock serializer classes
     serializer_module = Module.new
     api_module = Module.new
@@ -53,16 +57,18 @@ RSpec.describe Api::V1::PatternsController, type: :controller, unit: true do
     let(:mock_patterns) { double("patterns", current_page: 1, total_pages: 1, total_count: 1, limit_value: 10, next_page: nil, prev_page: nil, map: []) }
 
     before do
-      allow(CategorizationPattern).to receive(:includes).and_return(mock_patterns)
+      # index scopes through usable_by(current_api_user); return a chainable double.
+      allow(CategorizationPattern).to receive(:usable_by).and_return(mock_patterns)
       allow(mock_patterns).to receive(:where).and_return(mock_patterns)
       allow(mock_patterns).to receive(:order).and_return(mock_patterns)
       allow(mock_patterns).to receive(:ordered_by_success).and_return(mock_patterns)
+      allow(mock_patterns).to receive(:includes).and_return(mock_patterns)
       allow(controller).to receive(:paginate).and_return(mock_patterns)
       allow(controller).to receive(:render_success).and_return(nil)
     end
 
-    it "includes category associations" do
-      expect(CategorizationPattern).to receive(:includes).with(:category)
+    it "scopes patterns to the token owner (usable_by current_api_user)" do
+      expect(CategorizationPattern).to receive(:usable_by).with(controller.send(:current_api_user)).and_return(mock_patterns)
       get :index
     end
 

--- a/spec/controllers/api/v1/patterns_controller_unit_spec.rb
+++ b/spec/controllers/api/v1/patterns_controller_unit_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Api::V1::PatternsController, type: :controller, unit: true do
     allow(controller).to receive(:set_default_headers).and_return(true)
     allow(controller).to receive(:log_request).and_return(true)
 
+    # Patterns are scoped through .usable_by(current_api_user) for tenant isolation.
+    # Return the class itself so the existing .find/.includes stubs below still apply.
+    allow(CategorizationPattern).to receive(:usable_by).and_return(CategorizationPattern)
+
     # Mock serializer classes
     serializer_module = Module.new
     api_module = Module.new

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -62,14 +62,22 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
         )
       end
 
-      it 'logs email data in debug mode' do
+      it 'logs only non-sensitive email metadata in debug mode' do
         allow(Rails.logger).to receive(:debug)
 
         ProcessEmailJob.new.perform(email_account.id, email_data)
 
         expect(Rails.logger).to have_received(:debug).with(
-          "Email data: #{email_data.inspect}"
+          "Email data: subject=#{email_data[:subject].inspect}, message_id=#{email_data[:message_id].inspect}"
         )
+      end
+
+      it 'never writes the email body (bank PII) to the debug log' do
+        allow(Rails.logger).to receive(:debug)
+
+        ProcessEmailJob.new.perform(email_account.id, email_data)
+
+        expect(Rails.logger).not_to have_received(:debug).with(/#{Regexp.escape(email_data[:body])}/)
       end
 
       it 'creates expense with correct attributes' do

--- a/spec/jobs/unit/process_email_job_spec.rb
+++ b/spec/jobs/unit/process_email_job_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe ProcessEmailJob, type: :job, unit: true do
             job.perform(email_account_id, email_data)
           end
 
-          it 'logs the email data in debug mode' do
-            expect(Rails.logger).to receive(:debug).with("Email data: #{email_data.inspect}")
+          it 'logs only non-sensitive email metadata in debug mode (never the body)' do
+            expect(Rails.logger).to receive(:debug).with(
+              "Email data: subject=#{email_data[:subject].inspect}, message_id=#{email_data[:message_id].inspect}"
+            )
             job.perform(email_account_id, email_data)
           end
 

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ApiToken, type: :model, integration: true do
 
       it 'caches successful authentication' do
         # Verify Rails.cache.fetch is called with correct parameters
-        cache_key = "api_token:#{Digest::SHA256.hexdigest(valid_token.token)[0..16]}"
+        cache_key = "api_token:#{Digest::SHA256.hexdigest(valid_token.token)}"
 
         expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.minute).and_call_original
         result = ApiToken.authenticate(valid_token.token)

--- a/spec/models/api_token_unit_spec.rb
+++ b/spec/models/api_token_unit_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe ApiToken, type: :model, unit: true do
   describe 'constants' do
     it 'defines expected constants' do
       expect(ApiToken::TOKEN_LENGTH).to eq(32)
-      expect(ApiToken::CACHE_KEY_LENGTH).to eq(16)
       expect(ApiToken::CACHE_EXPIRY).to eq(1.minute)
     end
   end

--- a/spec/models/api_token_unit_spec.rb
+++ b/spec/models/api_token_unit_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe ApiToken, type: :model, unit: true do
         end
 
         it 'uses cache with correct key and expiry' do
-          cache_key = "api_token:#{token_hash[0..ApiToken::CACHE_KEY_LENGTH]}"
+          cache_key = "api_token:#{token_hash}"
           expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: ApiToken::CACHE_EXPIRY)
           ApiToken.authenticate(token_string)
         end
@@ -393,7 +393,7 @@ RSpec.describe ApiToken, type: :model, unit: true do
       it 'handles very long tokens in cache key' do
         very_long_token = 'a' * 1000
         token_hash = Digest::SHA256.hexdigest(very_long_token)
-        cache_key = "api_token:#{token_hash[0..ApiToken::CACHE_KEY_LENGTH]}"
+        cache_key = "api_token:#{token_hash}"
 
         expect(cache_key.length).to be < 250  # Memcached key length limit
       end

--- a/spec/requests/api/v1/categorization_spec.rb
+++ b/spec/requests/api/v1/categorization_spec.rb
@@ -177,6 +177,47 @@ RSpec.describe "Api::V1::Categorization", type: :request, integration: true do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "cross-tenant isolation (IDOR)" do
+      let(:non_admin) { create(:user) }
+      let(:tenant_token) { create(:api_token, user: non_admin) }
+      let(:tenant_headers) do
+        { "Authorization" => "Bearer #{tenant_token.token}", "Content-Type" => "application/json" }
+      end
+      let(:tenant_account) { create(:email_account, user: non_admin) }
+      let(:tenant_expense) { create(:expense, user: non_admin, email_account: tenant_account) }
+
+      let(:foreign_user) { create(:user) }
+      let(:foreign_category) { create(:category, user: foreign_user) }
+      let(:foreign_pattern) { create(:categorization_pattern, category: foreign_category) }
+
+      it "rejects feedback referencing another user's category" do
+        params = {
+          feedback: { expense_id: tenant_expense.id, category_id: foreign_category.id, was_correct: true }
+        }
+        expect {
+          post "/api/v1/categorization/feedback", params: params.to_json, headers: tenant_headers
+        }.not_to change(PatternFeedback, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "ignores another user's pattern_id rather than recording feedback against it" do
+        own_category = create(:category, user: non_admin)
+        params = {
+          feedback: {
+            expense_id: tenant_expense.id,
+            category_id: own_category.id,
+            pattern_id: foreign_pattern.id,
+            was_correct: true
+          }
+        }
+        post "/api/v1/categorization/feedback", params: params.to_json, headers: tenant_headers
+
+        # Foreign pattern is scoped out (find_by → nil), so its stats are untouched.
+        expect(foreign_pattern.reload.usage_count).to eq(0)
+      end
+    end
   end
 
   describe "POST /api/v1/categorization/batch_suggest", integration: true do

--- a/spec/requests/api/v1/categorization_spec.rb
+++ b/spec/requests/api/v1/categorization_spec.rb
@@ -212,9 +212,15 @@ RSpec.describe "Api::V1::Categorization", type: :request, integration: true do
             was_correct: true
           }
         }
+
+        # The controller resolves the pattern via usable_by(...).find_by, which
+        # returns nil for a foreign pattern — so record_feedback gets pattern: nil.
+        allow(PatternFeedback).to receive(:record_feedback).and_call_original
+
         post "/api/v1/categorization/feedback", params: params.to_json, headers: tenant_headers
 
-        # Foreign pattern is scoped out (find_by → nil), so its stats are untouched.
+        expect(PatternFeedback).to have_received(:record_feedback)
+          .with(hash_including(pattern: nil))
         expect(foreign_pattern.reload.usage_count).to eq(0)
       end
     end
@@ -319,6 +325,22 @@ RSpec.describe "Api::V1::Categorization", type: :request, integration: true do
 
       expect(top_categories).to be_an(Array)
       expect(top_categories.first).to include("name", "pattern_count") if top_categories.any?
+    end
+
+    it "does not count another tenant's patterns (cross-tenant isolation)" do
+      non_admin = create(:user)
+      tenant_token = create(:api_token, user: non_admin)
+      tenant_headers = { "Authorization" => "Bearer #{tenant_token.token}", "Content-Type" => "application/json" }
+
+      foreign_category = create(:category, user: create(:user))
+      create_list(:categorization_pattern, 4, category: foreign_category)
+
+      get "/api/v1/categorization/statistics", headers: tenant_headers
+
+      stats = JSON.parse(response.body)["statistics"]
+      # The 4 foreign patterns must be excluded from this tenant's aggregates.
+      expect(stats["total_patterns"]).to eq(CategorizationPattern.usable_by(non_admin).count)
+      expect(stats["total_patterns"]).to be < CategorizationPattern.count
     end
   end
 

--- a/spec/requests/api/v1/patterns_security_spec.rb
+++ b/spec/requests/api/v1/patterns_security_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe "Api::V1::Patterns Security", type: :request, integration: true d
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context "when the token owner's account is locked" do
+      let(:token) { create(:api_token) }
+
+      before { token.user.lock_account! }
+
+      it "returns 401 and does not execute the action" do
+        create(:categorization_pattern, category: category)
+        get "/api/v1/patterns", headers: { "Authorization" => "Bearer #{token.token}" }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)["error"]).to eq("Token owner account is unavailable")
+        # Action body must not run: no patterns payload is rendered.
+        expect(JSON.parse(response.body)).not_to have_key("patterns")
+      end
+    end
   end
 
   describe "Token BCrypt verification", integration: true do
@@ -143,6 +159,50 @@ RSpec.describe "Api::V1::Patterns Security", type: :request, integration: true d
       json = JSON.parse(response.body)
       # Pattern values are normalized to lowercase for consistent matching
       expect(json["pattern"]["pattern_value"]).to eq("<script>alert('xss')</script>")
+    end
+  end
+
+  describe "Cross-tenant isolation (IDOR)", integration: true do
+    let(:other_user) { create(:user) }
+    let(:other_category) { create(:category, user: other_user) }
+    let(:other_pattern) { create(:categorization_pattern, category: other_category) }
+
+    let(:token) { create(:api_token, user: create(:user)) }
+    let(:headers) do
+      { "Authorization" => "Bearer #{token.token}", "Content-Type" => "application/json" }
+    end
+
+    it "does not include another user's patterns in index" do
+      other_pattern # create it
+      get "/api/v1/patterns", headers: headers
+      expect(response).to have_http_status(:ok)
+      ids = JSON.parse(response.body)["patterns"].map { |p| p["id"] }
+      expect(ids).not_to include(other_pattern.id)
+    end
+
+    it "returns 404 when showing another user's pattern" do
+      get "/api/v1/patterns/#{other_pattern.id}", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 when updating another user's pattern" do
+      patch "/api/v1/patterns/#{other_pattern.id}",
+            params: { pattern: { confidence_weight: 5.0 } }.to_json, headers: headers
+      expect(response).to have_http_status(:not_found)
+      expect(other_pattern.reload.confidence_weight).to eq(1.0)
+    end
+
+    it "returns 404 when deleting (deactivating) another user's pattern" do
+      delete "/api/v1/patterns/#{other_pattern.id}", headers: headers
+      expect(response).to have_http_status(:not_found)
+      expect(other_pattern.reload.active).to be true
+    end
+
+    it "rejects creating a pattern on another user's category" do
+      post "/api/v1/patterns",
+           params: { pattern: { pattern_type: "merchant", pattern_value: "x", category_id: other_category.id } }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
## Summary

Findings from a full application security audit (Brakeman + four parallel security-review agents covering authn/authz, API surface, secrets/email-sync, and XSS/headers). This PR fixes the **self-contained** backend issues. All changes are backend-only and covered by new/updated specs.

## What's fixed

### Authorization (IDOR)
- **Patterns API** (`api/v1/patterns_controller.rb`): `index`, `show`, `update`, `destroy` now scope through `CategorizationPattern.usable_by(current_api_user)` (category-ownership aware). `create` rejects patterns targeting a category the caller can't see. Previously any token could read/modify/deactivate any tenant's categorization patterns.
- **Categorization feedback** (`api/v1/categorization_controller.rb`): `category` resolves through `CategoryPolicy.visible_scope`, `pattern` through `usable_by`. Prevents cross-tenant feedback poisoning the ML learning signal.
- **Sync session status** (`api/sync_sessions_controller.rb`): removed the `stored_ip.nil? => allow anyone` fallback that let a recent session be polled by guessing its sequential id, leaking the account email + bank name.

### Sensitive data exposure
- **ProcessEmailJob**: stopped logging `email_data.inspect` (full plaintext bank-email body, which bypasses `filter_parameters` since it's a plain Hash) — now logs only `subject` + `message_id`.
- **Health metrics**: exception text is logged server-side instead of echoed to the client.
- **Client errors**: client-supplied fields are stripped of control chars (CR/LF log injection, CWE-117) and truncated before logging.

### Hardening
- **ApiToken.authenticate**: auth cache now keys on the full SHA256 digest instead of a 17-char truncation, removing a latent token-confusion risk.

## Testing
- New cross-tenant IDOR request specs (patterns, categorization), sync-session nil-IP denial spec, PII-not-logged job spec, health no-leak spec, client-error sanitization specs.
- Full unit suite green via pre-commit hook (7900+ examples). Brakeman: 0 warnings.

## Audit follow-ups intentionally NOT in this PR
- **Queue controller authz**: "any valid token = queue admin" + unconditional `development?` bypass. Needs an `ApiToken` role/scope concept (redesign) — flagged for a separate ticket.
- **Bulk categorization / external sources IDORs**: already carry in-code `FIXME(PR-5b)/(PR-12)` markers; left to that planned work to avoid collision.
- **Solid Queue plaintext email body**: `ProcessEmailJob` args persist the full bank-email body unencrypted in `solid_queue_*` tables (bypasses the `encrypts` used elsewhere). Architectural change (persist encrypted, pass an id) — worth its own ticket.

A locked-account "auth bypass" the audit flagged was verified to be a **false positive** (Rails halts the before_action chain on `performed?`); a regression test was added to guard the behavior.