### PR TITLE
feat(budgets): alert banner when external budget sync needs attention

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -21,9 +21,11 @@ class BudgetsController < ApplicationController
     @category_options = Category.all.distinct.to_a
 
     # Whether an active external budget source (e.g., salary_calculator) is linked.
-    # Drives the empty-state CTA and sync-in-progress messaging.
+    # Drives the empty-state CTA, sync-in-progress messaging, and the
+    # shared "needs attention" alert banner (deactivated / sync failed).
     email_account = scoping_user.email_accounts.first
-    @has_external_source = email_account&.external_budget_source&.active? || false
+    @external_budget_source = email_account&.external_budget_source
+    @has_external_source = @external_budget_source&.active? || false
 
     # Salary-bucket rollup (fixed / guilt_free / savings / investment).
     # Scoped to the user's first email_account to match the rest of the index.

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,6 +5,11 @@ class DashboardController < ApplicationController
     @period = VALID_PERIODS.include?(params[:period]) ? params[:period] : "month"
     @primary_email_account = EmailAccount.active.first
 
+    # Drives the shared "needs attention" alert banner when the linked
+    # external budget source (e.g., salary_calculator) is deactivated or its
+    # last scheduled sync failed.
+    @external_budget_source = @primary_email_account&.external_budget_source
+
     if @primary_email_account
       calculator_period, reference_date = period_calculator_args(@period)
 

--- a/app/models/external_budget_source.rb
+++ b/app/models/external_budget_source.rb
@@ -22,6 +22,14 @@ class ExternalBudgetSource < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
+  # True when the source is silently broken and needs a human to look at it:
+  # either deactivated (e.g., revoked credentials) or the last scheduled sync
+  # failed while the source is still nominally active (transient error).
+  # Drives the dashboard/budgets alert banner (PER-365-follow-up).
+  def needs_attention?
+    !active? || last_sync_status == STATUSES[:failed]
+  end
+
   def mark_succeeded!
     update!(last_synced_at: Time.current, last_sync_status: STATUSES[:ok], last_sync_error: nil)
   end

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -1,5 +1,7 @@
 <%# Budget management page %>
 <div class="container mx-auto px-4 py-8">
+  <%= render "shared/external_source_alert", source: @external_budget_source %>
+
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-3xl font-bold text-slate-900"><%= t("budgets.index.title") %></h1>
     <%= link_to t("budgets.index.new_budget"), new_budget_path,

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -2,6 +2,8 @@
   <%# === Header === %>
   <%= render "dashboard/header" %>
 
+  <%= render "shared/external_source_alert", source: @external_budget_source %>
+
   <%= turbo_frame_tag "dashboard-body" do %>
     <%# === Period Selector (inside frame so active state updates) === %>
     <%= render "dashboard/period_selector", period: @period %>

--- a/app/views/external_sources/show.html.erb
+++ b/app/views/external_sources/show.html.erb
@@ -1,7 +1,7 @@
 <%# Settings → External Sources page. Renders one of three states:
     1. Not connected  — slate card with Connect CTA.
     2. Connected      — emerald accent with Sync now + Disconnect.
-    3. Reconnect req. — amber banner with Reconnect + Disconnect.
+    3. Reconnect req. — rose banner with Reconnect + Disconnect.
 %>
 <div class="container mx-auto px-4 py-8 max-w-3xl">
   <header class="mb-6">
@@ -53,14 +53,14 @@
     </section>
 
   <% else %>
-    <section class="bg-amber-50 border-l-4 border-amber-500 border border-amber-200 rounded-lg shadow-sm p-6"
+    <section class="bg-rose-50 border-l-4 border-rose-500 border border-rose-200 rounded-lg shadow-sm p-6"
              role="alert"
              aria-labelledby="external-source-reconnect">
       <h2 id="external-source-reconnect"
-          class="text-lg font-medium text-amber-900 mb-1">
+          class="text-lg font-medium text-rose-900 mb-1">
         <%= t("external_sources.reconnect_required") %>
       </h2>
-      <p class="text-sm text-amber-800 mb-4">
+      <p class="text-sm text-rose-800 mb-4">
         <%= t("external_sources.reconnect_required_body") %>
       </p>
       <div class="flex flex-wrap gap-3">

