### PR TITLE
feat(budgets): tiered budget→category mapping suggester (cache → exact → fuzzy → LLM)

### DIFF
--- a/app/jobs/budgets/suggest_mappings_job.rb
+++ b/app/jobs/budgets/suggest_mappings_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Budgets
+  # Runs the tiered MappingSuggester over an account's synced-but-unmapped
+  # budgets. Enqueued after every successful external budget sync; safe to
+  # re-run (cache hits and already-mapped budgets no-op). PER spec
+  # 2026-07-05-budget-mapping-suggester-design.md.
+  class SuggestMappingsJob < ApplicationJob
+    queue_as :low
+
+    def perform(email_account_id)
+      email_account = EmailAccount.find_by(id: email_account_id)
+      return if email_account.nil?
+
+      budgets = Budget.synced_unmapped.where(email_account: email_account).includes(:user, :categories)
+      return if budgets.empty?
+
+      result = Services::Budgets::MappingSuggester.call(budgets)
+      Rails.logger.info(
+        "[SuggestMappingsJob] account=#{email_account_id} applied=#{result[:applied]} " \
+        "suggested=#{result[:suggested]} unresolved=#{result[:unresolved].size}"
+      )
+    end
+  end
+end

--- a/app/jobs/budgets/suggest_mappings_job.rb
+++ b/app/jobs/budgets/suggest_mappings_job.rb
@@ -8,6 +8,14 @@ module Budgets
   class SuggestMappingsJob < ApplicationJob
     queue_as :low
 
+    # Serialize per USER (not per account): two accounts of one user syncing
+    # concurrently would otherwise race MappingSuggester's cache upserts on
+    # the shared (user_id, normalized_name) unique index. Solid Queue native
+    # concurrency control instead of a hand-rolled lock.
+    limits_concurrency to: 1, key: ->(email_account_id) {
+      EmailAccount.find_by(id: email_account_id)&.user_id || email_account_id
+    }
+
     def perform(email_account_id)
       email_account = EmailAccount.find_by(id: email_account_id)
       return if email_account.nil?

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -72,7 +72,9 @@ class Budget < ApplicationRecord
   scope :native, -> { where(external_source: nil) }
   # External budgets with no claimed category — neither legacy nor M2M.
   # Mirrors #unmapped?; see TODO there about dropping the legacy leg.
-  scope :synced_unmapped, -> { external.general }
+  # Excludes spend_tracking: false rows — those are allocations, intentionally
+  # not matched to a category (see BudgetNameMapping / MappingSuggester).
+  scope :synced_unmapped, -> { external.general.where(spend_tracking: true) }
 
   # Callbacks
   before_validation :set_defaults, on: :create
@@ -155,7 +157,7 @@ class Budget < ApplicationRecord
   # TODO(multi-category-rollout): drop the legacy category_id leg once
   # budgets.category_id column is removed in the follow-up migration.
   def unmapped?
-    external? && category_id.nil? && budget_categories.empty?
+    spend_tracking? && external? && category_id.nil? && budget_categories.empty?
   end
 
   # Calculate actual spending for the current period.

--- a/app/models/budget_name_mapping.rb
+++ b/app/models/budget_name_mapping.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Name-keyed cache of budget-name → category mappings, and the memory of
+# user confirmations. One row per (user, normalized budget name). The
+# suggester (Services::Budgets::MappingSuggester) writes exact/fuzzy/llm
+# rows; the future review UI upgrades rows to source: :user.
+class BudgetNameMapping < ApplicationRecord
+  belongs_to :user
+  belongs_to :category, optional: true
+
+  enum :kind, { category: 0, allocation: 1 }, prefix: :kind
+  enum :source, { exact: 0, fuzzy: 1, llm: 2, user: 3 }, prefix: :source
+
+  validates :normalized_name, presence: true, uniqueness: { scope: :user_id }
+  validates :category, presence: true, if: :kind_category?
+
+  scope :for_lookup, ->(user, normalized) { where(user: user, normalized_name: normalized) }
+
+  # Single normalization entry point — every reader/writer of
+  # normalized_name MUST go through this or cache lookups silently miss.
+  def self.normalize(text)
+    text.to_s.unicode_normalize(:nfkd).gsub(/\p{Mn}/, "").downcase.squish
+  end
+
+  # Only exact matches and user confirmations may be applied without review.
+  def auto_applicable?
+    source_user? || source_exact?
+  end
+end

--- a/app/services/budgets/mapping_llm_resolver.rb
+++ b/app/services/budgets/mapping_llm_resolver.rb
@@ -66,7 +66,7 @@ module Services::Budgets
 
       by_name = categories.index_by { |c| c.name }
       JSON.parse(json).each_with_object({}) do |row, acc|
-        name = row["name"].to_s
+        name = BudgetNameMapping.normalize(row["name"])
         answer = row["answer"].to_s
         next if answer == UNKNOWN || name.blank?
 

