### PR TITLE
fix(budgets): unbreak LLM mapping tier and gate fuzzy suggestions on word containment

### DIFF
--- a/app/services/budgets/mapping_llm_resolver.rb
+++ b/app/services/budgets/mapping_llm_resolver.rb
@@ -37,7 +37,9 @@ module Services::Budgets
         temperature: 0.0,
         messages: [ { role: :user, content: prompt(names, categories) } ]
       )
-      response.content.find { |block| block.type == "text" }&.text.to_s
+      # block.type is a Symbol (:text) in the anthropic gem — compare
+      # loosely or the text block is silently never found (prod 2026-07-06).
+      response.content.find { |block| block.type.to_s == "text" }&.text.to_s
     end
 
     def prompt(names, categories)

--- a/app/services/budgets/mapping_suggester.rb
+++ b/app/services/budgets/mapping_suggester.rb
@@ -79,11 +79,22 @@ module Services::Budgets
       result = fuzzy_matcher.match(normalized, candidates)
       best = result.respond_to?(:matches) ? result.matches.first : nil
       return false unless best && best[:score].to_f >= FUZZY_MIN_CONFIDENCE
+      return false unless word_containment?(normalized, BudgetNameMapping.normalize(best[:object].display_name))
 
       upsert_mapping(user, normalized, category: best[:object], kind: :category,
                      source: :fuzzy, confidence: best[:score].to_f.round(3))
       @suggested += 1
       true
+    end
+
+    # Similarity scores alone cannot separate real matches from lookalike
+    # Spanish words at these lengths — prod run 2026-07-06 scored
+    # "comida"→"Compras" at 0.82 (garbage) while the correct
+    # "impuestos de la casa"→"Impuestos" scored 0.69. A fuzzy hit is only
+    # trusted when the two names share a whole word (≥4 chars); everything
+    # else falls through to the LLM tier, which handles semantics.
+    def word_containment?(a, b)
+      (a.split & b.split).any? { |w| w.length >= 4 }
     end
 
     def resolve_with_llm(user, pending, categories)

--- a/spec/services/budgets/mapping_llm_resolver_spec.rb
+++ b/spec/services/budgets/mapping_llm_resolver_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Services::Budgets::MappingLlmResolver, :unit do
   subject(:resolver) { described_class.new(client: client) }
 
   def stub_llm_text(text)
-    content_block = double("content", type: "text", text: text)
+    # The anthropic gem returns block type as a Symbol — stub it faithfully
+    # (a string stub masked a prod bug where the text block was never found).
+    content_block = double("content", type: :text, text: text)
     response = double("response", content: [ content_block ], stop_reason: "end_turn")
     allow(messages_api).to receive(:create).and_return(response)
   end

--- a/spec/services/budgets/mapping_suggester_spec.rb
+++ b/spec/services/budgets/mapping_suggester_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe Services::Budgets::MappingSuggester, :unit do
       expect(mapping.confidence).to be > 0.6
       expect(result[:suggested]).to eq(1)
     end
+
+    it "rejects high-scoring lookalikes with no shared word and defers to the llm tier" do
+      create(:category, name: "Compras", user: nil)
+      budget = external_budget("Comida")
+      resolver = instance_double(Services::Budgets::MappingLlmResolver)
+      expect(resolver).to receive(:resolve) do |names:, categories:, user: nil|
+        expect(names).to eq([ "comida" ])
+        {}
+      end
+
+      result = described_class.call([ budget ], llm_resolver: resolver)
+
+      expect(BudgetNameMapping.where(user: user).count).to eq(0)
+      expect(result[:unresolved]).to eq([ "comida" ])
+    end
   end
 
   describe "tier 3 — delegation to llm resolver" do


### PR DESCRIPTION
## Why — prod backfill findings (2026-07-06)

First real run of #543's suggester exposed two quality bugs:

1. **The LLM tier silently never ran.** The anthropic gem returns content-block `type` as a Symbol (`:text`); the resolver compared against the string `"text"`, extracted an empty string, and every batch degraded to 'malformed response → {}'. The spec's double stubbed a string type, faithfully hiding the bug. Verified live in prod.
2. **Fuzzy tier at ≥0.6 produced garbage on short Spanish names** — prod suggested `comida→Compras` (0.82), `casa→Mascotas` (0.75), `gastos mariana→Gasolina` (0.80), `retirement→Restaurantes`, `spotify→Mascotas`… while the only genuinely correct fuzzy hit (`impuestos de la casa→Impuestos`) scored lower (0.69). Score thresholds cannot separate these.

## What

- `MappingLlmResolver#request_text`: compare `block.type.to_s == "text"`; spec doubles now stub the Symbol so this can't regress.
- `MappingSuggester#try_fuzzy`: fuzzy hits are only trusted when the budget name and category name **share a whole word (≥4 chars)** — keeps `impuestos de la casa→Impuestos`, rejects all six observed garbage pairs, and routes semantic cases (luz, pets, netflix) to the now-working LLM tier where they belong.
- New spec: high-scoring lookalike (`Comida` vs `Compras`) is rejected by fuzzy and deferred to the LLM tier.

## Post-merge

Deploy, delete the 17 garbage `source: fuzzy` rows in prod, rerun the backfill — semantic names then resolve via LLM (incl. ALLOCATION verdicts for Familia Mariana/Nico/Retirement).

## Tests

18 examples across both spec files, 0 failures. RuboCop clean.