### PR TITLE
fix(deploy): demote SENTRY_DSN to warn-only in pre-deploy-check gate 4

### DIFF
--- a/bin/pre-deploy-check
+++ b/bin/pre-deploy-check
@@ -174,9 +174,12 @@ if DEPLOY_YML.file?
   # Missing it makes the strategy 401 on every call and silently degrade to
   # pattern-only categorization (PER-548). Treated as a deploy gate so the
   # next contributor can't ship a deploy.yml that drops it.
-  # SENTRY_DSN: required for Sentry APM/error-tracking (PER-526). Without it
-  # the gem stays inert and no error events are sent to Sentry.
-  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false, "ANTHROPIC_API_KEY" => false, "SENTRY_DSN" => false }
+  # SENTRY_DSN: warn-only. Sentry (PER-526) is not provisioned — the entry is
+  # deliberately commented out of deploy.yml (PR #539) because Kamal
+  # hard-fails the whole deploy on any listed-but-missing secret. Promote to
+  # `seen` once the DSN exists in 1Password AND .kamal/secrets AND deploy.yml.
+  seen = { "ADMIN_EMAIL" => false, "ADMIN_PASSWORD" => false, "ANTHROPIC_API_KEY" => false }
+  recommended_seen = { "SENTRY_DSN" => false }
   yml.each_line do |line|
     stripped = line.strip
     if stripped.start_with?("secret:")
@@ -190,10 +193,14 @@ if DEPLOY_YML.file?
     if in_env_secret && stripped.start_with?("-")
       key = stripped.sub(/\A-\s*/, "").strip
       seen[key] = true if seen.key?(key)
+      recommended_seen[key] = true if recommended_seen.key?(key)
     end
   end
   seen.each do |key, found|
     failures << "config/deploy.yml env.secret is missing `#{key}` — the container will start without it" unless found
+  end
+  recommended_seen.each do |key, found|
+    info << "config/deploy.yml env.secret does not declare `#{key}` — its feature stays inert until provisioned (warn-only)" unless found
   end
 else
   failures << "config/deploy.yml not found at #{DEPLOY_YML.relative_path_from(ROOT)}"


### PR DESCRIPTION
## Why

Gate 4 hard-failed every `bin/pre-deploy-check` run since PR #539 deliberately commented `SENTRY_DSN` out of `deploy.yml` (Kamal hard-fails deploys on listed-but-missing secrets, and Sentry was never provisioned). Per the deploy-secrets norm: unprovisioned secrets are warn-only until the underlying service exists — Gate 2 already treats SENTRY_DSN that way; Gate 4 now matches.

## What

Gate 4 splits into required (`ADMIN_EMAIL`/`ADMIN_PASSWORD`/`ANTHROPIC_API_KEY` — unchanged, still hard-fail) and recommended (`SENTRY_DSN` — INFO line). Comment documents the promote-once-provisioned path.

## Verification

Ran `bin/pre-deploy-check` against current main state: **All gates passed**, SENTRY_DSN reported as two INFO lines (Gate 2 + Gate 4). No spec suite covers this ops script; the live run is the verification.