--- a/app/services/budgets/mapping_llm_resolver.rb
+++ b/app/services/budgets/mapping_llm_resolver.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "anthropic"
+
+module Services::Budgets
+  # One batched Anthropic call resolving budget names that exact/fuzzy
+  # tiers could not. Never raises to callers: any API or parse failure
+  # returns {} (MappingSuggester treats missing keys as unresolved and the
+  # next sync retries). LLM verdicts are suggestion-grade only — the
+  # suggester stores them with confidence 0.75 and never auto-applies.
+  class MappingLlmResolver
+    MODEL = "claude-haiku-4-5-20251001"
+    MAX_TOKENS = 2000
+    ALLOCATION = "ALLOCATION"
+    UNKNOWN = "UNKNOWN"
+
+    def initialize(client: nil)
+      @client = client
+    end
+
+    def resolve(names:, categories:, user:)
+      return {} if names.empty?
+
+      text = request_text(names, categories)
+      parse(text, categories)
+    rescue StandardError => e
+      Rails.logger.error("[MappingLlmResolver] LLM call failed: #{e.class} #{e.message}")
+      {}
+    end
+
+    private
+
+    def request_text(names, categories)
+      response = client.messages.create(
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        temperature: 0.0,
+        messages: [ { role: :user, content: prompt(names, categories) } ]
+      )
+      response.content.find { |block| block.type == "text" }&.text.to_s
+    end
+
+    def prompt(names, categories)
+      <<~PROMPT
+        You map personal budget line names (Spanish/English mix, Costa Rica) to expense categories.
+
+        Budget names:
+        #{names.map { |n| "- #{n}" }.join("\n")}
+
+        Allowed categories (answer with the EXACT name):
+        #{categories.map(&:name).join(", ")}
+
+        For each budget name answer with exactly one of:
+        - an EXACT category name from the list above,
+        - "#{ALLOCATION}" if the name is a person, family transfer, savings/investment allocation, or insurance — money set aside, not a spendable expense category,
+        - "#{UNKNOWN}" if genuinely unsure.
+
+        Respond with ONLY a JSON array, no prose:
+        [{"name":"<budget name>","answer":"<category name|#{ALLOCATION}|#{UNKNOWN}>"}]
+      PROMPT
+    end
+
+    def parse(text, categories)
+      json = text[/\[.*\]/m]
+      raise ArgumentError, "no JSON array in response" if json.nil?
+
+      by_name = categories.index_by { |c| c.name }
+      JSON.parse(json).each_with_object({}) do |row, acc|
+        name = row["name"].to_s
+        answer = row["answer"].to_s
+        next if answer == UNKNOWN || name.blank?
+
+        if answer == ALLOCATION
+          acc[name] = { category: nil, kind: :allocation }
+        elsif (category = by_name[answer])
+          acc[name] = { category: category, kind: :category }
+        end
+      end
+    rescue JSON::ParserError, ArgumentError => e
+      Rails.logger.error("[MappingLlmResolver] malformed LLM response: #{e.message}")
+      {}
+    end
+
+    def client
+      @client ||= Anthropic::Client.new(
+        api_key: Rails.application.credentials.dig(:anthropic, :api_key).presence ||
+                 ENV["ANTHROPIC_API_KEY"],
+        timeout: 30
+      )
+    end
+  end
+end

--- a/app/services/budgets/mapping_suggester.rb
+++ b/app/services/budgets/mapping_suggester.rb
@@ -36,7 +36,7 @@ module Services::Budgets
       pending = {}
 
       user_budgets.each do |budget|
-        next if budget.categories.exists? || !budget.spend_tracking?
+        next if budget.categories.any? || !budget.spend_tracking?
 
         normalized = BudgetNameMapping.normalize(budget.name)
         next if try_cache(user, budget, normalized)
@@ -49,6 +49,12 @@ module Services::Budgets
       resolve_with_llm(user, pending, categories) if pending.any?
     end
 
+    # Any existing row short-circuits the pipeline — this is what bounds LLM
+    # cost to once per name, and guarantees a user-confirmed row can never be
+    # overwritten by a lower tier. Deliberate tradeoff: a name cached as a
+    # fuzzy/llm suggestion will NOT auto-upgrade if a new exactly-matching
+    # category appears later; the review UI (or deleting the mapping row)
+    # resolves it.
     def try_cache(user, budget, normalized)
       mapping = BudgetNameMapping.for_lookup(user, normalized).first
       return false unless mapping

