### PR TITLE
feat(sync): idempotent email re-sync keyed on RFC822 Message-ID

### DIFF
--- a/app/jobs/process_email_job.rb
+++ b/app/jobs/process_email_job.rb
@@ -93,19 +93,26 @@ class ProcessEmailJob < ApplicationJob
   # created or marked duplicate). See Services::EmailProcessing::Processor
   # for the same pattern applied to non-transaction and conflict-skip outcomes.
   #
+  # Keyed on the RFC822 Message-ID header (email_data[:rfc_message_id]) — the
+  # IMAP sequence number in email_data[:message_id] is unstable across
+  # sessions (RFC 3501) and must never be used as an idempotency key. A
+  # blank/missing header is simply not recorded; the email gets re-processed
+  # next sync, which is the safe direction.
+  #
   # Never allowed to raise — a failure here just means one wasted re-process
   # on the next sync, which is much cheaper than losing an already-saved expense.
   def record_processed_email(email_account, email_data)
-    message_id = email_data&.dig(:message_id)
-    return if message_id.blank?
+    rfc_message_id = email_data&.dig(:rfc_message_id)
+    normalized_id = ProcessedEmail.normalize_message_id(rfc_message_id)
+    return if normalized_id.nil?
 
-    ProcessedEmail.find_or_create_by!(message_id: message_id.to_s, email_account_id: email_account.id) do |processed_email|
+    ProcessedEmail.find_or_create_by!(message_id: normalized_id, email_account_id: email_account.id) do |processed_email|
       processed_email.user = email_account.user
       processed_email.processed_at = Time.current
       processed_email.subject = email_data[:subject]
       processed_email.from_address = email_data[:from]
     end
   rescue StandardError => e
-    Rails.logger.error "Failed to record processed email #{message_id}: #{e.message}"
+    Rails.logger.error "Failed to record processed email #{rfc_message_id}: #{e.message}"
   end
 end

--- a/app/jobs/process_email_job.rb
+++ b/app/jobs/process_email_job.rb
@@ -51,6 +51,12 @@ class ProcessEmailJob < ApplicationJob
 
       # Optionally notify about new expense
       # NotificationJob.perform_later(expense.id) if expense.amount > 100
+
+      # Record the terminal outcome (success or marked-duplicate) so a future
+      # re-sync can skip this message via ProcessedEmail.already_processed?
+      # instead of re-parsing it. Enqueue time is NOT a terminal outcome — this
+      # job could still fail — so recording only happens once we get here.
+      record_processed_email(email_account, email_data)
     else
       Rails.logger.warn "Failed to create expense from email: #{parser.errors.join(", ")}"
 
@@ -81,5 +87,25 @@ class ProcessEmailJob < ApplicationJob
     )
   rescue StandardError => e
     Rails.logger.error "Failed to save parsing failure record: #{e.message}"
+  end
+
+  # Idempotently records that a message reached a terminal outcome (expense
+  # created or marked duplicate). See Services::EmailProcessing::Processor
+  # for the same pattern applied to non-transaction and conflict-skip outcomes.
+  #
+  # Never allowed to raise — a failure here just means one wasted re-process
+  # on the next sync, which is much cheaper than losing an already-saved expense.
+  def record_processed_email(email_account, email_data)
+    message_id = email_data&.dig(:message_id)
+    return if message_id.blank?
+
+    ProcessedEmail.find_or_create_by!(message_id: message_id.to_s, email_account_id: email_account.id) do |processed_email|
+      processed_email.user = email_account.user
+      processed_email.processed_at = Time.current
+      processed_email.subject = email_data[:subject]
+      processed_email.from_address = email_data[:from]
+    end
+  rescue StandardError => e
+    Rails.logger.error "Failed to record processed email #{message_id}: #{e.message}"
   end
 end

--- a/app/models/processed_email.rb
+++ b/app/models/processed_email.rb
@@ -7,12 +7,36 @@ class ProcessedEmail < ApplicationRecord
   validates :message_id, presence: true, uniqueness: { scope: :email_account_id }
   validates :email_account, presence: true
 
+  before_validation :normalize_message_id_column
+
   scope :for_user, ->(u) { where(user_id: u.id) }
   scope :for_account, ->(account) { where(email_account: account) }
   scope :recent, -> { order(processed_at: :desc) }
   scope :by_date_range, ->(start_date, end_date) { where(processed_at: start_date..end_date) }
 
+  # Canonical normalization for RFC822 Message-ID headers — the SINGLE place
+  # where readers (already_processed?) and writers must agree. Strips
+  # whitespace and the surrounding angle brackets ("<abc@host>" → "abc@host")
+  # and downcases. Returns nil for blank/bracket-only input.
+  def self.normalize_message_id(raw)
+    return nil if raw.blank?
+
+    raw.to_s.strip.delete_prefix("<").delete_suffix(">").strip.downcase.presence
+  end
+
+  # Blank/unparseable Message-IDs are never considered processed — the safe
+  # direction is to re-process (one wasted parse) rather than risk silently
+  # dropping a real expense.
   def self.already_processed?(message_id, email_account)
-    exists?(message_id: message_id, email_account: email_account)
+    normalized = normalize_message_id(message_id)
+    return false if normalized.nil?
+
+    exists?(message_id: normalized, email_account: email_account)
+  end
+
+  private
+
+  def normalize_message_id_column
+    self.message_id = self.class.normalize_message_id(message_id)
   end
 end

--- a/app/models/processed_email.rb
+++ b/app/models/processed_email.rb
@@ -21,7 +21,7 @@ class ProcessedEmail < ApplicationRecord
   def self.normalize_message_id(raw)
     return nil if raw.blank?
 
-    raw.to_s.strip.delete_prefix("<").delete_suffix(">").strip.downcase.presence
+    raw.to_s.strip.gsub(/\A<+/, "").gsub(/>+\z/, "").strip.downcase.presence
   end
 
   # Blank/unparseable Message-IDs are never considered processed — the safe

--- a/app/services/email_processing/processor.rb
+++ b/app/services/email_processing/processor.rb
@@ -41,6 +41,11 @@ module Services::EmailProcessing
     private
 
     def process_single_email(message_id, imap_service)
