### PR TITLE
fix(ops): repair PEM line structure when 1Password flattens the backup SSH key

### DIFF
--- a/app/services/backup_key_materializer.rb
+++ b/app/services/backup_key_materializer.rb
@@ -48,7 +48,10 @@ module Services
     # line breaks can be rebuilt deterministically. Keys that already contain
     # newlines pass through untouched.
     def self.repair_pem_lines(key)
-      return key if key.include?("\n")
+      # net-ssh requires the header be immediately followed by a newline —
+      # "contains a newline somewhere" is not enough (a flattened key often
+      # keeps its final trailing newline).
+      return key if key.match?(/\A-----BEGIN [A-Z0-9 ]+-----\r?\n/)
 
       match = key.match(/\A(-----BEGIN [A-Z0-9 ]+-----)(.*?)(-----END [A-Z0-9 ]+-----)\s*\z/m)
       return key unless match

--- a/app/services/backup_key_materializer.rb
+++ b/app/services/backup_key_materializer.rb
@@ -30,6 +30,7 @@ module Services
         return nil
       end
 
+      key = repair_pem_lines(key)
       path = root.join(DEFAULT_KEY_PATH).to_s
 
       File.write(path, key, perm: 0o600)
@@ -40,5 +41,21 @@ module Services
       Rails.logger.error("[BackupKeyMaterializer] STORAGE_BOX_SSH_KEY_CONTENT is not valid base64: #{e.message}")
       nil
     end
+
+    # 1Password single-line text fields flatten a pasted key's newlines into
+    # spaces, producing a one-line PEM net-ssh cannot parse (prod 2026-07-06).
+    # PEM structure is rigid — BEGIN header, base64 body, END footer — so the
+    # line breaks can be rebuilt deterministically. Keys that already contain
+    # newlines pass through untouched.
+    def self.repair_pem_lines(key)
+      return key if key.include?("\n")
+
+      match = key.match(/\A(-----BEGIN [A-Z0-9 ]+-----)(.*?)(-----END [A-Z0-9 ]+-----)\s*\z/m)
+      return key unless match
+
+      body = match[2].gsub(/\s+/, "")
+      "#{match[1]}\n#{body.scan(/.{1,70}/).join("\n")}\n#{match[3]}\n"
+    end
+    private_class_method :repair_pem_lines
   end
 end

--- a/spec/services/backup_key_materializer_spec.rb
+++ b/spec/services/backup_key_materializer_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe Services::BackupKeyMaterializer, :unit do
       )
     end
 
+    it "repairs a flattened key that kept only its trailing newline" do
+      flattened = "-----BEGIN OPENSSH PRIVATE KEY----- abc123 -----END OPENSSH PRIVATE KEY-----\n"
+      env = { "STORAGE_BOX_SSH_KEY_CONTENT" => Base64.strict_encode64(flattened) }
+
+      path = call(env)
+
+      expect(File.read(path)).to eq(key_material)
+    end
+
     it "leaves a properly multiline key byte-identical" do
       env = { "STORAGE_BOX_SSH_KEY_CONTENT" => encoded }
 

--- a/spec/services/backup_key_materializer_spec.rb
+++ b/spec/services/backup_key_materializer_spec.rb
@@ -25,6 +25,37 @@ RSpec.describe Services::BackupKeyMaterializer, :unit do
     expect(env["STORAGE_BOX_SSH_KEY"]).to eq(path)
   end
 
+  describe "PEM line repair (1Password single-line fields flatten newlines to spaces)" do
+    it "rebuilds a flattened one-line key into valid PEM structure" do
+      flattened = "-----BEGIN OPENSSH PRIVATE KEY----- abc123 -----END OPENSSH PRIVATE KEY-----"
+      env = { "STORAGE_BOX_SSH_KEY_CONTENT" => Base64.strict_encode64(flattened) }
+
+      path = call(env)
+
+      expect(File.read(path)).to eq(key_material)
+    end
+
+    it "re-wraps a long flattened body at 70 columns" do
+      body = "A" * 140
+      flattened = "-----BEGIN OPENSSH PRIVATE KEY----- #{body[0, 70]} #{body[70, 70]} -----END OPENSSH PRIVATE KEY-----"
+      env = { "STORAGE_BOX_SSH_KEY_CONTENT" => Base64.strict_encode64(flattened) }
+
+      path = call(env)
+
+      expect(File.read(path)).to eq(
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n#{body[0, 70]}\n#{body[70, 70]}\n-----END OPENSSH PRIVATE KEY-----\n"
+      )
+    end
+
+    it "leaves a properly multiline key byte-identical" do
+      env = { "STORAGE_BOX_SSH_KEY_CONTENT" => encoded }
+
+      path = call(env)
+
+      expect(File.read(path)).to eq(key_material)
+    end
+  end
+
   it "tolerates whitespace and newlines inside the base64 payload" do
     wrapped = encoded.scan(/.{1,40}/).join("\n")
     env = { "STORAGE_BOX_SSH_KEY_CONTENT" => wrapped }


### PR DESCRIPTION
## Why

First live `PostgresBackupJob` run: pg_dump + gpg succeeded, but SFTP key auth failed and fell back to a password prompt (`Inappropriate ioctl for device`). Root cause: the private key was pasted into a **single-line** 1Password field, which converts newlines to spaces — the materializer faithfully wrote a one-line PEM that `Net::SSH::KeyFactory` rejects (`Expected -----BEGIN OPENSSH PRIVATE KEY-----`). Verified in prod.

## What

`BackupKeyMaterializer.repair_pem_lines`: when the decoded key contains no newlines, rebuild the rigid PEM structure (BEGIN header / base64 body re-wrapped at 70 cols / END footer). Multiline keys pass through byte-identical. Never raises; non-PEM shapes fall through to the existing guards.

## Tests

3 new examples (flattened rebuild, 70-col re-wrap, multiline passthrough); 10 total in the file, 0 failures. RuboCop clean.

## Post-merge

Deploy, rerun `PostgresBackupJob.perform_now`, verify the encrypted dump lists on the Storage Box.