--- a/app/services/budgets/mapping_suggester.rb
+++ b/app/services/budgets/mapping_suggester.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Services::Budgets
+  # Tiered budget-name → category suggester (spec:
+  # 2026-07-05-budget-mapping-suggester-design.md). Tier 0 applies cached
+  # exact/user mappings; tier 1 auto-applies exact normalized name matches;
+  # tier 2 stores FuzzyMatcher suggestions; tier 3 batches every remaining
+  # name into one LLM call. Only exact/user tiers ever mutate budgets.
+  class MappingSuggester
+    FUZZY_MIN_CONFIDENCE = 0.6
+    LLM_CONFIDENCE = 0.75
+
+    def self.call(budgets, llm_resolver: nil)
+      new(budgets, llm_resolver: llm_resolver).call
+    end
+
+    def initialize(budgets, llm_resolver: nil)
+      @budgets = Array(budgets)
+      @llm_resolver = llm_resolver || MappingLlmResolver.new
+      @applied = 0
+      @suggested = 0
+      @unresolved = []
+    end
+
+    def call
+      @budgets.group_by(&:user).each do |user, user_budgets|
+        process_user(user, user_budgets)
+      end
+      { applied: @applied, suggested: @suggested, unresolved: @unresolved }
+    end
+
+    private
+
+    def process_user(user, user_budgets)
+      categories = Category.visible_to(user).to_a
+      pending = {}
+
+      user_budgets.each do |budget|
+        next if budget.categories.exists? || !budget.spend_tracking?
+
+        normalized = BudgetNameMapping.normalize(budget.name)
+        next if try_cache(user, budget, normalized)
+        next if try_exact(user, budget, normalized, categories)
+        next if try_fuzzy(user, normalized, categories)
+
+        (pending[normalized] ||= []) << budget
+      end
+
+      resolve_with_llm(user, pending, categories) if pending.any?
+    end
+
+    def try_cache(user, budget, normalized)
+      mapping = BudgetNameMapping.for_lookup(user, normalized).first
+      return false unless mapping
+
+      apply!(budget, mapping) if mapping.auto_applicable?
+      true
+    end
+
+    def try_exact(user, budget, normalized, categories)
+      category = categories.find { |c| BudgetNameMapping.normalize(c.display_name) == normalized ||
+                                       BudgetNameMapping.normalize(c.name) == normalized }
+      return false unless category
+
+      mapping = upsert_mapping(user, normalized, category: category, kind: :category,
+                               source: :exact, confidence: 1.0)
+      apply!(budget, mapping)
+      true
+    end
+
+    def try_fuzzy(user, normalized, categories)
+      candidates = categories.map { |c| { id: c.id, text: c.display_name, object: c } }
+      result = fuzzy_matcher.match(normalized, candidates)
+      best = result.respond_to?(:matches) ? result.matches.first : nil
+      return false unless best && best[:score].to_f >= FUZZY_MIN_CONFIDENCE
+
+      upsert_mapping(user, normalized, category: best[:object], kind: :category,
+                     source: :fuzzy, confidence: best[:score].to_f.round(3))
+      @suggested += 1
+      true
+    end
+
+    def resolve_with_llm(user, pending, categories)
+      verdicts = @llm_resolver.resolve(names: pending.keys, categories: categories, user: user)
+      pending.each do |normalized, _budgets|
+        verdict = verdicts[normalized]
+        if verdict.nil?
+          @unresolved << normalized
+          next
+        end
+        upsert_mapping(user, normalized, category: verdict[:category], kind: verdict[:kind],
+                       source: :llm, confidence: LLM_CONFIDENCE)
+        @suggested += 1
+      end
+    rescue StandardError => e
+      Rails.logger.error("[MappingSuggester] LLM tier failed, leaving #{pending.size} names unresolved: #{e.message}")
+      @unresolved.concat(pending.keys)
+    end
+
+    def apply!(budget, mapping)
+      if mapping.kind_allocation?
+        budget.update!(spend_tracking: false)
+      else
+        BudgetCategory.find_or_create_by!(budget: budget, category: mapping.category)
+      end
+      @applied += 1
+    end
+
+    def upsert_mapping(user, normalized, attrs)
+      mapping = BudgetNameMapping.for_lookup(user, normalized).first_or_initialize
+      mapping.update!(attrs)
+      mapping
+    end
+
+    def fuzzy_matcher
+      @fuzzy_matcher ||= Services::Categorization::Matchers::FuzzyMatcher.new(
+        algorithms: [ :jaro_winkler, :trigram ], min_confidence: FUZZY_MIN_CONFIDENCE, max_results: 1
+      )
+    end
+  end
+end

--- a/app/services/budgets/mapping_suggester.rb
+++ b/app/services/budgets/mapping_suggester.rb
@@ -116,6 +116,11 @@ module Services::Budgets
       mapping = BudgetNameMapping.for_lookup(user, normalized).first_or_initialize
       mapping.update!(attrs)
       mapping
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      # Concurrent suggester runs for the same user (one job per email
+      # account) can race on the unique (user_id, normalized_name) index.
+      # The winner's row stands — same never-raise posture as the LLM tier.
+      BudgetNameMapping.for_lookup(user, normalized).first!
     end
 
     def fuzzy_matcher

--- a/app/services/external_budgets/sync_service.rb
+++ b/app/services/external_budgets/sync_service.rb
@@ -44,6 +44,7 @@ module Services
         )
         apply_payload(result.body) if result.ok?
         @source.mark_succeeded!