+      if ProcessedEmail.already_processed?(message_id, email_account)
+        Rails.logger.info "[SKIP] Already processed message: #{message_id}"
+        return { processed: false, expense_created: false }
+      end
+
       if @metrics_collector
         begin
           result = @metrics_collector.track_operation(:parse_email, @email_account, { message_id: message_id }) do
@@ -68,6 +73,7 @@ module Services::EmailProcessing
       # Check if this is a transaction email based on subject
       unless transaction_email?(subject)
         Rails.logger.info "[SKIP] Non-transaction email: #{subject}"
+        record_processed_email(message_id, subject: subject, from_address: build_from_address(envelope))
         return { processed: false, expense_created: false }
       end
 
@@ -81,7 +87,9 @@ module Services::EmailProcessing
       conflict_result = detect_and_handle_conflict(email_data)
 
       if conflict_result.nil?
-        # Conflict detected
+        # Conflict detected — this email will never be re-processed successfully,
+        # so record it now (terminal outcome).
+        record_processed_email(message_id, subject: email_data[:subject], from_address: email_data[:from])
         { processed: true, expense_created: false, conflict_detected: true }
       else
         # No conflict — pass pre-parsed data if available
@@ -316,6 +324,25 @@ module Services::EmailProcessing
     def add_error(message)
       @errors << message
       Rails.logger.error "[Services::EmailProcessing::Processor] #{email_account.email}: #{message}"
+    end
+
+    # Idempotently records that an email has reached a terminal outcome so a
+    # future re-sync (which only filters IMAP by SINCE-date) can skip it via
+    # the ProcessedEmail.already_processed? check instead of re-parsing it.
+    #
+    # Never allowed to break expense processing — any failure here (including
+    # the unique index race between concurrent jobs) is logged and swallowed.
+    def record_processed_email(message_id, subject: nil, from_address: nil)
+      return if message_id.blank?
+
+      ProcessedEmail.find_or_create_by!(message_id: message_id.to_s, email_account_id: email_account.id) do |processed_email|
+        processed_email.user = email_account.user
+        processed_email.processed_at = Time.current
+        processed_email.subject = subject
+        processed_email.from_address = from_address
+      end
+    rescue StandardError => e
+      Rails.logger.error "[Services::EmailProcessing::Processor] Failed to record processed email #{message_id}: #{e.message}"
     end
   end
 end

--- a/app/services/email_processing/processor.rb
+++ b/app/services/email_processing/processor.rb
@@ -41,11 +41,6 @@ module Services::EmailProcessing
     private
 
     def process_single_email(message_id, imap_service)
-      if ProcessedEmail.already_processed?(message_id, email_account)
-        Rails.logger.info "[SKIP] Already processed message: #{message_id}"
-        return { processed: false, expense_created: false }
-      end
-
       if @metrics_collector
         begin
           result = @metrics_collector.track_operation(:parse_email, @email_account, { message_id: message_id }) do
@@ -68,12 +63,23 @@ module Services::EmailProcessing
       envelope = imap_service.fetch_envelope(message_id)
       return { processed: false, expense_created: false } unless envelope
 
+      # Idempotency is keyed on the RFC822 Message-ID header — NOT the IMAP
+      # sequence number in `message_id`, which RFC 3501 defines as unstable
+      # across sessions (expunges shift it, so a reused sequence number could
+      # silently drop a real expense). A nil/blank header never skips: one
+      # wasted re-process beats a dropped expense.
+      rfc_message_id = envelope.message_id
+      if ProcessedEmail.already_processed?(rfc_message_id, email_account)
+        Rails.logger.info "[SKIP] Already processed message: #{rfc_message_id}"
+        return { processed: false, expense_created: false }
+      end
+
       subject = decode_subject(envelope.subject || "")
 
       # Check if this is a transaction email based on subject
       unless transaction_email?(subject)
         Rails.logger.info "[SKIP] Non-transaction email: #{subject}"
-        record_processed_email(message_id, subject: subject, from_address: build_from_address(envelope))
+        record_processed_email(rfc_message_id, subject: subject, from_address: build_from_address(envelope))
         return { processed: false, expense_created: false }
       end
 
@@ -89,7 +95,7 @@ module Services::EmailProcessing
       if conflict_result.nil?
         # Conflict detected — this email will never be re-processed successfully,
         # so record it now (terminal outcome).
-        record_processed_email(message_id, subject: email_data[:subject], from_address: email_data[:from])
+        record_processed_email(email_data[:rfc_message_id], subject: email_data[:subject], from_address: email_data[:from])
         { processed: true, expense_created: false, conflict_detected: true }
       else
         # No conflict — pass pre-parsed data if available
@@ -137,6 +143,7 @@ module Services::EmailProcessing
 
       {
         message_id: message_id,
+        rfc_message_id: envelope.message_id,
         from: build_from_address(envelope),
         subject: decode_subject(envelope.subject || ""),
         date: envelope.date,
@@ -330,19 +337,24 @@ module Services::EmailProcessing
     # future re-sync (which only filters IMAP by SINCE-date) can skip it via
     # the ProcessedEmail.already_processed? check instead of re-parsing it.
     #
+    # Keyed on the RFC822 Message-ID header (normalized by the model — the
+    # find and the write must use the identical normalization or lookups
+    # would miss). Blank/missing headers are never recorded.
+    #
     # Never allowed to break expense processing — any failure here (including
     # the unique index race between concurrent jobs) is logged and swallowed.
-    def record_processed_email(message_id, subject: nil, from_address: nil)
-      return if message_id.blank?
+    def record_processed_email(rfc_message_id, subject: nil, from_address: nil)
+      normalized_id = ProcessedEmail.normalize_message_id(rfc_message_id)
+      return if normalized_id.nil?
 
-      ProcessedEmail.find_or_create_by!(message_id: message_id.to_s, email_account_id: email_account.id) do |processed_email|
+      ProcessedEmail.find_or_create_by!(message_id: normalized_id, email_account_id: email_account.id) do |processed_email|
         processed_email.user = email_account.user
         processed_email.processed_at = Time.current
         processed_email.subject = subject
         processed_email.from_address = from_address
       end
     rescue StandardError => e
-      Rails.logger.error "[Services::EmailProcessing::Processor] Failed to record processed email #{message_id}: #{e.message}"
+      Rails.logger.error "[Services::EmailProcessing::Processor] Failed to record processed email #{rfc_message_id}: #{e.message}"
     end
   end
 end

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -313,42 +313,56 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
   end
 
   describe 'idempotent recording via ProcessedEmail', integration: true do
-    let(:message_id) { 'msg-abc-123' }
-    let(:email_data_with_message_id) { email_data.merge(message_id: message_id) }
+    # RFC822 Message-ID header as fetched from the ENVELOPE — the idempotency
+    # key. Deliberately mixed-case and bracketed to exercise normalization.
+    let(:rfc_message_id) { '<MSG-Abc-123@Mail.Gmail.Com>' }
+    let(:email_data_with_rfc_id) { email_data.merge(message_id: 7, rfc_message_id: rfc_message_id) }
 
-    it 'records a ProcessedEmail when the expense is created successfully' do
+    it 'records a ProcessedEmail keyed on the normalized RFC822 Message-ID when the expense is created' do
       expect {
-        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id)
       }.to change(ProcessedEmail, :count).by(1)
 
       recorded = ProcessedEmail.last