--- a/app/views/shared/_external_source_alert.html.erb
+++ b/app/views/shared/_external_source_alert.html.erb
@@ -1,0 +1,38 @@
+<%# Alert banner shown when the linked external budget source (salary_calc)
+    needs attention. Rendered on both the dashboard and the budgets index.
+
+    Local: source — an ExternalBudgetSource or nil.
+
+    Two variants:
+      - deactivated (active == false)        -> rose-*  "reconnect required"
+      - sync failed but still active         -> amber-* "last sync failed"
+%>
+<% if source&.needs_attention? %>
+  <% if source.active? %>
+    <div class="bg-amber-50 border-l-4 border-amber-500 border border-amber-200 rounded-lg shadow-sm p-4 mb-6"
+         role="alert"
+         aria-labelledby="external-source-alert-sync-failed">
+      <h2 id="external-source-alert-sync-failed" class="text-sm font-semibold text-amber-900 mb-1">
+        <%= t("external_sources.alert.sync_failed_title") %>
+      </h2>
+      <p class="text-sm text-amber-800 mb-2">
+        <%= t("external_sources.alert.sync_failed_body") %>
+      </p>
+      <%= link_to t("external_sources.alert.cta"), external_source_path,
+            class: "text-sm font-medium text-amber-900 underline hover:no-underline" %>
+    </div>
+  <% else %>
+    <div class="bg-rose-50 border-l-4 border-rose-500 border border-rose-200 rounded-lg shadow-sm p-4 mb-6"
+         role="alert"
+         aria-labelledby="external-source-alert-reconnect">
+      <h2 id="external-source-alert-reconnect" class="text-sm font-semibold text-rose-900 mb-1">
+        <%= t("external_sources.alert.reconnect_required_title") %>
+      </h2>
+      <p class="text-sm text-rose-800 mb-2">
+        <%= t("external_sources.alert.reconnect_required_body") %>
+      </p>
+      <%= link_to t("external_sources.alert.cta"), external_source_path,
+            class: "text-sm font-medium text-rose-900 underline hover:no-underline" %>
+    </div>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1094,3 +1094,9 @@ en:
     state_expired: "Link request expired — please try again"
     exchange_failed: "Could not exchange authorization — please reconnect"
     no_account: "Add an email account first"
+    alert:
+      reconnect_required_title: "Reconnect required"
+      reconnect_required_body: "Your salary_calc connection was disconnected. Reconnect to resume automatic budget syncing."
+      sync_failed_title: "Last sync failed"
+      sync_failed_body: "The last sync from salary_calc failed. It will retry automatically, or you can check the connection now."
+      cta: "Manage connection"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1098,3 +1098,9 @@ es:
     state_expired: "La solicitud expiró — intentá de nuevo"
     exchange_failed: "No se pudo intercambiar la autorización — reconectá por favor"
     no_account: "Agregá primero una cuenta de correo"
+    alert:
+      reconnect_required_title: "Requiere reconexión"
+      reconnect_required_body: "Tu conexión con salary_calc se desconectó. Reconectá para reanudar la sincronización automática del presupuesto."
+      sync_failed_title: "La última sincronización falló"
+      sync_failed_body: "La última sincronización con salary_calc falló. Se reintentará automáticamente, o podés revisar la conexión ahora."
+      cta: "Gestionar conexión"

--- a/spec/models/external_budget_source_spec.rb
+++ b/spec/models/external_budget_source_spec.rb
@@ -234,4 +234,27 @@ RSpec.describe ExternalBudgetSource, type: :model, unit: true do
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  describe "#needs_attention?" do
+    it "is true when the source is deactivated" do
+      source = create(:external_budget_source, email_account: email_account, active: false)
+      expect(source.needs_attention?).to be(true)
+    end
+
+    it "is true when the last sync failed while the source is still active" do
+      source = create(:external_budget_source, email_account: email_account, active: true, last_sync_status: "failed")
+      expect(source.needs_attention?).to be(true)
+    end
+
+    it "is false when the source is active and the last sync succeeded" do
+      source = create(:external_budget_source, email_account: email_account, active: true, last_sync_status: "ok")
+      expect(source.needs_attention?).to be(false)
+    end
+
+    it "is true when both deactivated and the last recorded status is failed" do
+      source = create(:external_budget_source, email_account: email_account)
+      source.deactivate!(reason: "token revoked")
+      expect(source.needs_attention?).to be(true)
+    end
+  end
 end