+        ::Budgets::SuggestMappingsJob.perform_later(@source.email_account_id)
         true
       rescue ApiClient::NotFoundError
         @source.mark_succeeded!

--- a/db/migrate/20260706052107_create_budget_name_mappings.rb
+++ b/db/migrate/20260706052107_create_budget_name_mappings.rb
@@ -5,7 +5,10 @@ class CreateBudgetNameMappings < ActiveRecord::Migration[8.1]
     create_table :budget_name_mappings do |t|
       t.references :user, null: false, foreign_key: true
       t.string :normalized_name, null: false
-      t.references :category, null: true, foreign_key: true
+      # Cascade: a mapping is meaningless once its category is deleted, and a
+      # plain FK would make Category#destroy raise for user-deletable
+      # personal categories. The suggester re-resolves the name on next sync.
+      t.references :category, null: true, foreign_key: { on_delete: :cascade }
       t.integer :kind, null: false, default: 0
       t.integer :source, null: false
       t.decimal :confidence, precision: 4, scale: 3

--- a/db/migrate/20260706052107_create_budget_name_mappings.rb
+++ b/db/migrate/20260706052107_create_budget_name_mappings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateBudgetNameMappings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :budget_name_mappings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :normalized_name, null: false
+      t.references :category, null: true, foreign_key: true
+      t.integer :kind, null: false, default: 0
+      t.integer :source, null: false
+      t.decimal :confidence, precision: 4, scale: 3
+      t.datetime :confirmed_at
+      t.timestamps
+    end
+    add_index :budget_name_mappings, [ :user_id, :normalized_name ], unique: true
+  end
+end

--- a/db/migrate/20260706052320_add_spend_tracking_to_budgets.rb
+++ b/db/migrate/20260706052320_add_spend_tracking_to_budgets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSpendTrackingToBudgets < ActiveRecord::Migration[8.1]
+  def change
+    add_column :budgets, :spend_tracking, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_052107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -42,6 +42,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_120000) do
     t.index ["budget_id", "category_id"], name: "index_budget_categories_on_budget_and_category", unique: true
     t.index ["budget_id"], name: "index_budget_categories_on_budget_id"
     t.index ["category_id"], name: "index_budget_categories_on_category_id"
+  end
+
+  create_table "budget_name_mappings", force: :cascade do |t|
+    t.bigint "category_id"
+    t.decimal "confidence", precision: 4, scale: 3
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.integer "kind", default: 0, null: false
+    t.string "normalized_name", null: false
+    t.integer "source", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["category_id"], name: "index_budget_name_mappings_on_category_id"
+    t.index ["user_id", "normalized_name"], name: "index_budget_name_mappings_on_user_id_and_normalized_name", unique: true
+    t.index ["user_id"], name: "index_budget_name_mappings_on_user_id"
   end
 
   create_table "budgets", force: :cascade do |t|
@@ -818,6 +833,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_120000) do
   add_foreign_key "api_tokens", "users"
   add_foreign_key "budget_categories", "budgets"
   add_foreign_key "budget_categories", "categories"
+  add_foreign_key "budget_name_mappings", "categories"
+  add_foreign_key "budget_name_mappings", "users"
   add_foreign_key "budgets", "categories"
   add_foreign_key "budgets", "email_accounts"
   add_foreign_key "budgets", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_052107) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_052320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -84,6 +84,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_052107) do
     t.decimal "rollover_amount", precision: 12, scale: 2, default: "0.0"
     t.boolean "rollover_enabled", default: false
     t.integer "salary_bucket"
+    t.boolean "spend_tracking", default: true, null: false
     t.date "start_date", null: false
     t.integer "times_exceeded", default: 0
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -834,7 +834,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_052320) do
   add_foreign_key "api_tokens", "users"
   add_foreign_key "budget_categories", "budgets"
   add_foreign_key "budget_categories", "categories"
-  add_foreign_key "budget_name_mappings", "categories"
+  add_foreign_key "budget_name_mappings", "categories", on_delete: :cascade
   add_foreign_key "budget_name_mappings", "users"
   add_foreign_key "budgets", "categories"
   add_foreign_key "budgets", "email_accounts"

--- a/spec/factories/budget_name_mappings.rb
+++ b/spec/factories/budget_name_mappings.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :budget_name_mapping do
+    user
+    category
+    kind { :category }
+    source { :fuzzy }
+    confidence { 0.7 }
+    sequence(:normalized_name) { |n| "budget name #{n}" }
+
+    trait :allocation do
+      kind { :allocation }
+      category { nil }
+      source { :llm }
+    end
+
+    trait :confirmed do
+      source { :user }
+      confidence { 1.0 }
+      confirmed_at { Time.current }
+    end
+  end
+end