-      expect(recorded.message_id).to eq(message_id)
+      expect(recorded.message_id).to eq('msg-abc-123@mail.gmail.com')
       expect(recorded.email_account).to eq(email_account)
       expect(recorded.user).to eq(email_account.user)
-      expect(recorded.subject).to eq(email_data_with_message_id[:subject])
+      expect(recorded.subject).to eq(email_data_with_rfc_id[:subject])
+    end
+
+    it 'never uses the IMAP sequence number as the recorded key' do
+      ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id)
+
+      expect(ProcessedEmail.where(message_id: '7')).to be_empty
     end
 
     it 'records a ProcessedEmail when the expense is marked as duplicate' do
-      ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+      ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id)
 
       expect {
-        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id.merge(message_id: "#{message_id}-dup"))
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id.merge(rfc_message_id: '<resent-copy@mail.gmail.com>'))
       }.to change(Expense, :count).by(0).and change(ProcessedEmail, :count).by(1)
 
       expect(Expense.last.status).to eq('duplicate')
     end
 
     it 'does not record a ProcessedEmail when parsing fails (non-terminal outcome)' do
-      invalid_email_data = { body: "Invalid email content", subject: "Random subject", message_id: message_id }
+      invalid_email_data = { body: "Invalid email content", subject: "Random subject", rfc_message_id: rfc_message_id }
 
       expect {
         ProcessEmailJob.new.perform(email_account.id, invalid_email_data)
       }.not_to change(ProcessedEmail, :count)
     end
 
-    it 'does not record and does not raise when message_id is missing' do
+    it 'does not record and does not raise when the RFC822 Message-ID header is missing' do
       expect {
-        ProcessEmailJob.new.perform(email_account.id, email_data)
+        ProcessEmailJob.new.perform(email_account.id, email_data.merge(rfc_message_id: nil))
+      }.not_to change(ProcessedEmail, :count)
+    end
+
+    it 'does not record when the header is bracket-only garbage' do
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, email_data.merge(rfc_message_id: '<>'))
       }.not_to change(ProcessedEmail, :count)
     end
 
@@ -357,7 +371,7 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
       allow(Rails.logger).to receive(:error)
 
       expect {
-        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id)
       }.not_to raise_error
 
       expect(Rails.logger).to have_received(:error).with(

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -311,4 +311,58 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
       end
     end
   end
+
+  describe 'idempotent recording via ProcessedEmail', integration: true do
+    let(:message_id) { 'msg-abc-123' }
+    let(:email_data_with_message_id) { email_data.merge(message_id: message_id) }
+
+    it 'records a ProcessedEmail when the expense is created successfully' do
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+      }.to change(ProcessedEmail, :count).by(1)
+
+      recorded = ProcessedEmail.last
+      expect(recorded.message_id).to eq(message_id)
+      expect(recorded.email_account).to eq(email_account)
+      expect(recorded.user).to eq(email_account.user)
+      expect(recorded.subject).to eq(email_data_with_message_id[:subject])
+    end
+
+    it 'records a ProcessedEmail when the expense is marked as duplicate' do
+      ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id.merge(message_id: "#{message_id}-dup"))
+      }.to change(Expense, :count).by(0).and change(ProcessedEmail, :count).by(1)
+
+      expect(Expense.last.status).to eq('duplicate')
+    end
+
+    it 'does not record a ProcessedEmail when parsing fails (non-terminal outcome)' do
+      invalid_email_data = { body: "Invalid email content", subject: "Random subject", message_id: message_id }
+
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, invalid_email_data)
+      }.not_to change(ProcessedEmail, :count)
+    end
+
+    it 'does not record and does not raise when message_id is missing' do
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, email_data)
+      }.not_to change(ProcessedEmail, :count)
+    end
+
+    it 'does not raise when recording fails' do
+      allow(ProcessedEmail).to receive(:find_or_create_by!).and_raise(StandardError, 'boom')
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        ProcessEmailJob.new.perform(email_account.id, email_data_with_message_id)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(
+        a_string_matching(/Failed to record processed email/)
+      )
+    end
+  end
 end

--- a/spec/models/processed_email_unit_spec.rb
+++ b/spec/models/processed_email_unit_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe ProcessedEmail, type: :model, unit: true do
       expect(described_class.normalize_message_id("Abc@Mail.example")).to eq("abc@mail.example")
     end
 
+    it "strips every layer of malformed nested brackets" do
+      expect(described_class.normalize_message_id("<<abc@mail.example>>")).to eq("abc@mail.example")
+    end
+
     it "returns nil for nil, blank, and bracket-only input" do
       expect(described_class.normalize_message_id(nil)).to be_nil
       expect(described_class.normalize_message_id("")).to be_nil

--- a/spec/models/processed_email_unit_spec.rb
+++ b/spec/models/processed_email_unit_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe ProcessedEmail, type: :model, unit: true do
     subject { build(:processed_email) }
 
     it { should validate_presence_of(:message_id) }
-    it { should validate_uniqueness_of(:message_id).scoped_to(:email_account_id) }
+    # Normalization downcases message_id before validation, so uniqueness is
+    # effectively case-insensitive — tell the matcher not to probe case variants.
+    it { should validate_uniqueness_of(:message_id).scoped_to(:email_account_id).ignoring_case_sensitivity }
     it { should validate_presence_of(:email_account) }
   end
 
@@ -56,6 +58,46 @@ RSpec.describe ProcessedEmail, type: :model, unit: true do
     end
   end
 
