### PR TITLE
fix(ci): unbreak scan_ruby and claude-review for all PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model: the @beta action's default (Sonnet 4) was retired and now 404s.
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model: the @beta action's default (Sonnet 4) was retired and now 404s.
+          model: "claude-sonnet-5"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## Why

Every open PR currently fails two CI checks for reasons unrelated to its diff:

- **scan_ruby**: `bin/brakeman` prepends `--ensure-latest`; the lockfile pins Brakeman 8.0.4 but 8.0.5 was released, so Brakeman exits 5 before scanning.
- **claude-review**: `anthropics/claude-code-action@beta` defaults to a Sonnet 4 model that has been retired — the API returns 404 `model: claude-sonnet-4-20250514` on every run.

## What

- Commit 1: `bundle update brakeman` → 8.0.5 (lockfile only). Verified locally: scan runs, no warnings.
- Commit 2: pin `model: "claude-sonnet-5"` in `claude-code-review.yml` and `claude.yml` (current model, no more reliance on the stale action default).

Separate commits per layer for independent revert.

## Verification

- Local `bin/brakeman --no-pager`: no warnings found, exit 0.
- This PR's own claude-review run exercises the pinned model (workflow file is taken from the PR branch).