--- a/spec/jobs/budgets/suggest_mappings_job_spec.rb
+++ b/spec/jobs/budgets/suggest_mappings_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Budgets::SuggestMappingsJob, :unit do
+  let(:email_account) { create(:email_account) }
+
+  it "runs the suggester over the account's synced unmapped budgets" do
+    budget = create(:budget, email_account: email_account, user: email_account.user,
+                    external_source: "salary_calculator", external_id: 1, category: nil)
+    create(:budget, email_account: email_account, user: email_account.user, name: "native one")
+
+    expect(Services::Budgets::MappingSuggester).to receive(:call) do |budgets|
+      expect(budgets).to contain_exactly(budget)
+      { applied: 0, suggested: 0, unresolved: [] }
+    end
+
+    described_class.perform_now(email_account.id)
+  end
+
+  it "no-ops for a missing email account" do
+    expect(Services::Budgets::MappingSuggester).not_to receive(:call)
+    expect { described_class.perform_now(-1) }.not_to raise_error
+  end
+end

--- a/spec/models/budget_name_mapping_spec.rb
+++ b/spec/models/budget_name_mapping_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BudgetNameMapping, :unit do
+  describe ".normalize" do
+    it "downcases, strips accents, and squishes whitespace" do
+      expect(described_class.normalize("  Alimentación  Extra ")).to eq("alimentacion extra")
+      expect(described_class.normalize("Condominio")).to eq("condominio")
+      expect(described_class.normalize(nil)).to eq("")
+    end
+  end
+
+  describe "validations" do
+    it "enforces uniqueness of normalized_name per user" do
+      existing = create(:budget_name_mapping)
+      dup = build(:budget_name_mapping, user: existing.user, normalized_name: existing.normalized_name)
+      expect(dup).not_to be_valid
+    end
+
+    it "requires a category when kind is category" do
+      mapping = build(:budget_name_mapping, kind: :category, category: nil)
+      expect(mapping).not_to be_valid
+    end
+
+    it "allows a nil category when kind is allocation" do
+      mapping = build(:budget_name_mapping, kind: :allocation, category: nil, source: :llm)
+      expect(mapping).to be_valid
+    end
+  end
+
+  describe "#auto_applicable?" do
+    it "is true for source user and source exact" do
+      expect(build(:budget_name_mapping, source: :user).auto_applicable?).to be(true)
+      expect(build(:budget_name_mapping, source: :exact).auto_applicable?).to be(true)
+    end
+
+    it "is false for fuzzy and llm suggestions" do
+      expect(build(:budget_name_mapping, source: :fuzzy).auto_applicable?).to be(false)
+      expect(build(:budget_name_mapping, source: :llm).auto_applicable?).to be(false)
+    end
+  end
+end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -424,6 +424,13 @@ RSpec.describe Budget, type: :model, integration: true do
       expect(results).to include(external_unmapped)
       expect(results).not_to include(external_mapped_via_m2m)
     end
+
+    it "excludes budgets with spend_tracking disabled" do
+      budget = create(:budget, email_account: email_account, category: nil, period: 'monthly',
+                               external_source: 'salary_calculator', external_id: 107)
+      budget.update!(spend_tracking: false)
+      expect(described_class.synced_unmapped).not_to include(budget)
+    end
   end
 
   describe 'external-source dedup (DB-level)', integration: true do
@@ -496,6 +503,12 @@ RSpec.describe Budget, type: :model, integration: true do
 
     it 'is false when native (no external_source) even without a category' do
       budget = build(:budget, external_source: nil, category: nil)
+      expect(budget.unmapped?).to be(false)
+    end
+
+    it 'is not unmapped when spend_tracking is disabled' do
+      budget = create(:budget, external_source: 'salary_calculator', category: nil, external_id: 108)
+      budget.update!(spend_tracking: false)
       expect(budget.unmapped?).to be(false)
     end
   end

--- a/spec/services/budgets/mapping_llm_resolver_spec.rb
+++ b/spec/services/budgets/mapping_llm_resolver_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Services::Budgets::MappingLlmResolver, :unit do
     expect(result["luz"]).to eq(category: electricidad, kind: :category)
   end
 
+  it "re-normalizes echoed names so a non-verbatim echo still resolves" do
+    stub_llm_text('[{"name":"LUZ ","answer":"Electricidad"}]')
+
+    result = resolver.resolve(names: [ "luz" ], categories: categories, user: user)
+
+    expect(result["luz"]).to eq(category: electricidad, kind: :category)
+  end
+
   it "returns {} and logs on malformed JSON" do
     stub_llm_text("I think Luz is electricity related")
     allow(Rails.logger).to receive(:error)