+  describe ".normalize_message_id" do
+    it "strips surrounding angle brackets" do
+      expect(described_class.normalize_message_id("<abc@mail.gmail.com>")).to eq("abc@mail.gmail.com")
+    end
+
+    it "downcases" do
+      expect(described_class.normalize_message_id("<ABC@Mail.Gmail.Com>")).to eq("abc@mail.gmail.com")
+    end
+
+    it "strips surrounding whitespace, inside and outside the brackets" do
+      expect(described_class.normalize_message_id("  < abc@mail.gmail.com >  ")).to eq("abc@mail.gmail.com")
+    end
+
+    it "leaves bracket-less ids intact apart from case" do
+      expect(described_class.normalize_message_id("Abc@Mail.example")).to eq("abc@mail.example")
+    end
+
+    it "returns nil for nil, blank, and bracket-only input" do
+      expect(described_class.normalize_message_id(nil)).to be_nil
+      expect(described_class.normalize_message_id("")).to be_nil
+      expect(described_class.normalize_message_id("   ")).to be_nil
+      expect(described_class.normalize_message_id("<>")).to be_nil
+    end
+  end
+
+  describe "message_id normalization on write" do
+    it "persists the normalized form" do
+      record = create(:processed_email, message_id: "<Some-ID@Mail.Example>")
+      expect(record.reload.message_id).to eq("some-id@mail.example")
+    end
+
+    it "treats bracket/case variants as the same record for uniqueness" do
+      account = create(:email_account)
+      create(:processed_email, message_id: "<dup@mail.example>", email_account: account)
+
+      duplicate = build(:processed_email, message_id: "DUP@MAIL.EXAMPLE", email_account: account)
+      expect(duplicate).not_to be_valid
+    end
+  end
+
   describe ".already_processed?" do
     let(:account) { create(:email_account) }
     let(:message_id) { "msg_123" }
@@ -67,11 +109,23 @@ RSpec.describe ProcessedEmail, type: :model, unit: true do
       it "returns true" do
         expect(ProcessedEmail.already_processed?(message_id, account)).to be true
       end
+
+      it "returns true for a bracketed/uppercased variant of the same id (shared normalization)" do
+        expect(ProcessedEmail.already_processed?("<MSG_123>", account)).to be true
+      end
     end
 
     context "when email not processed" do
       it "returns false" do
         expect(ProcessedEmail.already_processed?(message_id, account)).to be false
+      end
+    end
+
+    context "when the message id is nil, blank, or bracket-only" do
+      it "returns false" do
+        expect(ProcessedEmail.already_processed?(nil, account)).to be false
+        expect(ProcessedEmail.already_processed?("", account)).to be false
+        expect(ProcessedEmail.already_processed?("<>", account)).to be false
       end
     end
   end

--- a/spec/services/email_processing/fetcher_connection_reuse_spec.rb
+++ b/spec/services/email_processing/fetcher_connection_reuse_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'IMAP connection reuse', type: :service, unit: true do
     double('envelope',
       subject: 'Notificacion de transaccion',
       from: [ double(mailbox: 'alerts', host: 'bac.net') ],
-      date: Time.current
+      date: Time.current,
+      message_id: '<connection-reuse@bac.net>'
     )
   end
 

--- a/spec/services/email_processing/processor/idempotent_resync_spec.rb
+++ b/spec/services/email_processing/processor/idempotent_resync_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'Services::EmailProcessing::Processor - Idempotent Re-sync', type
   let!(:parsing_rule) { create(:parsing_rule, :bac) }
   let(:email_account) { create(:email_account, :bac) }
   let(:mock_imap_service) { create_mock_imap_service }
-  let(:message_id) { 1 }
+  let(:sequence_number) { 1 } # IMAP sequence number — unstable across sessions, fetch mechanics only
+  let(:rfc_message_id) { '<stable-id-123@mail.bank.example>' }
 
   let(:sample_bac_email) do
     <<~EMAIL
@@ -26,31 +27,52 @@ RSpec.describe 'Services::EmailProcessing::Processor - Idempotent Re-sync', type
     EMAIL
   end
 
-  before do
-    mock_imap_service.configure_envelope(message_id, create_transaction_envelope)
-    mock_imap_service.configure_body_structure(message_id, create_plain_text_body_structure)
-    mock_imap_service.configure_text_body(message_id, sample_bac_email)
+  let(:different_bac_email) do
+    <<~EMAIL
+      Estimado cliente,
+
+      Le informamos sobre una transacción realizada con su tarjeta de débito BAC:
+
+      Comercio: OTRO COMERCIO XYZ
+      Ciudad: HEREDIA
+      Fecha: Ago 2, 2025, 09:30
+      Monto: CRC 12,345.00
+      Tipo de Transacción: COMPRA
+
+      Si no reconoce esta transacción, contacte inmediatamente al centro de atención al cliente.
+    EMAIL
   end
 
-  # Simulates re-syncing the exact same IMAP SINCE-date window twice — the
-  # fetcher has no BEFORE/UID cursor (fetcher.rb:124-128), so the same
-  # message_id is handed to the Processor on both syncs.
-  it 'processes the same message only once across two re-syncs' do
-    first_processor = Services::EmailProcessing::Processor.new(email_account)
-    first_result = nil
+  def configure_message(seq, message_id:, body:)
+    mock_imap_service.configure_envelope(seq, create_transaction_envelope('Notificación de transacción', message_id: message_id))
+    mock_imap_service.configure_body_structure(seq, create_plain_text_body_structure)
+    mock_imap_service.configure_text_body(seq, body)
+  end
+
+  def run_sync
+    result = nil
     perform_enqueued_jobs do
-      first_result = first_processor.process_emails([ message_id ], mock_imap_service)
+      result = Services::EmailProcessing::Processor.new(email_account)
+                                                   .process_emails([ sequence_number ], mock_imap_service)
     end
+    result
+  end
+
+  # The fetcher has no cursor — it searches by SINCE-date only
+  # (fetcher.rb build_search_criteria), so a re-sync hands the Processor the
+  # same window of messages again. Idempotency must key on the RFC822
+  # Message-ID header, never the IMAP sequence number.
+  it 'processes a message with the same RFC822 Message-ID only once across two re-syncs' do
+    configure_message(sequence_number, message_id: rfc_message_id, body: sample_bac_email)
+
+    first_result = run_sync
 
     expect(Expense.count).to eq(1)
     expect(ProcessedEmail.count).to eq(1)
