### PR TITLE
fix(ops): install pg_dump 17 and gpg in production image for PostgresBackupJob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,17 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 # Rails app lives here
 WORKDIR /rails
 
-# Install base packages
+# Install base packages.
+# postgresql-client-17 comes from the PGDG repo: PostgresBackupJob (PER-527)
+# shells out to pg_dump, which must be >= the PG 17 production server, while
+# bookworm's stock client is 15. gnupg provides gpg for the backup's AES256
+# encryption step (and dearmors the PGDG signing key below).
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 && \
+    apt-get install --no-install-recommends -y curl gnupg libjemalloc2 libvips sqlite3 && \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y postgresql-client-17 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
## Why

Forced a test run of `PostgresBackupJob` in prod after provisioning its secrets (#540) and it failed immediately: **neither `pg_dump` nor `gpg` exists in the production image**. The backup feature (PR #515) shells out to both — it could never have run in the container it shipped to.

Additionally, bookworm's stock `postgresql-client` is v15, and `pg_dump` refuses servers newer than itself — prod runs PostgreSQL 17.9 — so the client must come from the PGDG repo.

## What

Base image stage now installs `gnupg` and `postgresql-client-17` (via the PGDG apt repo, key dearmored to `/usr/share/keyrings`). Single RUN layer, apt lists cleaned.

## Verification

Built the `base` stage locally: `pg_dump (PostgreSQL) 17.10 (Debian 17.10-1.pgdg12+1)` and `gpg (GnuPG) 2.2.40` both present. Post-merge: deploy and force-run `PostgresBackupJob.perform_now`, then confirm the encrypted dump lists on the Storage Box.