--- a/spec/services/budgets/mapping_llm_resolver_spec.rb
+++ b/spec/services/budgets/mapping_llm_resolver_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Budgets::MappingLlmResolver, :unit do
+  let(:user) { create(:user) }
+  let!(:electricidad) { create(:category, name: "Electricidad", user: nil) }
+  let!(:mascotas) { create(:category, name: "Mascotas", user: nil) }
+  let(:categories) { [ electricidad, mascotas ] }
+  let(:messages_api) { double("messages") }
+  let(:client) { instance_double(Anthropic::Client, messages: messages_api) }
+  subject(:resolver) { described_class.new(client: client) }
+
+  def stub_llm_text(text)
+    content_block = double("content", type: "text", text: text)
+    response = double("response", content: [ content_block ], stop_reason: "end_turn")
+    allow(messages_api).to receive(:create).and_return(response)
+  end
+
+  it "maps names to categories and allocations from a JSON response" do
+    stub_llm_text('[{"name":"luz","answer":"Electricidad"},{"name":"familia mariana","answer":"ALLOCATION"}]')
+
+    result = resolver.resolve(names: [ "luz", "familia mariana" ], categories: categories, user: user)
+
+    expect(result["luz"]).to eq(category: electricidad, kind: :category)
+    expect(result["familia mariana"]).to eq(category: nil, kind: :allocation)
+  end
+
+  it "omits UNKNOWN answers and answers naming nonexistent categories" do
+    stub_llm_text('[{"name":"punta leona","answer":"UNKNOWN"},{"name":"x","answer":"Invented Category"}]')
+
+    result = resolver.resolve(names: [ "punta leona", "x" ], categories: categories, user: user)
+
+    expect(result).to eq({})
+  end
+
+  it "tolerates a fenced JSON response" do
+    stub_llm_text("```json\n[{\"name\":\"luz\",\"answer\":\"Electricidad\"}]\n```")
+
+    result = resolver.resolve(names: [ "luz" ], categories: categories, user: user)
+
+    expect(result["luz"]).to eq(category: electricidad, kind: :category)
+  end
+
+  it "returns {} and logs on malformed JSON" do
+    stub_llm_text("I think Luz is electricity related")
+    allow(Rails.logger).to receive(:error)
+
+    expect(resolver.resolve(names: [ "luz" ], categories: categories, user: user)).to eq({})
+    expect(Rails.logger).to have_received(:error).with(/malformed/i)
+  end
+
+  it "returns {} for empty names without calling the API" do
+    expect(messages_api).not_to receive(:create)
+    expect(resolver.resolve(names: [], categories: categories, user: user)).to eq({})
+  end
+end

--- a/spec/services/budgets/mapping_suggester_spec.rb
+++ b/spec/services/budgets/mapping_suggester_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Services::Budgets::MappingSuggester, :unit do
   let(:user) { create(:user) }
   let(:email_account) { create(:email_account, user: user) }