+    expect(ProcessedEmail.last.message_id).to eq('stable-id-123@mail.bank.example')
     expect(first_result[:processed_count]).to eq(1)
 
-    second_processor = Services::EmailProcessing::Processor.new(email_account)
-    second_result = nil
-    perform_enqueued_jobs do
-      second_result = second_processor.process_emails([ message_id ], mock_imap_service)
-    end
+    second_result = run_sync
 
     # No new Expense, no new ProcessedEmail — the skip gate short-circuited
     # before any parsing or conflict-detection work happened.
@@ -58,5 +80,37 @@ RSpec.describe 'Services::EmailProcessing::Processor - Idempotent Re-sync', type
     expect(ProcessedEmail.count).to eq(1)
     expect(second_result[:processed_count]).to eq(0)
     expect(second_result[:total_count]).to eq(1)
+  end
+
+  # REGRESSION (architect review): RFC 3501 sequence numbers shift when
+  # messages are expunged (routine with Gmail archiving), so on a later sync
+  # the SAME sequence position can carry a DIFFERENT email. That email must
+  # be processed — skipping it would silently drop a real expense.
+  it 'creates a new expense when the same sequence number carries a different Message-ID' do
+    configure_message(sequence_number, message_id: rfc_message_id, body: sample_bac_email)
+    run_sync
+    expect(Expense.count).to eq(1)
+
+    # Same sequence position, different email (expunge shifted the mailbox)
+    configure_message(sequence_number,
+                      message_id: '<completely-different-id@mail.bank.example>',
+                      body: different_bac_email)
+    result = run_sync
+
+    expect(result[:processed_count]).to eq(1)
+    expect(Expense.count).to eq(2)
+    expect(ProcessedEmail.count).to eq(2)
+    expect(Expense.order(:created_at).last.merchant_name).to include('OTRO COMERCIO')
+  end
+
+  it 'processes a message with a nil Message-ID header normally and records nothing' do
+    configure_message(sequence_number, message_id: nil, body: sample_bac_email)
+
+    result = nil
+    expect { result = run_sync }.not_to raise_error
+
+    expect(result[:processed_count]).to eq(1)
+    expect(Expense.count).to eq(1)
+    expect(ProcessedEmail.count).to eq(0)
   end
 end

--- a/spec/services/email_processing/processor/idempotent_resync_spec.rb
+++ b/spec/services/email_processing/processor/idempotent_resync_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+require 'support/email_processing_processor_test_helper'
+
+RSpec.describe 'Services::EmailProcessing::Processor - Idempotent Re-sync', type: :job, integration: true do
+  include EmailProcessingProcessorTestHelper
+  include ActiveJob::TestHelper
+
+  let!(:parsing_rule) { create(:parsing_rule, :bac) }
+  let(:email_account) { create(:email_account, :bac) }
+  let(:mock_imap_service) { create_mock_imap_service }
+  let(:message_id) { 1 }
+
+  let(:sample_bac_email) do
+    <<~EMAIL
+      Estimado cliente,
+
+      Le informamos sobre una transacción realizada con su tarjeta de débito BAC:
+
+      Comercio: PTA LEONA SOC
+      Ciudad: SAN JOSE
+      Fecha: Ago 1, 2025, 14:16
+      Monto: CRC 95,000.00
+      Tipo de Transacción: COMPRA
+
+      Si no reconoce esta transacción, contacte inmediatamente al centro de atención al cliente.
+    EMAIL
+  end
+
+  before do
+    mock_imap_service.configure_envelope(message_id, create_transaction_envelope)
+    mock_imap_service.configure_body_structure(message_id, create_plain_text_body_structure)
+    mock_imap_service.configure_text_body(message_id, sample_bac_email)
+  end
+
+  # Simulates re-syncing the exact same IMAP SINCE-date window twice — the
+  # fetcher has no BEFORE/UID cursor (fetcher.rb:124-128), so the same
+  # message_id is handed to the Processor on both syncs.
+  it 'processes the same message only once across two re-syncs' do
+    first_processor = Services::EmailProcessing::Processor.new(email_account)
+    first_result = nil
+    perform_enqueued_jobs do
+      first_result = first_processor.process_emails([ message_id ], mock_imap_service)
+    end
+
+    expect(Expense.count).to eq(1)
+    expect(ProcessedEmail.count).to eq(1)
+    expect(first_result[:processed_count]).to eq(1)
+
+    second_processor = Services::EmailProcessing::Processor.new(email_account)
+    second_result = nil
+    perform_enqueued_jobs do
+      second_result = second_processor.process_emails([ message_id ], mock_imap_service)
+    end
+
+    # No new Expense, no new ProcessedEmail — the skip gate short-circuited
+    # before any parsing or conflict-detection work happened.
+    expect(Expense.count).to eq(1)
+    expect(ProcessedEmail.count).to eq(1)
+    expect(second_result[:processed_count]).to eq(0)
+    expect(second_result[:total_count]).to eq(1)
+  end
+end

--- a/spec/services/email_processing/processor/metrics_tracking_spec.rb
+++ b/spec/services/email_processing/processor/metrics_tracking_spec.rb
@@ -283,7 +283,8 @@ RSpec.describe 'Services::EmailProcessing::Processor - Metrics Tracking', type: 
       envelope = double('envelope',
         subject: 'BAC - Notificación de transacción',
         date: Time.current,
-        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ]
+        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ],
+        message_id: "<no-metrics-#{SecureRandom.hex(4)}@example.com>"
       )
 
       allow(mock_imap_service).to receive(:fetch_envelope).and_return(envelope)
@@ -299,7 +300,8 @@ RSpec.describe 'Services::EmailProcessing::Processor - Metrics Tracking', type: 
       envelope = double('envelope',
         subject: 'BAC - Notificación de transacción',
         date: Time.current,
-        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ]
+        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ],
+        message_id: "<no-metrics-#{SecureRandom.hex(4)}@example.com>"
       )
 
       allow(mock_imap_service).to receive(:fetch_envelope).and_return(envelope)

--- a/spec/services/email_processing/processor_spec.rb
+++ b/spec/services/email_processing/processor_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
     context 'with transaction emails' do
       let(:message_ids) { [ 1, 2, 3 ] }