--- a/spec/requests/external_source_alert_spec.rb
+++ b/spec/requests/external_source_alert_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Covers the "needs attention" alert banner shared between the dashboard and
+# the budgets index. Renders when the linked salary_calc external budget
+# source is deactivated (rose, reconnect required) or its last scheduled
+# sync failed while still active (amber, sync failed).
+RSpec.describe "External source alert banner", type: :request, unit: true do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:email_account) { create(:email_account, user: admin_user, active: true) }
+
+  before do
+    sign_in_admin(admin_user)
+
+    # Mock SolidQueue::Job used by DashboardService#sync_info (dashboard#show only).
+    jobs_relation = double("jobs_relation", exists?: false, count: 0)
+    allow(SolidQueue::Job).to receive(:where)
+      .with(class_name: "ProcessEmailsJob", finished_at: nil)
+      .and_return(double("intermediate", where: jobs_relation))
+
+    # BudgetsController scopes via scoping_user.email_accounts.first; the
+    # dashboard scopes via EmailAccount.active.first — both resolve to the
+    # same email_account here since admin_user has a single active account.
+  end
+
+  shared_examples "renders the external source alert banner" do |path_helper|
+    context "when the source is deactivated" do
+      let!(:source) do
+        create(:external_budget_source, email_account: email_account, active: false, last_sync_status: "failed",
+               last_sync_error: "token revoked")
+      end
+
+      it "renders the rose reconnect-required banner" do
+        get send(path_helper)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('role="alert"')
+        expect(response.body).to include(I18n.t("external_sources.alert.reconnect_required_title"))
+        expect(response.body).to include(I18n.t("external_sources.alert.reconnect_required_body"))
+        expect(response.body).to include("bg-rose-50")
+        expect(response.body).not_to include(I18n.t("external_sources.alert.sync_failed_title"))
+        expect(response.body).to match(%r{<a[^>]+href="#{Regexp.escape(external_source_path)}"[^>]*>#{Regexp.escape(I18n.t("external_sources.alert.cta"))}</a>})
+      end
+    end
+
+    context "when the source is active but the last sync failed" do
+      let!(:source) do
+        create(:external_budget_source, email_account: email_account, active: true, last_sync_status: "failed",
+               last_sync_error: "timeout")
+      end
+
+      it "renders the amber sync-failed banner" do
+        get send(path_helper)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('role="alert"')
+        expect(response.body).to include(I18n.t("external_sources.alert.sync_failed_title"))
+        expect(response.body).to include(I18n.t("external_sources.alert.sync_failed_body"))
+        expect(response.body).to include("bg-amber-50")
+        expect(response.body).not_to include(I18n.t("external_sources.alert.reconnect_required_title"))
+        expect(response.body).to match(%r{<a[^>]+href="#{Regexp.escape(external_source_path)}"[^>]*>#{Regexp.escape(I18n.t("external_sources.alert.cta"))}</a>})
+      end
+    end
+
+    context "when the source is active and healthy" do
+      let!(:source) do
+        create(:external_budget_source, email_account: email_account, active: true, last_sync_status: "ok")
+      end
+
+      it "does not render the alert banner" do
+        get send(path_helper)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(I18n.t("external_sources.alert.reconnect_required_title"))
+        expect(response.body).not_to include(I18n.t("external_sources.alert.sync_failed_title"))
+      end
+    end
+
+    context "when there is no external source" do
+      it "does not render the alert banner" do
+        get send(path_helper)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(I18n.t("external_sources.alert.reconnect_required_title"))
+        expect(response.body).not_to include(I18n.t("external_sources.alert.sync_failed_title"))
+      end
+    end
+  end
+
+  describe "GET /budgets" do
+    include_examples "renders the external source alert banner", :budgets_path
+  end
+
+  describe "GET /dashboard" do
+    include_examples "renders the external source alert banner", :dashboard_page_path
+  end
+end

--- a/spec/requests/external_sources_spec.rb
+++ b/spec/requests/external_sources_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "ExternalSources", type: :request do
         get external_source_path
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(I18n.t("external_sources.reconnect_required"))
-        expect(response.body).to match(/bg-amber-|text-amber-|border-amber-/)
+        expect(response.body).to match(/bg-rose-|text-rose-|border-rose-/)
       end
     end
   end


### PR DESCRIPTION
## Why

When the salary-calculator OAuth token dies (401 → source deactivated) or a sync fails, nothing tells the user — the daily 6am sync fails silently and budgets quietly stop updating. You only find out by visiting Settings → External Sources.

## What

- `ExternalBudgetSource#needs_attention?` — true when the source is deactivated or the last sync failed.
- Shared partial `shared/_external_source_alert` rendered on the budgets index AND the dashboard:
  - deactivated → rose (error) "reconnect required" banner
  - active but last sync failed → amber (warning) "last sync failed" banner
  - both link to the External Sources settings page.
- Settings page's own "Reconnect required" banner switched amber → rose so the deactivated state has one color everywhere (architect finding).
- i18n: en + es, key parity verified.

## Follow-ups deliberately deferred (small, non-blocking)

- Deduplicate the near-identical i18n copy between the settings banner and the shared alert.
- Extract a generic status-banner partial used by both pages.

## Tests

- 4 model specs for `needs_attention?`, 8 request specs across /budgets and /dashboard (rose when deactivated, amber when failed, absent when healthy/no source), settings-page spec updated for rose.
- Full unit suite: 9088 examples, 0 failures. RuboCop clean.