### PR TITLE
feat(budgets): auto-map remote category to salary_bucket during external sync

### DIFF
--- a/app/services/external_budgets/sync_service.rb
+++ b/app/services/external_budgets/sync_service.rb
@@ -116,11 +116,11 @@ module Services
           active: true,
           external_synced_at: Time.current
         )
-        # Only auto-map salary_bucket when it isn't already set — same
-        # never-overwrite property as category_id above, so manual bucket
-        # assignments (and buckets set by a prior sync) survive re-sync.
-        # Unknown/missing remote categories miss the lookup and are skipped,
-        # leaving salary_bucket nil rather than raising on an invalid enum value.
+        # Auto-map the remote category to salary_bucket only when the local value
+        # is nil. Unlike category_id (which sync never writes at all), this WILL
+        # re-apply a bucket on the next sync if a user deliberately clears it on
+        # an external budget — accepted tradeoff so existing unmapped rows get
+        # backfilled automatically.
         if budget.salary_bucket.nil?
           mapped_bucket = SALARY_BUCKET_MAP[item["category"].to_s]
           budget.salary_bucket = mapped_bucket if mapped_bucket

--- a/app/services/external_budgets/sync_service.rb
+++ b/app/services/external_budgets/sync_service.rb
@@ -21,6 +21,17 @@ module Services
       SOURCE_KEY = "salary_calculator"
       ALLOWED_CURRENCIES = %w[CRC USD EUR].freeze
 
+      # Remote `category` values (salary_calculator enum) => local Budget#salary_bucket
+      # enum values. Note the singular/plural mismatch: remote "investments" maps to
+      # the local singular "investment". Unknown/missing remote values are intentionally
+      # left out — lookups miss and salary_bucket stays nil (see #upsert_budget).
+      SALARY_BUCKET_MAP = {
+        "fixed" => "fixed",
+        "guilt_free" => "guilt_free",
+        "savings" => "savings",
+        "investments" => "investment"
+      }.freeze
+
       class InvalidPayload < StandardError; end
 
       def initialize(source:)
@@ -105,6 +116,15 @@ module Services
           active: true,
           external_synced_at: Time.current
         )
+        # Only auto-map salary_bucket when it isn't already set — same
+        # never-overwrite property as category_id above, so manual bucket
+        # assignments (and buckets set by a prior sync) survive re-sync.
+        # Unknown/missing remote categories miss the lookup and are skipped,
+        # leaving salary_bucket nil rather than raising on an invalid enum value.
+        if budget.salary_bucket.nil?
+          mapped_bucket = SALARY_BUCKET_MAP[item["category"].to_s]
+          budget.salary_bucket = mapped_bucket if mapped_bucket
+        end
         budget.save!
       end
     end

--- a/spec/services/external_budgets/sync_service_spec.rb
+++ b/spec/services/external_budgets/sync_service_spec.rb
@@ -339,6 +339,106 @@ RSpec.describe Services::ExternalBudgets::SyncService, :unit do
       end
     end
 
+    context "salary_bucket auto-mapping" do
+      %w[fixed guilt_free savings].each do |category|
+        it "maps remote category #{category.inspect} to the same salary_bucket on create" do
+          stub_request(:get, path)
+            .to_return(status: 200, body: payload([ rent_item.merge(category: category) ]),
+                       headers: { "Content-Type" => "application/json" })
+
+          service.call
+
+          budget = account.budgets.find_by(external_source: "salary_calculator", external_id: 101)
+          expect(budget.salary_bucket).to eq(category)
+        end
+      end
+
+      it "maps remote category \"investments\" to the singular salary_bucket \"investment\"" do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item.merge(category: "investments") ]),
+                     headers: { "Content-Type" => "application/json" })
+
+        service.call
+
+        budget = account.budgets.find_by(external_source: "salary_calculator", external_id: 101)
+        expect(budget.salary_bucket).to eq("investment")
+      end
+
+      it "backfills salary_bucket on an existing row that was never bucketed" do
+        existing = account.budgets.create!(
+          user: account.user,
+          name: "Rent",
+          amount: 800.0,
+          currency: "USD",
+          period: :monthly,
+          start_date: period_start,
+          end_date: period_end,
+          external_source: "salary_calculator",
+          external_id: 101,
+          salary_bucket: nil,
+          active: true,
+          external_synced_at: 1.day.ago
+        )
+
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item.merge(category: "fixed") ]),
+                     headers: { "Content-Type" => "application/json" })
+
+        service.call
+
+        expect(existing.reload.salary_bucket).to eq("fixed")
+      end
+
+      it "preserves a manually set salary_bucket on re-sync even if the remote category differs" do
+        existing = account.budgets.create!(
+          user: account.user,
+          name: "Rent",
+          amount: 800.0,
+          currency: "USD",
+          period: :monthly,
+          start_date: period_start,
+          end_date: period_end,
+          external_source: "salary_calculator",
+          external_id: 101,
+          salary_bucket: :savings,
+          active: true,
+          external_synced_at: 1.day.ago
+        )
+
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item.merge(category: "fixed") ]),
+                     headers: { "Content-Type" => "application/json" })
+
+        service.call
+
+        expect(existing.reload.salary_bucket).to eq("savings")
+      end
+
+      it "leaves salary_bucket nil for an unknown remote category, without raising" do
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ rent_item.merge(category: "variable") ]),
+                     headers: { "Content-Type" => "application/json" })
+
+        expect { service.call }.not_to raise_error
+
+        budget = account.budgets.find_by(external_source: "salary_calculator", external_id: 101)
+        expect(budget.salary_bucket).to be_nil
+      end
+
+      it "leaves salary_bucket nil when the remote category is missing, without raising" do
+        item_without_category = rent_item.except(:category)
+
+        stub_request(:get, path)
+          .to_return(status: 200, body: payload([ item_without_category ]),
+                     headers: { "Content-Type" => "application/json" })
+
+        expect { service.call }.not_to raise_error
+
+        budget = account.budgets.find_by(external_source: "salary_calculator", external_id: 101)
+        expect(budget.salary_bucket).to be_nil
+      end
+    end
+
     context "when source.last_synced_at is present" do
       let(:since) { Time.parse("2026-04-10T00:00:00Z") }
 


### PR DESCRIPTION
## Why

Every budget synced from the salary calculator lands with `salary_bucket: nil`, so external budgets are excluded from the bucket rollup (`Services::Budgets::BucketSummary`) until manually mapped. In prod today: 72 of 72 synced budgets are unmapped — the bucket dashboard has never included them.

## What

- New frozen `SALARY_BUCKET_MAP` in `ExternalBudgets::SyncService`: remote `fixed/guilt_free/savings/investments` → local `fixed/guilt_free/savings/investment` (remote plural → local singular).
- `upsert_budget` assigns `salary_bucket` only when the local value is nil: new rows get mapped on create, existing unmapped rows get backfilled on their next daily sync, manually-set buckets are never overwritten. Unknown/missing remote categories are silently ignored (no enum ArgumentError, no InvalidPayload).
- Documented tradeoff in-code: a user who deliberately clears the bucket on an external budget will see it re-applied next sync (accepted so prod rows backfill automatically).

## Notes

- Current-month prod rows backfill on the next 6am sync. Older months' rows stay unmapped (the remote category was never persisted locally) — acceptable for historical data.
- `category_id` mapping behavior is untouched.

## Tests

- 7 new examples: all 4 mappings, backfill-on-nil, preserve-manual, unknown/missing category no-raise.
- Full sync spec file: 25 examples, 0 failures. Full unit suite: 9084 examples, 0 failures. RuboCop clean.