-      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción') }
-      let(:non_transaction_envelope) { double('envelope', subject: 'Regular email') }
+      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción', from: nil) }
+      let(:non_transaction_envelope) { double('envelope', subject: 'Regular email', from: nil) }
 
       before do
         allow(mock_imap_service).to receive(:fetch_envelope).with(1).and_return(transaction_envelope)
@@ -781,6 +781,133 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
         result = processor_with_session.send(:detect_and_handle_conflict, email_data)
         expect(result).to be false
+      end
+    end
+  end
+
+  describe '#process_single_email idempotent skip gate', integration: true do
+    let(:message_id) { 42 }
+
+    context 'when the message was already processed' do
+      before do
+        allow(ProcessedEmail).to receive(:already_processed?).with(message_id, email_account).and_return(true)
+      end
+
+      it 'returns the standard skip result without touching the imap service' do
+        expect(mock_imap_service).not_to receive(:fetch_envelope)
+
+        result = processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+
+        expect(result).to eq(processed: false, expense_created: false)
+      end
+
+      it 'never invokes conflict detection' do
+        expect(Services::ConflictDetectionService).not_to receive(:new)
+
+        processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+      end
+
+      it 'is counted as skipped (not processed) at the process_emails level' do
+        result = processor_without_metrics.process_emails([ message_id ], mock_imap_service)
+
+        expect(result[:processed_count]).to eq(0)
+        expect(result[:total_count]).to eq(1)
+        expect(result[:detected_expenses_count]).to eq(0)
+      end
+
+      it 'does not create a new ProcessedEmail record' do
+        expect {
+          processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+        }.not_to change(ProcessedEmail, :count)
+      end
+    end
+
+    context 'when the message has not been processed yet' do
+      before do
+        allow(ProcessedEmail).to receive(:already_processed?).and_return(false)
+        allow(mock_imap_service).to receive(:fetch_envelope).and_return(nil)
+      end
+
+      it 'proceeds to fetch the envelope' do
+        processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+
+        expect(mock_imap_service).to have_received(:fetch_envelope).with(message_id)
+      end
+    end
+  end
+
+  describe '#process_email_with_metrics recording at terminal outcomes', integration: true do
+    let(:message_id) { 55 }
+
+    before do
+      allow(ProcessedEmail).to receive(:already_processed?).and_return(false)
+    end
+
+    context 'when the email is not a transaction email' do
+      let(:non_transaction_envelope) do
+        double('envelope', subject: 'Newsletter', from: [ double('from', mailbox: 'news', host: 'example.com') ], date: Time.current)
+      end
+
+      before do
+        allow(mock_imap_service).to receive(:fetch_envelope).and_return(non_transaction_envelope)
+      end
+
+      it 'records a ProcessedEmail for the skipped message' do
+        expect {
+          processor_without_metrics.send(:process_email_with_metrics, message_id, mock_imap_service)
+        }.to change(ProcessedEmail, :count).by(1)
+
+        recorded = ProcessedEmail.last
+        expect(recorded.message_id).to eq(message_id.to_s)
+        expect(recorded.email_account).to eq(email_account)
+        expect(recorded.user).to eq(email_account.user)
+        expect(recorded.subject).to eq('Newsletter')
+      end
+
+      it 'does not raise when recording fails' do
+        allow(ProcessedEmail).to receive(:find_or_create_by!).and_raise(StandardError, 'boom')
+        allow(Rails.logger).to receive(:error)
+
+        expect {
+          processor_without_metrics.send(:process_email_with_metrics, message_id, mock_imap_service)
+        }.not_to raise_error
+
+        expect(Rails.logger).to have_received(:error).with(
+          a_string_matching(/Failed to record processed email/)
+        )
+      end
+    end
+
+    context 'when a conflict is detected for a transaction email' do
+      let(:sync_session_for_conflict) { instance_double(SyncSession, id: 1) }
+      let(:processor_with_session) { described_class.new(email_account, sync_session: sync_session_for_conflict) }
+      let(:transaction_envelope) do
+        double('envelope', subject: 'Notificación de transacción', from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ], date: Time.current)
+      end
+
+      before do
+        allow(mock_imap_service).to receive(:fetch_envelope).and_return(transaction_envelope)
+        allow(processor_with_session).to receive(:extract_email_data).and_return({
+          message_id: message_id,
+          from: 'bank@bac.co.cr',
+          subject: 'Notificación de transacción',
+          date: Time.current,
+          body: 'body'
+        })
+        allow(processor_with_session).to receive(:detect_and_handle_conflict).and_return(nil)
+        allow(ProcessEmailJob).to receive(:perform_later)
+      end
+
+      it 'records a ProcessedEmail for the conflict-skipped message' do
+        expect {
+          processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
+        }.to change(ProcessedEmail, :count).by(1)
+      end
+
+      it 'does not enqueue ProcessEmailJob' do
+        processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
+
+        expect(ProcessEmailJob).not_to have_received(:perform_later)
       end
     end
   end

--- a/spec/services/email_processing/processor_spec.rb
+++ b/spec/services/email_processing/processor_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
     context 'with transaction emails' do
       let(:message_ids) { [ 1, 2, 3 ] }
-      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción', from: nil) }
-      let(:non_transaction_envelope) { double('envelope', subject: 'Regular email', from: nil) }
+      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción', from: nil, message_id: '<txn@example.com>') }
+      let(:non_transaction_envelope) { double('envelope', subject: 'Regular email', from: nil, message_id: '<regular@example.com>') }
 
       before do
         allow(mock_imap_service).to receive(:fetch_envelope).with(1).and_return(transaction_envelope)
@@ -120,7 +120,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
     context 'with failed email data extraction' do
       let(:message_ids) { [ 1 ] }
-      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción') }
+      let(:transaction_envelope) { double('envelope', subject: 'BAC - Notificación de transacción', message_id: '<failed-extraction@example.com>') }
 
       before do
         allow(mock_imap_service).to receive(:fetch_envelope).and_return(transaction_envelope)
@@ -161,7 +161,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
     let(:imap_service) { instance_double(Services::ImapConnectionService) }
 
     it 'passes 3 arguments to progress callback' do
