### PR TITLE
fix(budgets): make category scopes M2M-aware, dedup overall health spend, fix update redirect

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -209,7 +209,10 @@ class BudgetsController < ApplicationController
     return { status: :no_budgets, message: "Sin presupuestos activos" } if active_budgets.empty?
 
     total_budget = active_budgets.sum(:amount)
-    total_spend = active_budgets.sum(:current_spend)
+    # Dedup shared logic with Services::Budgets::BucketSummary: summing each
+    # budget's cached current_spend double-counts expenses claimed by more
+    # than one overlapping active budget.
+    total_spend = Services::Budgets::DedupSpend.call(active_budgets)
 
     usage_percentage = total_budget.zero? ? 0 : ((total_spend / total_budget) * 100).round(1)
 

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -205,7 +205,10 @@ class BudgetsController < ApplicationController
   end
 
   def calculate_overall_budget_health
-    active_budgets = Budget.for_user(scoping_user).active.current
+    # includes(:email_account) — DedupSpend walks budget.email_account per
+    # budget; without preloading that's one query per budget outside the
+    # request-level query cache (background jobs, multi-account users).
+    active_budgets = Budget.for_user(scoping_user).active.current.includes(:email_account)
     return { status: :no_budgets, message: "Sin presupuestos activos" } if active_budgets.empty?
 
     total_budget = active_budgets.sum(:amount)

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -90,7 +90,7 @@ class BudgetsController < ApplicationController
       # Recalculate spend after update
       @budget.calculate_current_spend!
 
-      redirect_to dashboard_expenses_path,
+      redirect_to budgets_path,
         notice: "Presupuesto actualizado exitosamente."
     else
       @categories = Category.all.order(:name)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -52,6 +52,10 @@ class Budget < ApplicationRecord
   # or through the M2M budget_categories join. During the multi-category
   # rollout, the controller writes ONLY the M2M side, so keying on the
   # legacy column alone misses budgets mapped through the UI.
