### PR TITLE
fix(sync_conflicts): make the conflict-resolution modal actually usable

### DIFF
--- a/app/controllers/sync_conflicts_controller.rb
+++ b/app/controllers/sync_conflicts_controller.rb
@@ -135,7 +135,7 @@ class SyncConflictsController < ApplicationController
               message: "Error: #{service.errors.join(', ')}",
               type: "error"
             }
-          )
+          ), status: :unprocessable_content
         }
       end
     end

--- a/app/javascript/controllers/conflict_modal_controller.js
+++ b/app/javascript/controllers/conflict_modal_controller.js
@@ -3,11 +3,24 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     console.log("Conflict modal controller connected")
+
+    // Bind once so add/removeEventListener reference the same function.
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.handleSubmitEnd = this.handleSubmitEnd.bind(this)
+
+    // Scoped to this controller's element (the whole conflicts page), so it
+    // only ever needs to be registered/torn down once — not per open/close.
+    this.element.addEventListener("turbo:submit-end", this.handleSubmitEnd)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("turbo:submit-end", this.handleSubmitEnd)
+    document.removeEventListener("keydown", this.handleKeydown)
   }
 
   open(event) {
     const conflictId = event.currentTarget.dataset.conflictId
-    
+
     // Fetch conflict details and show modal
     fetch(`/sync_conflicts/${conflictId}`, {
       headers: {
@@ -25,15 +38,47 @@ export default class extends Controller {
         modal.dataset.controller = 'conflict-modal'
         document.body.appendChild(modal)
       }
-      
+
       // Insert content and show
       modal.innerHTML = html
       modal.classList.remove('hidden')
+
+      // Registered on open, removed on close — avoids leaking listeners
+      // across repeated opens (duplicate addEventListener calls with the
+      // same bound function reference are no-ops per the DOM spec).
+      document.addEventListener('keydown', this.handleKeydown)
     })
     .catch(error => {
       console.error('Error loading conflict details:', error)
       this.showError('Error al cargar los detalles del conflicto')
     })
+  }
+
+  // Bound to backdrop clicks. Uses e.target === e.currentTarget (not
+  // stopPropagation on the panel) so a click that bubbles up from inside the
+  // modal panel never closes the modal, while a genuine backdrop click does.
+  closeOnBackdropClick(event) {
+    if (event.target !== event.currentTarget) return
+    this.close()
+  }
+
+  handleKeydown(event) {
+    if (event.key === 'Escape') {
+      this.close()
+    }
+  }
+
+  // Closes the modal once a form submitted from within it (resolve, merge)
+  // completes successfully. Scoped to forms inside #conflict_modal so
+  // unrelated submissions elsewhere on the page (e.g. bulk actions, undo)
+  // never trigger a close.
+  handleSubmitEnd(event) {
+    const modal = document.getElementById('conflict_modal')
+    if (!modal || modal.classList.contains('hidden')) return
+    if (!modal.contains(event.target)) return
+    if (event.detail && event.detail.success) {
+      this.close()
+    }
   }
 
   close() {
@@ -42,6 +87,7 @@ export default class extends Controller {
       modal.classList.add('hidden')
       modal.innerHTML = ''
     }
+    document.removeEventListener('keydown', this.handleKeydown)
   }
 
   showError(message) {
@@ -56,9 +102,9 @@ export default class extends Controller {
         <span class="text-rose-700">${message}</span>
       </div>
     `
-    
+
     document.body.appendChild(notification)
-    
+
     // Remove after 5 seconds
     setTimeout(() => {
       notification.remove()

--- a/app/views/sync_conflicts/_modal.html.erb
+++ b/app/views/sync_conflicts/_modal.html.erb
@@ -1,12 +1,17 @@
 <div class="fixed inset-0 z-50 overflow-y-auto" data-controller="conflict-resolution" id="conflict_modal_content">
   <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
     <!-- Background overlay -->
-    <div class="fixed inset-0 transition-opacity" aria-hidden="true">
-      <div class="absolute inset-0 bg-slate-900 opacity-75"></div>
-    </div>
+    <!-- A single element (not the previous nested fixed+absolute pair) so it
+         paints as one layer behind the panel. It has no explicit z-index, so
+         the panel below must set its own (relative z-10) to stack above it —
+         without that, this positioned overlay paints above static-positioned
+         in-flow content per CSS stacking rules and swallows every click. -->
+    <div class="fixed inset-0 bg-slate-900 opacity-75 transition-opacity"
+         aria-hidden="true"
+         data-action="click->conflict-modal#closeOnBackdropClick"></div>
 
     <!-- Modal panel -->
-    <div class="inline-block align-bottom bg-white rounded-xl text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-6xl sm:w-full">
+    <div class="relative z-10 inline-block align-bottom bg-white rounded-xl text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-6xl sm:w-full">
       <!-- Header -->
       <div class="bg-slate-50 px-6 py-4 border-b border-slate-200">
         <div class="flex items-center justify-between">

--- a/app/views/sync_conflicts/index.html.erb
+++ b/app/views/sync_conflicts/index.html.erb
@@ -122,9 +122,13 @@
 
     </div><!-- end bulk-actions wrapper -->
   </div>
-</div>
 
-<!-- Conflict Resolution Modal -->
-<div id="conflict_modal" class="hidden">
-  <!-- Modal content will be loaded here -->
+  <!-- Conflict Resolution Modal -->
+  <!-- Nested inside the conflict-modal controller scope (not a sibling after it
+       closes) so Stimulus actions on the dynamically-injected modal content
+       (close button, backdrop click, Escape key, turbo:submit-end) resolve to
+       the same controller instance that owns the "Resolver" open buttons. -->
+  <div id="conflict_modal" class="hidden">
+    <!-- Modal content will be loaded here -->
+  </div>
 </div>

--- a/spec/requests/sync_conflicts_resolve_turbo_stream_spec.rb
+++ b/spec/requests/sync_conflicts_resolve_turbo_stream_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for the sync-conflict resolution modal fix (PER conflict
+# modal overlay bug): the modal's Stimulus controller decides whether to close
+# on `turbo:submit-end` by reading `event.detail.success`, which Turbo derives
+# from the response HTTP status. The controller previously rendered the
+# turbo_stream failure branch with an implicit 200 OK, which would have made
+# a failed resolution look like a success to the frontend and close the modal
+# on error. This spec locks in the status codes both branches must return.
+RSpec.describe "SyncConflicts#resolve turbo_stream response", type: :request, unit: true do
+  let(:admin_user) { create(:user, :admin) }
+  let(:sync_session) { create(:sync_session, user: admin_user) }
+  let(:existing_expense) { create(:expense, amount: 100.00, merchant_name: "Original Store") }
+  let(:new_expense) { create(:expense, amount: 150.00, merchant_name: "Updated Store") }
+  let(:sync_conflict) do
+    create(:sync_conflict,
+           sync_session: sync_session,
+           user: admin_user,
+           existing_expense: existing_expense,
+           new_expense: new_expense,
+           status: "pending",
+           conflict_type: "duplicate")
+  end
+
+  before do
+    allow_any_instance_of(SyncConflictsController).to receive(:require_authentication).and_return(true)
+    allow_any_instance_of(SyncConflictsController).to receive(:current_user).and_return(nil)
+    allow_any_instance_of(SyncConflictsController).to receive(:scoping_user).and_return(admin_user)
+  end
+
+  def turbo_stream_headers
+    { "ACCEPT" => "text/vnd.turbo-stream.html" }
+  end
+
+  context "when the resolution succeeds" do
+    it "returns 200 so the frontend can safely close the modal" do
+      post resolve_sync_conflict_path(sync_conflict),
+           params: { action_type: "keep_existing" },
+           headers: turbo_stream_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    end
+
+    it "replaces the conflict row and prepends a success toast" do
+      post resolve_sync_conflict_path(sync_conflict),
+           params: { action_type: "keep_existing" },
+           headers: turbo_stream_headers
+
+      expect(response.body).to include("conflict_#{sync_conflict.id}")
+      expect(response.body).to include("Conflicto resuelto exitosamente")
+    end
+  end
+
+  context "when the resolution fails" do
+    it "returns 422 so the frontend keeps the modal open for the user to see the error" do
+      post resolve_sync_conflict_path(sync_conflict),
+           params: { action_type: "not_a_real_action" },
+           headers: turbo_stream_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "prepends an error toast" do
+      post resolve_sync_conflict_path(sync_conflict),
+           params: { action_type: "not_a_real_action" },
+           headers: turbo_stream_headers
+
+      expect(response.body).to include("bg-rose-50")
+    end
+  end
+
+  # This repo's system specs require a real JS-capable browser (Selenium +
+  # Chrome), which isn't available in this environment (no chromedriver /
+  # Chrome binary, and the shared `sign_in_admin_user` system-spec helper is
+  # currently broken independent of this fix — see limitation note below).
+  # A `spec/system/sync_conflicts_modal_spec.rb` was still added for CI
+  # environments where the browser driver *is* available; here we lock in the
+  # markup contract at the request layer, which is exercisable everywhere.
+  describe "GET show (modal partial markup)" do
+    it "gives the panel a higher stacking layer than the backdrop" do
+      get sync_conflict_path(sync_conflict),
+          headers: { "X-Requested-With" => "XMLHttpRequest", "Accept" => "text/html" }
+
+      expect(response.body).to include('data-action="click->conflict-modal#closeOnBackdropClick"')
+      expect(response.body).to include("relative z-10 inline-block")
+    end
+  end
+end

--- a/spec/system/sync_conflicts_modal_spec.rb
+++ b/spec/system/sync_conflicts_modal_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# Regression coverage for the sync-conflict resolution modal overlay bug:
+# the backdrop (position: fixed, z-index: auto) used to paint ABOVE the
+# static-positioned modal panel per CSS stacking rules, silently swallowing
+# every click on the panel (buttons, close icon, cancel). Verified via
+# Playwright: `document.elementFromPoint` at "Mantener Existente" resolved to
+# the backdrop div, not the button, so clicks there timed out and 0 of 75
+# pending conflicts were ever resolved in production.
+#
+# This spec drives the real browser (Selenium/Chrome headless) so it exercises
+# actual pointer-event hit-testing, which a rack_test / request spec cannot.
+RSpec.describe "Sync conflict resolution modal", type: :system, js: true, tier: :system do
+  let(:admin_user) { create(:user, :admin) }
+  let(:sync_session) { create(:sync_session, user: admin_user) }
+  let(:existing_expense) { create(:expense, amount: 100.00, merchant_name: "Original Store") }
+  let(:new_expense) { create(:expense, amount: 150.00, merchant_name: "Updated Store") }
+
+  let!(:sync_conflict) do
+    create(:sync_conflict,
+           sync_session: sync_session,
+           user: admin_user,
+           existing_expense: existing_expense,
+           new_expense: new_expense,
+           status: "pending",
+           conflict_type: "duplicate")
+  end
+
+  before do
+    sign_in_admin_user(admin_user)
+    visit sync_conflicts_path
+  end
+
+  def open_modal
+    within "#conflict_#{sync_conflict.id}" do
+      click_link_or_button "Resolver"
+    end
+    expect(page).to have_css("#conflict_modal_content", wait: 5)
+  end
+
+  it "clicking the backdrop closes the modal without resolving anything" do
+    open_modal
+
+    # Click near the top-left corner of the full-viewport backdrop, well
+    # outside the centered panel, so we genuinely hit the backdrop element
+    # instead of Selenium clicking through to the panel underneath it.
+    find('[data-action="click->conflict-modal#closeOnBackdropClick"]').click(x: 5, y: 5)
+
+    expect(page).to have_no_css("#conflict_modal_content")
+    expect(sync_conflict.reload.status).to eq("pending")
+  end
+
+  it "clicking a panel button never closes the modal via the backdrop handler" do
+    open_modal
+
+    # A click on real panel content (the header) must not bubble into a
+    # modal close — this is the "e.target === e.currentTarget" contract.
+    find("h3", text: "Resolver Conflicto de Sincronización").click
+
+    expect(page).to have_css("#conflict_modal_content")
+  end
+
+  it "resolving a conflict closes the modal and updates the row" do
+    open_modal
+
+    # This is the exact click that used to time out in production: the
+    # backdrop overlay previously intercepted every pointer event here.
+    click_button "Mantener Existente"
+
+    expect(page).to have_content("Resuelto", wait: 5)
+    expect(page).to have_no_css("#conflict_modal_content")
+    expect(sync_conflict.reload.status).to eq("resolved")
+  end
+
+  it "pressing Escape closes the open modal" do
+    open_modal
+
+    find("body").send_keys(:escape)
+
+    expect(page).to have_no_css("#conflict_modal_content")
+  end
+end


### PR DESCRIPTION
## Why

The conflict modal was fully unusable — the backdrop painted ABOVE the dialog and intercepted every click (verified with Playwright: clicking 'Mantener Existente' times out; `elementFromPoint` at the button returns the backdrop). Prod evidence: **75 conflicts pending, 0 ever resolved** — nobody has ever been able to click a resolution button.

## What (four real bugs)

1. **Stacking**: panel gets `relative z-10`; redundant nested backdrop wrapper merged. Backdrop stays visually behind and full-viewport.
2. **Controller scope**: `#conflict_modal` moved INSIDE the `conflict-modal` Stimulus controller element — it was a sibling, so actions on injected modal content silently never bound.
3. **Close behavior**: backdrop click closes (`e.target === e.currentTarget`, no stopPropagation), Escape closes (listener added on open, removed on close AND disconnect — no leaks across Turbo cache restores), successful resolve closes via `turbo:submit-end` scoped to forms inside the modal.
4. **Failure semantics**: resolve's failure turbo_stream branch now returns 422 (was 200) — otherwise `event.detail.success` would close the modal over the error toast.

## Review trail

Frontend-architect: ship it — stacking verified per CSS2.1 painting order, no Stimulus listener leaks, `event.detail.success === response.ok` confirmed against Turbo 8 source, no broken references to the moved container. Pre-existing follow-ups (not introduced here): dead `createElement` branch in `open()`, orphaned JSON resolve path in conflict_resolution_controller, and the resolved-row 'Ver' link targeting a turbo_frame that was never a frame.

## Tests

- New request spec (5 examples): 200/422 turbo_stream contract + markup regression pins (`relative z-10`, backdrop data-action).
- New JS system spec for backdrop/Escape/resolve-closes (unrunnable locally — the shared `sign_in_admin_user` system-spec helper is broken on main in this env; verified pre-existing).
- Full unit suite: 9156 examples, 0 failures. RuboCop + Brakeman clean.
- Post-deploy: Playwright end-to-end re-verification planned.