-      envelope = double("envelope", subject: "Notificación de transacción", from: nil, date: Time.current)
+      envelope = double("envelope", subject: "Notificación de transacción", from: nil, date: Time.current, message_id: "<progress-1@example.com>")
       allow(imap_service).to receive(:fetch_envelope).and_return(envelope)
       allow(imap_service).to receive(:fetch_body_structure).and_return(nil)
       allow(imap_service).to receive(:fetch_text_body).and_return("Test body")
@@ -176,7 +176,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
     end
 
     it 'passes nil as third arg for non-expense emails' do
-      non_transaction_envelope = double("envelope", subject: "Newsletter", from: nil, date: Time.current)
+      non_transaction_envelope = double("envelope", subject: "Newsletter", from: nil, date: Time.current, message_id: "<progress-2@example.com>")
       allow(imap_service).to receive(:fetch_envelope).and_return(non_transaction_envelope)
 
       callback_args = []
@@ -265,7 +265,8 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
       double('envelope',
         subject: 'Test Transaction',
         date: Time.current,
-        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ]
+        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ],
+        message_id: '<extract-data@example.com>'
       )
     end
     let(:email_body) { 'Transaction details here' }
@@ -279,6 +280,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
       expect(result).to include(
         message_id: message_id,
+        rfc_message_id: '<extract-data@example.com>',
         from: 'bank@bac.co.cr',
         subject: 'Test Transaction',
         date: envelope.date,
@@ -662,7 +664,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
 
   describe 'metrics integration', integration: true do
     let(:message_id) { 123 }
-    let(:envelope) { double('envelope', subject: 'BAC - Notificación de transacción', date: Time.current, from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ]) }
+    let(:envelope) { double('envelope', subject: 'BAC - Notificación de transacción', date: Time.current, from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ], message_id: '<metrics@example.com>') }
 
     describe '#process_single_email with metrics' do
       it 'tracks operation with metrics collector when available' do
@@ -785,26 +787,35 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
     end
   end
 
-  describe '#process_single_email idempotent skip gate', integration: true do
-    let(:message_id) { 42 }
+  describe 'idempotent skip gate keyed on RFC822 Message-ID', integration: true do
+    let(:message_id) { 42 } # IMAP sequence number — fetch mechanics only, never the idempotency key
+    let(:rfc_message_id) { '<abc-123@mail.bank.example>' }
+    let(:envelope) do
+      double('envelope',
+        subject: 'BAC - Notificación de transacción',
+        from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ],
+        date: Time.current,
+        message_id: rfc_message_id)
+    end
 
-    context 'when the message was already processed' do
+    before do
+      allow(mock_imap_service).to receive(:fetch_envelope).with(message_id).and_return(envelope)
+    end
+
+    context 'when the RFC822 Message-ID was already processed' do
       before do
-        allow(ProcessedEmail).to receive(:already_processed?).with(message_id, email_account).and_return(true)
+        create(:processed_email, message_id: rfc_message_id, email_account: email_account)
       end
 
-      it 'returns the standard skip result without touching the imap service' do
-        expect(mock_imap_service).not_to receive(:fetch_envelope)
+      it 'skips with the standard result before any parsing or conflict work' do
+        expect(Services::ConflictDetectionService).not_to receive(:new)
+        expect(ProcessEmailJob).not_to receive(:perform_later)
+        expect(mock_imap_service).not_to receive(:fetch_body_structure)
+        expect(mock_imap_service).not_to receive(:fetch_text_body)
 
         result = processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
 
         expect(result).to eq(processed: false, expense_created: false)
-      end
-
-      it 'never invokes conflict detection' do
-        expect(Services::ConflictDetectionService).not_to receive(:new)
-
-        processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
       end
 
       it 'is counted as skipped (not processed) at the process_emails level' do
@@ -820,45 +831,76 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
           processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
         }.not_to change(ProcessedEmail, :count)
       end
+
+      it 'matches bracket/case variants through the shared normalization' do
+        variant_envelope = double('envelope',
+          subject: 'BAC - Notificación de transacción',
+          from: nil, date: Time.current,
+          message_id: '  <ABC-123@MAIL.BANK.EXAMPLE>  ')
+        allow(mock_imap_service).to receive(:fetch_envelope).with(message_id).and_return(variant_envelope)
+
+        result = processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+
+        expect(result).to eq(processed: false, expense_created: false)
+      end
     end
 
-    context 'when the message has not been processed yet' do
+    # REGRESSION (architect): IMAP sequence numbers are unstable across
+    # sessions (RFC 3501 — expunges shift them). A reused sequence position
+    # carrying a DIFFERENT email must be processed, never skipped.
+    context 'when the same sequence number carries a different Message-ID' do
       before do
-        allow(ProcessedEmail).to receive(:already_processed?).and_return(false)
-        allow(mock_imap_service).to receive(:fetch_envelope).and_return(nil)
+        create(:processed_email, message_id: '<some-other-email@mail.bank.example>', email_account: email_account)
+        allow(processor_without_metrics).to receive(:extract_email_data).and_return(nil)
       end
 
-      it 'proceeds to fetch the envelope' do
+      it 'does not skip — proceeds into the transaction pipeline' do
         processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
 
-        expect(mock_imap_service).to have_received(:fetch_envelope).with(message_id)
+        expect(processor_without_metrics).to have_received(:extract_email_data)
+      end
+    end
+
+    context 'when the Message-ID header is nil (malformed email)' do
+      let(:envelope) do
+        double('envelope',
+          subject: 'BAC - Notificación de transacción',
+          from: nil, date: Time.current,
+          message_id: nil)
+      end
+
+      before do
+        allow(processor_without_metrics).to receive(:extract_email_data).and_return(nil)
+      end
+
+      it 'never skips, even when a blank-keyed record could theoretically match' do
+        processor_without_metrics.send(:process_single_email, message_id, mock_imap_service)
+
+        expect(processor_without_metrics).to have_received(:extract_email_data)
       end
     end
   end
 
   describe '#process_email_with_metrics recording at terminal outcomes', integration: true do
-    let(:message_id) { 55 }
-
-    before do
-      allow(ProcessedEmail).to receive(:already_processed?).and_return(false)
-    end
+    let(:message_id) { 55 } # IMAP sequence number
+    let(:rfc_message_id) { '<Terminal-55@Mail.Bank.Example>' }
 
     context 'when the email is not a transaction email' do
       let(:non_transaction_envelope) do