-  let(:null_llm) { instance_double("LlmResolver", resolve: {}) }
+  let(:null_llm) { instance_double(Services::Budgets::MappingLlmResolver, resolve: {}) }
 
   def external_budget(name)
     create(:budget, email_account: email_account, user: user, name: name,
@@ -94,7 +94,7 @@ RSpec.describe Services::Budgets::MappingSuggester, :unit do
     it "passes only unresolved names, with the user's visible categories" do
       create(:category, name: "Mascotas", user: nil)
       budget = external_budget("Pets")
-      resolver = instance_double("LlmResolver")
+      resolver = instance_double(Services::Budgets::MappingLlmResolver)
       expect(resolver).to receive(:resolve) do |names:, categories:, user: u|
         expect(names).to eq([ "pets" ])
         expect(categories.map(&:name)).to include("Mascotas")
@@ -112,7 +112,7 @@ RSpec.describe Services::Budgets::MappingSuggester, :unit do
 
     it "records llm allocation verdicts as suggestions (spend_tracking untouched)" do
       budget = external_budget("Familia Mariana")
-      resolver = instance_double("LlmResolver",
+      resolver = instance_double(Services::Budgets::MappingLlmResolver,
         resolve: { "familia mariana" => { category: nil, kind: :allocation } })
 
       described_class.call([ budget ], llm_resolver: resolver)
@@ -124,12 +124,34 @@ RSpec.describe Services::Budgets::MappingSuggester, :unit do
 
     it "leaves names unresolved when the resolver returns nil for them" do
       budget = external_budget("Punta Leona")
-      resolver = instance_double("LlmResolver", resolve: {})
+      resolver = instance_double(Services::Budgets::MappingLlmResolver, resolve: {})
 
       result = described_class.call([ budget ], llm_resolver: resolver)
 
       expect(BudgetNameMapping.where(user: user).count).to eq(0)
       expect(result[:unresolved]).to eq([ "punta leona" ])
+    end
+  end
+
+  describe "concurrent upsert race" do
+    it "falls back to the winner's row instead of raising" do
+      cat = create(:category, name: "Agua", user: nil)
+      existing = create(:budget_name_mapping, user: user, normalized_name: "agua",
+                        category: cat, source: :exact, confidence: 1.0)
+      suggester = described_class.new([], llm_resolver: null_llm)
+      # Simulate the race: first_or_initialize returns an unsaved duplicate
+      # (as if the row did not exist yet), whose save trips the uniqueness
+      # validation because `existing` was committed by a concurrent run.
+      losing_duplicate = BudgetNameMapping.new(user: user, normalized_name: "agua")
+      relation = instance_double(ActiveRecord::Relation)
+      allow(BudgetNameMapping).to receive(:for_lookup).with(user, "agua").and_return(relation)
+      allow(relation).to receive(:first_or_initialize).and_return(losing_duplicate)
+      allow(relation).to receive(:first!).and_return(existing)
+
+      result = suggester.send(:upsert_mapping, user, "agua",
+                              category: cat, kind: :category, source: :exact, confidence: 1.0)
+
+      expect(result).to eq(existing)
     end
   end
 

--- a/spec/services/budgets/mapping_suggester_spec.rb
+++ b/spec/services/budgets/mapping_suggester_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Budgets::MappingSuggester, :unit do
+  let(:user) { create(:user) }
+  let(:email_account) { create(:email_account, user: user) }
+  let(:null_llm) { instance_double("LlmResolver", resolve: {}) }
+
+  def external_budget(name)
+    create(:budget, email_account: email_account, user: user, name: name,
+           external_source: "salary_calculator", external_id: rand(10_000), category: nil)
+  end
+
+  def call(budgets)
+    described_class.call(budgets, llm_resolver: null_llm)
+  end
+
+  describe "tier 0 — cache" do
+    it "auto-applies a user-confirmed mapping" do
+      cat = create(:category, name: "Servicios", user: nil)
+      create(:budget_name_mapping, :confirmed, user: user, normalized_name: "condominio", category: cat)
+      budget = external_budget("Condominio")
+
+      result = call([ budget ])
+
+      expect(budget.reload.categories).to contain_exactly(cat)
+      expect(result[:applied]).to eq(1)
+    end
+
+    it "auto-applies a confirmed allocation by disabling spend_tracking" do
+      create(:budget_name_mapping, :allocation, :confirmed, user: user, normalized_name: "retirement")
+      budget = external_budget("Retirement")
+
+      call([ budget ])
+
+      expect(budget.reload.spend_tracking).to be(false)
+      expect(budget.reload.categories).to be_empty
+    end
+
+    it "does nothing for a cached fuzzy suggestion (already suggested)" do
+      cat = create(:category, name: "Electricidad", user: nil)
+      create(:budget_name_mapping, user: user, normalized_name: "luz", category: cat, source: :fuzzy)
+      budget = external_budget("Luz")
+
+      result = call([ budget ])
+
+      expect(budget.reload.categories).to be_empty
+      expect(result[:applied]).to eq(0)
+      expect(result[:suggested]).to eq(0) # no new row written
+    end
+  end
+
+  describe "tier 1 — exact match" do
+    it "auto-applies and records an exact normalized name match" do
+      cat = create(:category, name: "Agua", user: nil)
+      budget = external_budget("Agua")
+
+      result = call([ budget ])
+
+      expect(budget.reload.categories).to contain_exactly(cat)
+      mapping = BudgetNameMapping.find_by!(user: user, normalized_name: "agua")
+      expect(mapping).to have_attributes(source: "exact", confidence: 1.0, category: cat)
+      expect(result[:applied]).to eq(1)
+    end
+
+    it "matches accent-insensitively" do
+      cat = create(:category, name: "Alimentación", user: nil)
+      budget = external_budget("alimentacion")
+
+      call([ budget ])
+
+      expect(budget.reload.categories).to contain_exactly(cat)
+    end
+  end
+
+  describe "tier 2 — fuzzy suggestion" do
+    it "records a suggestion without applying for a close-but-inexact name" do
+      cat = create(:category, name: "Impuestos", user: nil)
+      budget = external_budget("Impuestos de la casa")
+
+      result = call([ budget ])
+
+      expect(budget.reload.categories).to be_empty
+      mapping = BudgetNameMapping.find_by!(user: user, normalized_name: "impuestos de la casa")
+      expect(mapping.source_fuzzy?).to be(true)
+      expect(mapping.category).to eq(cat)
+      expect(mapping.confidence).to be > 0.6
+      expect(result[:suggested]).to eq(1)
+    end
+  end
+
+  describe "tier 3 — delegation to llm resolver" do
+    it "passes only unresolved names, with the user's visible categories" do
+      create(:category, name: "Mascotas", user: nil)
+      budget = external_budget("Pets")
+      resolver = instance_double("LlmResolver")
+      expect(resolver).to receive(:resolve) do |names:, categories:, user: u|
+        expect(names).to eq([ "pets" ])
+        expect(categories.map(&:name)).to include("Mascotas")
+        { "pets" => { category: Category.find_by!(name: "Mascotas"), kind: :category } }
+      end
+
+      result = described_class.call([ budget ], llm_resolver: resolver)
+
+      mapping = BudgetNameMapping.find_by!(user: user, normalized_name: "pets")
+      expect(mapping.source_llm?).to be(true)
+      expect(mapping.confidence).to eq(0.75)
+      expect(budget.reload.categories).to be_empty # llm results are suggestions only
+      expect(result[:suggested]).to eq(1)
+    end
+
+    it "records llm allocation verdicts as suggestions (spend_tracking untouched)" do
+      budget = external_budget("Familia Mariana")
+      resolver = instance_double("LlmResolver",
+        resolve: { "familia mariana" => { category: nil, kind: :allocation } })
+
+      described_class.call([ budget ], llm_resolver: resolver)
+
+      mapping = BudgetNameMapping.find_by!(user: user, normalized_name: "familia mariana")
+      expect(mapping.kind_allocation?).to be(true)
+      expect(budget.reload.spend_tracking).to be(true) # not auto-applied
+    end
+
+    it "leaves names unresolved when the resolver returns nil for them" do
+      budget = external_budget("Punta Leona")
+      resolver = instance_double("LlmResolver", resolve: {})
+
+      result = described_class.call([ budget ], llm_resolver: resolver)
+
+      expect(BudgetNameMapping.where(user: user).count).to eq(0)
+      expect(result[:unresolved]).to eq([ "punta leona" ])
+    end
+  end
+
+  it "skips budgets that already have categories and groups by user" do
+    cat = create(:category, name: "Agua", user: nil)
+    mapped = external_budget("Agua")
+    BudgetCategory.create!(budget: mapped, category: cat)
+
+    result = call([ mapped ])
+
+    expect(result).to eq(applied: 0, suggested: 0, unresolved: [])
+  end
+end

--- a/spec/services/external_budgets/sync_service_spec.rb
+++ b/spec/services/external_budgets/sync_service_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Services::ExternalBudgets::SyncService, :unit do
         expect(source.last_sync_status).to eq("ok")
         expect(source.last_synced_at).to be_within(5.seconds).of(Time.current)
       end
+
+      it "enqueues a mapping suggestion job after a successful sync" do
+        expect { service.call }.to have_enqueued_job(Budgets::SuggestMappingsJob)
+          .with(source.email_account_id)
+      end
     end
 
     context "when an existing synced budget is updated" do
@@ -181,6 +186,10 @@ RSpec.describe Services::ExternalBudgets::SyncService, :unit do
         expect(source.active).to be false
         expect(source.last_sync_status).to eq("failed")
         expect(source.last_sync_error).to include("unauthorized")
+      end
+
+      it "does not enqueue the suggestion job when the sync fails" do
+        expect { service.call }.not_to have_enqueued_job(Budgets::SuggestMappingsJob)
       end
     end
 


### PR DESCRIPTION
## Why

Budgets synced from the salary calculator arrive bucketed (#536) but category-less, so budget-vs-actual shows zero spend until each is mapped by hand (~100 clicks for a month of budgets, and ~10 of 26 names are allocations that can never map). Spec: approved 2026-07-05 (tiered suggester design).

## What

- **`BudgetNameMapping`** — name-keyed cache + confirmation memory: unique per (user, normalized name); kind `category`/`allocation`; source `exact`/`fuzzy`/`llm`/`user`; the future review UI upgrades rows to `user`.
- **`budgets.spend_tracking`** flag — allocations (Familia Mariana, Retirement…) opt out of mapping; `synced_unmapped`/`#unmapped?` treat them as resolved; bucket budgeted totals unchanged.
- **`Services::Budgets::MappingSuggester`** — tier 0 cache (auto-applies only `user`/`exact` rows), tier 1 exact normalized match (auto-applies via `budget_categories` M2M + records mapping), tier 2 FuzzyMatcher ≥0.6 (suggestion only), tier 3 **one** batched Anthropic call per user (`MappingLlmResolver`, Haiku, temperature 0; "ALLOCATION"/"UNKNOWN" allowed; never raises — failures leave names unresolved for next sync). LLM cost bounded to once per distinct name, ever.
- **`::Budgets::SuggestMappingsJob`** (low queue) enqueued from `ExternalBudgets::SyncService` success path (post-transaction), idempotent.

## Review trail

Backend-architect: ship-able; both MEDIUMs addressed in `e8f97c5` (category FK now `on_delete: :cascade`; cache short-circuit tradeoff documented in-code) plus the `.any?` preload fix. Accepted as follow-ups (all LOW): job-level uniqueness lock, routing the resolver through the shared LLM client/circuit breaker, sending `display_name` to the model, allocation-implies-nil-category validation.

## Verified correct by review

Normalization single entry point everywhere; user-confirmed rows unoverwritable; auto-apply idempotent; prompt-injection blast radius nil (answers constrained to the user's own category list, suggestion-grade only); enqueue after COMMIT; no conflict with #542's M2M scopes or DedupSpend.

## Tests

Full unit suite 9144 examples, 0 failures. New: model (6), suggester tiers 0–3 (10), LLM resolver incl. fenced/malformed/UNKNOWN/invented-category (5), job + sync enqueue (4). RuboCop + Brakeman clean.

## Post-merge

Deploy, then backfill: `Budgets::SuggestMappingsJob.perform_now(1)` and verify mappings + auto-applied exacts in prod.