+  # WARNING: do not chain aggregates (.sum/.count) onto this scope — the
+  # DISTINCT emitted for the join fan-out becomes SUM(DISTINCT amount),
+  # silently collapsing different budgets that share the same amount.
+  # Load records first (or use a where(id: ...) subquery) before aggregating.
   scope :for_category, ->(category_id) {
     left_joins(:budget_categories)
       .where("budgets.category_id = :category_id OR budget_categories.category_id = :category_id", category_id: category_id)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -48,15 +48,27 @@ class Budget < ApplicationRecord
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
   scope :current, -> { active.where("start_date <= ? AND (end_date IS NULL OR end_date >= ?)", Date.current, Date.current) }
-  scope :for_category, ->(category_id) { where(category_id: category_id) }
-  scope :general, -> { where(category_id: nil) }
+  # Matches a budget claiming category_id either through the legacy column
+  # or through the M2M budget_categories join. During the multi-category
+  # rollout, the controller writes ONLY the M2M side, so keying on the
+  # legacy column alone misses budgets mapped through the UI.
+  scope :for_category, ->(category_id) {
+    left_joins(:budget_categories)
+      .where("budgets.category_id = :category_id OR budget_categories.category_id = :category_id", category_id: category_id)
+      .distinct
+  }
+  # A budget is "general" only when it claims no category at all — neither
+  # via the legacy column nor via the M2M join. Mirrors #unmapped?.
+  scope :general, -> { where(category_id: nil).where.missing(:budget_categories) }
   # Optimized scopes that use precomputed values instead of divisions in WHERE clause
   scope :exceeded, -> { where("current_spend > amount") }
   scope :warning, -> { where("current_spend >= (amount * warning_threshold / 100.0)") }
   scope :critical, -> { where("current_spend >= (amount * critical_threshold / 100.0)") }
   scope :external, -> { where.not(external_source: nil) }
   scope :native, -> { where(external_source: nil) }
-  scope :synced_unmapped, -> { external.where(category_id: nil) }
+  # External budgets with no claimed category — neither legacy nor M2M.
+  # Mirrors #unmapped?; see TODO there about dropping the legacy leg.
+  scope :synced_unmapped, -> { external.general }
 
   # Callbacks
   before_validation :set_defaults, on: :create

--- a/app/services/budgets/bucket_summary.rb
+++ b/app/services/budgets/bucket_summary.rb
@@ -43,36 +43,10 @@ module Services::Budgets
     end
 
     # Per-budget accurate routing, then union expense ids, then sum once.
+    # Delegates to the shared Services::Budgets::DedupSpend so the same
+    # dedup logic is used here and in BudgetsController#calculate_overall_budget_health.
     def dedup_spend(budgets)
-      expense_ids = budgets.flat_map do |b|
-        range = b.current_period_range
-        currency_enum = currency_to_expense_currency(b.currency)
-        base = @email_account.expenses
-          .where(transaction_date: range)
-          .where(currency: currency_enum)
-
-        conditions = [ "expenses.budget_id = :bid" ]
-        bindings = { bid: b.id }
-
-        if b.category_ids.any?
-          conditions << "(expenses.budget_id IS NULL AND expenses.category_id IN (:cats))"
-          bindings[:cats] = b.category_ids
-        end
-
-        base.where(conditions.join(" OR "), bindings).pluck(:id)
-      end.uniq
-
-      return 0.0 if expense_ids.empty?
-      @email_account.expenses.where(id: expense_ids).sum(:amount).to_f
-    end
-
-    def currency_to_expense_currency(code)
-      case code
-      when "CRC" then Expense.currencies[:crc]
-      when "USD" then Expense.currencies[:usd]
-      when "EUR" then Expense.currencies[:eur]
-      else Expense.currencies[:crc]
-      end
+      Services::Budgets::DedupSpend.call(budgets)
     end
   end
 end

--- a/app/services/budgets/dedup_spend.rb
+++ b/app/services/budgets/dedup_spend.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Computes total spend across a collection of budgets without double-counting
+# an expense claimed by more than one budget (e.g., two active budgets that
+# both claim the same category).
+#
+# For each budget, collect the ids of matching expenses:
+#   1. expenses.budget_id = budget.id always counts (override).
+#   2. expenses.budget_id IS NULL AND category IN budget's claimed categories
+#      counts (default routing).
+# scoped to that budget's own period range, currency, and email_account.
+# Then union the ids across all budgets and sum each expense exactly once.
+module Services::Budgets
+  class DedupSpend
+    def self.call(budgets)
+      new(budgets).call
+    end
+
+    def initialize(budgets)
+      @budgets = budgets
+    end
+
+    def call
+      budgets = Array(@budgets)
+      return 0.0 if budgets.empty?
+
+      expense_ids = budgets.flat_map { |budget| matching_expense_ids(budget) }.uniq
+      return 0.0 if expense_ids.empty?
+
+      Expense.where(id: expense_ids).sum(:amount).to_f
+    end
+
+    private
+
+    def matching_expense_ids(budget)
+      range = budget.current_period_range
+      currency_enum = currency_to_expense_currency(budget.currency)
+
+      base = budget.email_account.expenses
+        .where(transaction_date: range)
+        .where(currency: currency_enum)
+
+      conditions = [ "expenses.budget_id = :bid" ]
+      bindings = { bid: budget.id }
+
+      claimed = claimed_category_ids_by_budget[budget.id] || []
+      if claimed.any?
+        conditions << "(expenses.budget_id IS NULL AND expenses.category_id IN (:cats))"
+        bindings[:cats] = claimed
+      end
+
+      base.where(conditions.join(" OR "), bindings).pluck(:id)
+    end
+
+    # Batch-load claimed category ids for all budgets in a single query
+    # instead of calling budget.category_ids per budget (avoids an N+1
+    # against the budget_categories/categories tables).
+    def claimed_category_ids_by_budget
+      @claimed_category_ids_by_budget ||= BudgetCategory
+        .where(budget_id: Array(@budgets).map(&:id))
+        .pluck(:budget_id, :category_id)
+        .each_with_object(Hash.new { |h, k| h[k] = [] }) { |(bid, cid), acc| acc[bid] << cid }
+    end
+
+    def currency_to_expense_currency(code)
+      case code
+      when "CRC" then Expense.currencies[:crc]
+      when "USD" then Expense.currencies[:usd]
+      when "EUR" then Expense.currencies[:eur]
+      else Expense.currencies[:crc]
+      end
+    end
+  end
+end

--- a/spec/controllers/budgets_controller_unit_spec.rb
+++ b/spec/controllers/budgets_controller_unit_spec.rb
@@ -279,10 +279,10 @@ RSpec.describe BudgetsController, type: :controller, unit: true do
         patch :update, params: { id: budget.id, budget: budget_params }
       end
 
-      it "redirects to dashboard with success message" do
+      it "redirects to budgets list with success message" do
         patch :update, params: { id: budget.id, budget: budget_params }
 
-        expect(response).to redirect_to(dashboard_expenses_path)
+        expect(response).to redirect_to(budgets_path)
         expect(flash[:notice]).to eq("Presupuesto actualizado exitosamente.")
       end
     end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -103,12 +103,37 @@ RSpec.describe Budget, type: :model, integration: true do
         expect(Budget.for_category(category.id)).to include(category_budget)
         expect(Budget.for_category(category.id)).not_to include(general_budget)
       end
+
+      it 'also matches budgets that claim the category only via the M2M join (legacy category_id nil)' do
+        m2m_budget = create(:budget, email_account: email_account, category: nil, period: 'weekly', active: true)
+        m2m_budget.categories << category
+
+        results = Budget.for_category(category.id)
+        expect(results).to include(category_budget, m2m_budget)
+        expect(results).not_to include(general_budget)
+      end
+
+      it 'does not return duplicate rows when a budget matches via both legacy and M2M columns' do
+        category_budget.categories << category
+
+        results = Budget.for_category(category.id)
+        expect(results.to_a.count { |b| b.id == category_budget.id }).to eq(1)
+      end
     end
 
     describe '.general', integration: true do
       it 'returns budgets without category' do
         expect(Budget.general).to include(general_budget)
         expect(Budget.general).not_to include(category_budget)
+      end
+
+      it 'excludes a budget with no legacy category_id but a category claimed via the M2M join' do
+        m2m_budget = create(:budget, email_account: email_account, category: nil, period: 'weekly', active: true)
+        m2m_budget.categories << category
+
+        results = Budget.general
+        expect(results).to include(general_budget)
+        expect(results).not_to include(m2m_budget)
       end
     end
   end
@@ -386,6 +411,18 @@ RSpec.describe Budget, type: :model, integration: true do
       results = described_class.synced_unmapped
       expect(results).to include(external_unmapped)
       expect(results).not_to include(native, external_mapped)
+    end
+
+    it 'excludes an external budget mapped through the M2M join even though legacy category_id is nil' do
+      external_mapped_via_m2m = create(:budget, email_account: email_account, category: nil, period: 'daily',
+                                                  external_source: 'salary_calculator', external_id: 105)
+      external_mapped_via_m2m.categories << category
+      external_unmapped = create(:budget, email_account: email_account, category: nil, period: 'yearly',
+                                          external_source: 'salary_calculator', external_id: 106)
+
+      results = described_class.synced_unmapped
+      expect(results).to include(external_unmapped)
+      expect(results).not_to include(external_mapped_via_m2m)
     end
   end
 

--- a/spec/models/budget_unit_spec.rb
+++ b/spec/models/budget_unit_spec.rb
@@ -159,9 +159,15 @@ RSpec.describe Budget, type: :model, unit: true do
     end
 
     context "category-based scopes" do
-      it "filters by category relationship" do
-        expect(described_class.for_category(5).to_sql).to include('"budgets"."category_id" = 5')
+      it "filters by category relationship, matching legacy category_id OR the M2M join" do
+        sql = described_class.for_category(5).to_sql
+        expect(sql).to include("LEFT OUTER JOIN \"budget_categories\"")
+        expect(sql).to include("budgets.category_id = 5 OR budget_categories.category_id = 5")
+      end
+
+      it "excludes budgets claimed via either the legacy column or the M2M join" do
         expect(described_class.general.to_sql).to include('"budgets"."category_id" IS NULL')
+        expect(described_class.general.to_sql).to include('"budget_categories"."id" IS NULL')
       end
     end
 

--- a/spec/requests/budgets_spec.rb
+++ b/spec/requests/budgets_spec.rb
@@ -234,4 +234,26 @@ RSpec.describe "Budgets", type: :request, integration: true do
       expect(Budget.last.categories).not_to include(stranger_category)
     end
   end
+
+  describe "GET /budgets overall health", integration: true do
+    let(:food) { create(:category, name: "Food Overall") }
+
+    it "does not double count an expense claimed by two overlapping active budgets" do
+      budget_a = create(:budget, email_account: email_account, amount: 100_000, active: true)
+      budget_b = create(:budget, email_account: email_account, amount: 100_000, active: true)
+      budget_a.categories << food
+      budget_b.categories << food
+
+      create(:expense, email_account: email_account, category: food, amount: 15_000,
+                        currency: :crc, status: :processed,
+                        transaction_date: Date.current.beginning_of_month + 3.days)
+
+      budget_a.calculate_current_spend!
+      budget_b.calculate_current_spend!
+
+      get budgets_path
+
+      expect(assigns(:overall_health)[:total_spend]).to eq(15_000.0)
+    end
+  end
 end

--- a/spec/requests/budgets_spec.rb
+++ b/spec/requests/budgets_spec.rb
@@ -106,9 +106,9 @@ RSpec.describe "Budgets", type: :request, integration: true do
         expect(budget.current_spend_updated_at).not_to eq(original_updated_at)
       end
 
-      it "redirects to the dashboard" do
+      it "redirects to the budgets list" do
         patch budget_path(budget), params: new_attributes
-        expect(response).to redirect_to(dashboard_expenses_path)
+        expect(response).to redirect_to(budgets_path)
         expect(flash[:notice]).to eq('Presupuesto actualizado exitosamente.')
       end
     end

--- a/spec/services/budgets/dedup_spend_spec.rb
+++ b/spec/services/budgets/dedup_spend_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Budgets::DedupSpend, type: :service, unit: true do
+  let(:email_account) { create(:email_account) }
+  let(:food)          { create(:category, name: "Food") }
+  let(:rent)          { create(:category, name: "Rent") }
+
+  def in_period(extra = {})
+    {
+      email_account: email_account,
+      transaction_date: Date.current.beginning_of_month + 3.days,
+      currency: :crc,
+      amount: 10_000,
+      status: :processed
+    }.merge(extra)
+  end
+
+  it "returns 0.0 when given no budgets" do
+    expect(described_class.call([])).to eq(0.0)
+  end
+
+  it "sums spend for a single budget's claimed category" do
+    budget = create(:budget, email_account: email_account, amount: 100_000)
+    budget.categories << food
+    create(:expense, in_period(category: food, amount: 20_000))
+
+    expect(described_class.call([ budget ])).to eq(20_000.0)
+  end
+
+  it "counts an override expense (expenses.budget_id set) even outside claimed categories" do
+    budget = create(:budget, email_account: email_account, amount: 100_000)
+    other_category = create(:category, name: "Other")
+    create(:expense, in_period(category: other_category, amount: 12_000, budget: budget))
+
+    expect(described_class.call([ budget ])).to eq(12_000.0)
+  end
+
+  it "does not double count an expense claimed by two overlapping budgets" do
+    a = create(:budget, email_account: email_account, name: "A", amount: 100_000)
+    b = create(:budget, email_account: email_account, name: "B", amount: 100_000)
+    a.categories << food
+    b.categories << food
+    create(:expense, in_period(category: food, amount: 15_000))
+
+    expect(described_class.call([ a, b ])).to eq(15_000.0)
+  end
+
+  it "sums distinct claimed-category expenses across non-overlapping budgets" do
+    fixed_b = create(:budget, email_account: email_account, amount: 300_000)
+    fixed_b.categories << rent
+    gf_b = create(:budget, email_account: email_account, amount: 80_000)
+    gf_b.categories << food
+
+    create(:expense, in_period(category: rent, amount: 250_000))
+    create(:expense, in_period(category: food, amount: 40_000))
+
+    expect(described_class.call([ fixed_b, gf_b ])).to eq(290_000.0)
+  end
+
+  it "excludes expenses outside a budget's period range" do
+    budget = create(:budget, email_account: email_account, amount: 100_000, period: "monthly")
+    budget.categories << food
+    create(:expense, in_period(category: food, amount: 20_000, transaction_date: 2.months.ago))
+
+    expect(described_class.call([ budget ])).to eq(0.0)
+  end
+
+  it "excludes expenses in a different currency than the budget" do
+    budget = create(:budget, email_account: email_account, amount: 100_000, currency: "CRC")
+    budget.categories << food
+    create(:expense, in_period(category: food, amount: 20_000, currency: :usd))
+
+    expect(described_class.call([ budget ])).to eq(0.0)
+  end
+
+  it "unions spend across budgets belonging to different email_accounts" do
+    other_account = create(:email_account)
+    budget_a = create(:budget, email_account: email_account, amount: 100_000)
+    budget_a.categories << food
+    budget_b = create(:budget, email_account: other_account, amount: 100_000)
+    budget_b.categories << food
+
+    create(:expense, in_period(category: food, amount: 20_000))
+    create(:expense, email_account: other_account, transaction_date: Date.current.beginning_of_month + 3.days,
+                      currency: :crc, amount: 30_000, status: :processed, category: food)
+
+    expect(described_class.call([ budget_a, budget_b ])).to eq(50_000.0)
+  end
+end


### PR DESCRIPTION
## Why

Three correctness bugs in budget↔category matching, found during the budget-matching audit:

1. **Scopes ignored M2M mappings.** `synced_unmapped`, `general`, and `for_category` keyed only on the legacy `budgets.category_id` column — but the controller writes mappings exclusively to the `budget_categories` join (legacy column stays NULL), so a budget mapped through the UI still counted as unmapped/general.
2. **Overall budget health double-counted.** `calculate_overall_budget_health` summed each budget's cached `current_spend`; overlapping budgets counted the same expense twice, inflating the headline usage %. `BucketSummary` already dedups via expense-id union — that logic is now extracted to `Services::Budgets::DedupSpend` and used by both.
3. **Mapping a category ejected the user.** `update` redirected to the expenses dashboard; now returns to `/budgets` (the inline card mapping flow depends on it).

## Notes

- Consumer audit for the scope changes: only production call-site is `metrics_calculator.rb:489` (`.general.first`) — behavior strictly improves. `for_category`/`synced_unmapped` have zero production callers today.
- `DedupSpend` batch-loads `budget_id → category_ids` (caught & fixed an N+1 the request-spec query guard flagged).
- `for_category` carries a WARNING comment about the `SUM(DISTINCT)` aggregate trap (architect finding, verified live).
- Known same-pattern issue deliberately out of scope: `metrics_calculator.rb` `category_budgets` also keys on the legacy column — follow-up candidate.
- Pre-existing mixed-currency summation in health totals unchanged (separate ticket).

## Tests

- New: 8 `DedupSpend` examples (override, overlap dedup, cross-account, period/currency filters), M2M scope edge cases, overlap regression asserting deduped health totals.
- Full unit suite: 9117 examples, 0 failures. BucketSummary specs unchanged and green (behavior bit-identical, architect-verified). RuboCop clean.