-        double('envelope', subject: 'Newsletter', from: [ double('from', mailbox: 'news', host: 'example.com') ], date: Time.current)
+        double('envelope', subject: 'Newsletter', from: [ double('from', mailbox: 'news', host: 'example.com') ], date: Time.current, message_id: rfc_message_id)
       end
 
       before do
         allow(mock_imap_service).to receive(:fetch_envelope).and_return(non_transaction_envelope)
       end
 
-      it 'records a ProcessedEmail for the skipped message' do
+      it 'records a ProcessedEmail keyed on the normalized RFC822 Message-ID' do
         expect {
           processor_without_metrics.send(:process_email_with_metrics, message_id, mock_imap_service)
         }.to change(ProcessedEmail, :count).by(1)
 
         recorded = ProcessedEmail.last
-        expect(recorded.message_id).to eq(message_id.to_s)
+        expect(recorded.message_id).to eq('terminal-55@mail.bank.example')
         expect(recorded.email_account).to eq(email_account)
         expect(recorded.user).to eq(email_account.user)
         expect(recorded.subject).to eq('Newsletter')
@@ -876,19 +918,32 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
           a_string_matching(/Failed to record processed email/)
         )
       end
+
+      context 'with a nil Message-ID header' do
+        let(:non_transaction_envelope) do
+          double('envelope', subject: 'Newsletter', from: nil, date: Time.current, message_id: nil)
+        end
+
+        it 'records nothing and does not raise' do
+          expect {
+            processor_without_metrics.send(:process_email_with_metrics, message_id, mock_imap_service)
+          }.not_to change(ProcessedEmail, :count)
+        end
+      end
     end
 
     context 'when a conflict is detected for a transaction email' do
       let(:sync_session_for_conflict) { instance_double(SyncSession, id: 1) }
       let(:processor_with_session) { described_class.new(email_account, sync_session: sync_session_for_conflict) }
       let(:transaction_envelope) do
-        double('envelope', subject: 'Notificación de transacción', from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ], date: Time.current)
+        double('envelope', subject: 'Notificación de transacción', from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ], date: Time.current, message_id: rfc_message_id)
       end
 
       before do
         allow(mock_imap_service).to receive(:fetch_envelope).and_return(transaction_envelope)
         allow(processor_with_session).to receive(:extract_email_data).and_return({
           message_id: message_id,
+          rfc_message_id: rfc_message_id,
           from: 'bank@bac.co.cr',
           subject: 'Notificación de transacción',
           date: Time.current,
@@ -898,10 +953,12 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
         allow(ProcessEmailJob).to receive(:perform_later)
       end
 
-      it 'records a ProcessedEmail for the conflict-skipped message' do
+      it 'records a ProcessedEmail keyed on the normalized RFC822 Message-ID' do
         expect {
           processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
         }.to change(ProcessedEmail, :count).by(1)
+
+        expect(ProcessedEmail.last.message_id).to eq('terminal-55@mail.bank.example')
       end
 
       it 'does not enqueue ProcessEmailJob' do

--- a/spec/support/email_processing_processor_test_helper.rb
+++ b/spec/support/email_processing_processor_test_helper.rb
@@ -57,12 +57,16 @@ module EmailProcessingProcessorTestHelper
 
   # Mock envelope structure
   class MockEnvelope
-    attr_accessor :subject, :date, :from
+    attr_accessor :subject, :date, :from, :message_id
 
-    def initialize(subject:, date: Time.current, from: nil)
+    def initialize(subject:, date: Time.current, from: nil, message_id: :generate)
       @subject = subject
       @date = date
       @from = from || [ MockAddress.new("test", "example.com") ]
+      # RFC822 Message-ID header (Net::IMAP::Envelope#message_id). Defaults to
+      # a unique id per envelope instance; pass nil explicitly to simulate a
+      # malformed email missing the header.
+      @message_id = message_id == :generate ? "<mock-#{SecureRandom.hex(8)}@example.com>" : message_id
     end
   end
 
@@ -116,11 +120,12 @@ module EmailProcessingProcessorTestHelper
     create_imap_error(Net::IMAP::ByeResponseError, message)
   end
 
-  def create_transaction_envelope(subject = "Notificación de transacción")
+  def create_transaction_envelope(subject = "Notificación de transacción", message_id: :generate)
     MockEnvelope.new(
       subject: subject,
       date: 1.day.ago,
-      from: [ MockAddress.new("notificacion", "bank.com") ]
+      from: [ MockAddress.new("notificacion", "bank.com") ],
+      message_id: message_id
     )
   end
 


### PR DESCRIPTION
## Why

The IMAP fetcher searches by SINCE-date only, so every sync re-processes the entire 1-week window — re-synced duplicates then churn through conflict detection, creating the noise that piled up 75 permanently-pending conflicts in prod. The `processed_emails` table (unique on message_id + account) existed since 2025-08 but was never wired to anything.

## What

- **Skip-gate**: right after the (single) envelope fetch, `ProcessedEmail.already_processed?` short-circuits the message — a re-synced email costs one envelope fetch + one indexed query. Nothing bypasses the gate.
- **Recording at terminal outcomes only** (never at enqueue): job success AND marked-duplicate, non-transaction gate, conflict-skip. Idempotent writes; recording failures log and never break expense processing.
- **Key = RFC822 Message-ID** (`envelope.message_id`), NOT the IMAP sequence number — sequence numbers are RFC-3501-unstable and a reused one would have silently dropped a real expense (caught as a blocker in architect review; reworked). Normalization (strip brackets/downcase/presence) centralized in `ProcessedEmail.normalize_message_id`, used by the gate, both writers, and a `before_validation`.
- **Safety direction**: nil/blank Message-ID → never skip, never record (one wasted re-parse beats one dropped expense).

## Review trail

Backend-architect round 1: BLOCKER (sequence-number instability → silent data loss) with full RFC 3501 evidence chain. Rework re-keyed on Message-ID. Round 2: **CLEARED — ship it**; verified read/write key identity, single envelope fetch, no gate bypass, and the demanded collision regression (same sequence position + different Message-ID → expense IS created).

## Tests

Collision regression, nil-header safety, bracket/case normalization round-trips, recording at every terminal outcome, record-failure-never-raises, full re-sync integration (two syncs → one Expense, one ProcessedEmail, second run skipped). Full unit suite: 7991+ examples via pre-commit, 0 failures. RuboCop + Brakeman clean.