### PR TITLE
fix(deploy): comment out unprovisioned secrets that brick kamal deploy

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -47,21 +47,28 @@ env:
     # Without this the strategy 401s on every call and the circuit-breaker
     # silently degrades to pattern-only categorization (PER-548).
     - ANTHROPIC_API_KEY
+    # --- Not yet provisioned: re-add each entry below once its secret exists in
+    # --- 1Password AND .kamal/secrets. Kamal hard-fails the whole deploy on any
+    # --- listed-but-missing secret (this bricked the 2026-07-04 deploy), so
+    # --- unprovisioned secrets stay commented out. Both features degrade
+    # --- gracefully without their env (Sentry stays inert; PostgresBackupJob
+    # --- raises a descriptive BackupError).
+    #
     # Sentry APM/error-tracking DSN (PER-526). Without this the gem stays
     # inert (no events sent). Store in 1Password:
     #   op://Personal Brand/Expense Tracker/SENTRY_DSN
     # and append to .kamal/secrets before deploying.
-    - SENTRY_DSN
+    # - SENTRY_DSN
     # Hetzner Storage Box credentials for nightly Postgres backup (PER-527).
     # STORAGE_BOX_HOST:    u<id>.your-storagebox.de
     # STORAGE_BOX_USER:    u<id> (the Storage Box username)
     # STORAGE_BOX_SSH_KEY: path to the private key inside the container
     #                      (mount via kamal volumes or write via env)
     # BACKUP_GPG_PASSPHRASE: symmetric GPG passphrase for .dump.gpg files
-    - STORAGE_BOX_HOST
-    - STORAGE_BOX_USER
-    - STORAGE_BOX_SSH_KEY
-    - BACKUP_GPG_PASSPHRASE
+    # - STORAGE_BOX_HOST
+    # - STORAGE_BOX_USER
+    # - STORAGE_BOX_SSH_KEY
+    # - BACKUP_GPG_PASSPHRASE
   clear:
     RAILS_ENV: production
     POSTGRES_USER: expense_tracker


### PR DESCRIPTION
## Why

Kamal hard-fails the entire deploy when any `env.secret` entry is missing from `.kamal/secrets`. Five entries added by PR #513 (Sentry, PER-526) and PR #515 (Storage Box backups, PER-527) were never provisioned in 1Password/.kamal/secrets — this bricked the 2026-07-04 deploy (`Secret 'SENTRY_DSN' not found`), which was the first deploy attempted since those PRs merged.

## What

Comment out the five unprovisioned entries (`SENTRY_DSN`, `STORAGE_BOX_HOST/USER/SSH_KEY`, `BACKUP_GPG_PASSPHRASE`) with instructions to re-add each once its secret exists in BOTH 1Password and `.kamal/secrets`. Per the deploy-secrets norm: warn-only until provisioned, promote to required after.

Both features degrade gracefully without env: the Sentry initializer explicitly skips init when no DSN is present, and `PostgresBackupJob` raises a descriptive `BackupError`.

## Follow-up (important)

**Nightly prod DB backups have never actually run** — the backup feature merged in May but its credentials were never provisioned. Provision the Storage Box creds + GPG passphrase, add them to `.kamal/secrets`, and uncomment the four entries.

## Verification

Prod was deployed with exactly this working-tree config today (image = main@d729c0b): boot succeeded, `/up` 200, live sync verified.