### PR TITLE
feat(ops): enable nightly Storage Box backup with env-materialized SSH key (PER-527)

### DIFF
--- a/app/services/backup_key_materializer.rb
+++ b/app/services/backup_key_materializer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Materializes the Storage Box SSH private key from an environment variable
+# into an on-disk keyfile at boot.
+#
+# PostgresBackupJob uploads via Net::SFTP, which authenticates with a key
+# *file* (STORAGE_BOX_SSH_KEY is a path). Kamal, however, can only inject
+# secrets as env vars — and its env transport does not survive multiline
+# values — so the key travels base64-encoded in STORAGE_BOX_SSH_KEY_CONTENT
+# and is written out here (0600) before any job runs.
+#
+# Wired from config/initializers/backup_ssh_key.rb (PER-527).
+module Services
+  class BackupKeyMaterializer
+    DEFAULT_KEY_PATH = "tmp/storage_box_ed25519"
+
+    # Returns the materialized key path, or nil when there is nothing to do.
+    # Never raises: a malformed value logs and leaves ENV untouched so boot
+    # continues — PostgresBackupJob then fails loudly with its own BackupError.
+    def self.call(env: ENV, root: Rails.root)
+      return env["STORAGE_BOX_SSH_KEY"] if env["STORAGE_BOX_SSH_KEY"].present?
+
+      encoded = env["STORAGE_BOX_SSH_KEY_CONTENT"]
+      return nil if encoded.blank?
+
+      key = Base64.strict_decode64(encoded.gsub(/\s+/, ""))
+      path = root.join(DEFAULT_KEY_PATH).to_s
+
+      File.write(path, key, perm: 0o600)
+      File.chmod(0o600, path) # enforce even when the file already existed
+      env["STORAGE_BOX_SSH_KEY"] = path
+      path
+    rescue ArgumentError => e
+      Rails.logger.error("[BackupKeyMaterializer] STORAGE_BOX_SSH_KEY_CONTENT is not valid base64: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/backup_key_materializer.rb
+++ b/app/services/backup_key_materializer.rb
@@ -24,6 +24,12 @@ module Services
       return nil if encoded.blank?
 
       key = Base64.strict_decode64(encoded.gsub(/\s+/, ""))
+
+      unless key.start_with?("-----BEGIN")
+        Rails.logger.error("[BackupKeyMaterializer] decoded STORAGE_BOX_SSH_KEY_CONTENT does not look like a private key (missing -----BEGIN header)")
+        return nil
+      end
+
       path = root.join(DEFAULT_KEY_PATH).to_s
 
       File.write(path, key, perm: 0o600)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,25 +50,27 @@ env:
     # --- Not yet provisioned: re-add each entry below once its secret exists in
     # --- 1Password AND .kamal/secrets. Kamal hard-fails the whole deploy on any
     # --- listed-but-missing secret (this bricked the 2026-07-04 deploy), so
-    # --- unprovisioned secrets stay commented out. Both features degrade
-    # --- gracefully without their env (Sentry stays inert; PostgresBackupJob
-    # --- raises a descriptive BackupError).
+    # --- unprovisioned secrets stay commented out.
     #
     # Sentry APM/error-tracking DSN (PER-526). Without this the gem stays
     # inert (no events sent). Store in 1Password:
     #   op://Personal Brand/Expense Tracker/SENTRY_DSN
     # and append to .kamal/secrets before deploying.
     # - SENTRY_DSN
+    #
     # Hetzner Storage Box credentials for nightly Postgres backup (PER-527).
-    # STORAGE_BOX_HOST:    u<id>.your-storagebox.de
-    # STORAGE_BOX_USER:    u<id> (the Storage Box username)
-    # STORAGE_BOX_SSH_KEY: path to the private key inside the container
-    #                      (mount via kamal volumes or write via env)
-    # BACKUP_GPG_PASSPHRASE: symmetric GPG passphrase for .dump.gpg files
-    # - STORAGE_BOX_HOST
-    # - STORAGE_BOX_USER
-    # - STORAGE_BOX_SSH_KEY
-    # - BACKUP_GPG_PASSPHRASE
+    # STORAGE_BOX_HOST: u<id>.your-storagebox.de
+    # STORAGE_BOX_USER: u<id> (the Storage Box username)
+    # STORAGE_BOX_SSH_KEY_CONTENT: the private key, base64-encoded — Kamal's
+    #   env transport cannot carry multiline values, so .kamal/secrets pipes
+    #   `op read ... | base64` and Services::BackupKeyMaterializer writes it
+    #   to a 0600 keyfile at boot (config/initializers/backup_ssh_key.rb).
+    # BACKUP_GPG_PASSPHRASE: symmetric GPG passphrase for .dump.gpg files —
+    #   losing it makes every backup permanently unreadable.
+    - STORAGE_BOX_HOST
+    - STORAGE_BOX_USER
+    - STORAGE_BOX_SSH_KEY_CONTENT
+    - BACKUP_GPG_PASSPHRASE
   clear:
     RAILS_ENV: production
     POSTGRES_USER: expense_tracker

--- a/config/initializers/backup_ssh_key.rb
+++ b/config/initializers/backup_ssh_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Writes the Storage Box SSH private key from STORAGE_BOX_SSH_KEY_CONTENT
+# (base64, injected by Kamal from 1Password) to an on-disk 0600 keyfile and
+# points STORAGE_BOX_SSH_KEY at it, so PostgresBackupJob's Net::SFTP client
+# can authenticate. No-ops when the env is absent (dev, test, CI). PER-527.
+Rails.application.config.after_initialize do
+  Services::BackupKeyMaterializer.call
+end

--- a/spec/services/backup_key_materializer_spec.rb
+++ b/spec/services/backup_key_materializer_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Services::BackupKeyMaterializer, :unit do
     expect(File.exist?(root.join(described_class::DEFAULT_KEY_PATH))).to be(false)
   end
 
+  it "logs and leaves ENV untouched when the decoded payload is not a private key" do
+    env = { "STORAGE_BOX_SSH_KEY_CONTENT" => Base64.strict_encode64("garbage from a failed op read") }
+    allow(Rails.logger).to receive(:error)
+
+    expect(call(env)).to be_nil
+    expect(env).not_to have_key("STORAGE_BOX_SSH_KEY")
+    expect(File.exist?(root.join(described_class::DEFAULT_KEY_PATH))).to be(false)
+    expect(Rails.logger).to have_received(:error).with(/does not look like a private key/)
+  end
+
   it "logs and leaves ENV untouched when the payload is not valid base64" do
     env = { "STORAGE_BOX_SSH_KEY_CONTENT" => "not-base64!!!" }
     allow(Rails.logger).to receive(:error)

--- a/spec/services/backup_key_materializer_spec.rb
+++ b/spec/services/backup_key_materializer_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::BackupKeyMaterializer, :unit do
+  let(:key_material) { "-----BEGIN OPENSSH PRIVATE KEY-----\nabc123\n-----END OPENSSH PRIVATE KEY-----\n" }
+  let(:encoded) { Base64.strict_encode64(key_material) }
+  let(:root) { Pathname.new(Dir.mktmpdir) }
+
+  before { FileUtils.mkdir_p(root.join("tmp")) }
+  after { FileUtils.remove_entry(root) }
+
+  def call(env)
+    described_class.call(env: env, root: root)
+  end
+
+  it "writes the decoded key to tmp with 0600 permissions and sets STORAGE_BOX_SSH_KEY" do
+    env = { "STORAGE_BOX_SSH_KEY_CONTENT" => encoded }
+
+    path = call(env)
+
+    expect(path).to eq(root.join(described_class::DEFAULT_KEY_PATH).to_s)
+    expect(File.read(path)).to eq(key_material)
+    expect(File.stat(path).mode & 0o777).to eq(0o600)
+    expect(env["STORAGE_BOX_SSH_KEY"]).to eq(path)
+  end
+
+  it "tolerates whitespace and newlines inside the base64 payload" do
+    wrapped = encoded.scan(/.{1,40}/).join("\n")
+    env = { "STORAGE_BOX_SSH_KEY_CONTENT" => wrapped }
+
+    path = call(env)
+
+    expect(File.read(path)).to eq(key_material)
+  end
+
+  it "returns the existing path untouched when STORAGE_BOX_SSH_KEY is already set" do
+    env = { "STORAGE_BOX_SSH_KEY" => "/run/secrets/key", "STORAGE_BOX_SSH_KEY_CONTENT" => encoded }
+
+    expect(call(env)).to eq("/run/secrets/key")
+    expect(File.exist?(root.join(described_class::DEFAULT_KEY_PATH))).to be(false)
+  end
+
+  it "no-ops when no key content is present" do
+    env = {}
+
+    expect(call(env)).to be_nil
+    expect(env).not_to have_key("STORAGE_BOX_SSH_KEY")
+    expect(File.exist?(root.join(described_class::DEFAULT_KEY_PATH))).to be(false)
+  end
+
+  it "logs and leaves ENV untouched when the payload is not valid base64" do
+    env = { "STORAGE_BOX_SSH_KEY_CONTENT" => "not-base64!!!" }
+    allow(Rails.logger).to receive(:error)
+
+    expect(call(env)).to be_nil
+    expect(env).not_to have_key("STORAGE_BOX_SSH_KEY")
+    expect(Rails.logger).to have_received(:error).with(/not valid base64/)
+  end
+
+  it "overwrites a stale keyfile and re-enforces 0600" do
+    stale_path = root.join(described_class::DEFAULT_KEY_PATH)
+    File.write(stale_path, "old key")
+    File.chmod(0o644, stale_path)
+    env = { "STORAGE_BOX_SSH_KEY_CONTENT" => encoded }
+
+    call(env)
+
+    expect(File.read(stale_path)).to eq(key_material)
+    expect(File.stat(stale_path).mode & 0o777).to eq(0o600)
+  end
+end


### PR DESCRIPTION
## Why

The nightly off-site backup (PR #515, PER-527) has never run: its four secrets were never provisioned, and `PostgresBackupJob` needs the SSH key as a *file* (`Net::SFTP keys:`) while Kamal can only inject env vars — whose transport can't carry multiline values.

The Storage Box now exists and all four secrets are in 1Password + `.kamal/secrets` (key travels as `op read ... | base64`).

## What

- `Services::BackupKeyMaterializer` — at boot, decodes `STORAGE_BOX_SSH_KEY_CONTENT` (base64) to `tmp/storage_box_ed25519` with 0600 perms and sets `STORAGE_BOX_SSH_KEY` to that path. Never raises: malformed input logs and defers to the job's own descriptive `BackupError`. No-ops in dev/test/CI.
- `config/initializers/backup_ssh_key.rb` — wires it `after_initialize`.
- `config/deploy.yml` — re-enables the four backup secrets (as `STORAGE_BOX_SSH_KEY_CONTENT`); `SENTRY_DSN` stays commented (still unprovisioned).

## Tests

6 new specs: happy path + perms, whitespace-tolerant base64, respects pre-set path, no-op without env, invalid base64 logs without raising, stale-file overwrite re-enforces 0600. RuboCop clean.

## Post-merge

Deploy, then force-run `PostgresBackupJob.perform_now` and verify an encrypted dump lands on the box.