### PR TITLE
fix(sync): duplicates skip silently — no more ghost SyncConflicts

### DIFF
--- a/app/services/conflict_detection_service.rb
+++ b/app/services/conflict_detection_service.rb
@@ -1,5 +1,42 @@
 module Services
   class ConflictDetectionService
+  # Outcome of a single conflict-detection attempt.
+  #
+  # This replaces the old ambiguous return contract where `nil` meant BOTH
+  # "no matching expense found" (proceed with normal expense creation) AND,
+  # via create_conflict's high-confidence skip, "duplicate silently
+  # discarded" (must NOT proceed). Callers could not tell those apart —
+  # Services::EmailProcessing::Processor#detect_and_handle_conflict treated
+  # any nil as "no conflict" and let the caller create a brand-new Expense
+  # for what was actually an already-seen duplicate.
+  #
+  #   :no_conflict       — no matching expense found, or best match scored
+  #                         below SIMILAR_THRESHOLD. Caller should proceed
+  #                         with normal expense creation.
+  #   :duplicate_skipped — score >= DUPLICATE_THRESHOLD. This is not
+  #                         ambiguous — it's the same expense seen again.
+  #                         The incoming duplicate is soft-deleted and saved
+  #                         (for audit/history) but no SyncConflict row is
+  #                         created. Caller must stop and must NOT create a
+  #                         new expense for it.
+  #   :conflict          — SIMILAR_THRESHOLD <= score < DUPLICATE_THRESHOLD
+  #                         (or an "updated"/"needs_review" case). A
+  #                         SyncConflict row was persisted for human review.
+  #                         Caller must stop.
+  Result = Struct.new(:outcome, :conflict, :existing_expense, :duplicate_expense, :similarity_score, keyword_init: true) do
+    def no_conflict?
+      outcome == :no_conflict
+    end
+
+    def duplicate_skipped?
+      outcome == :duplicate_skipped
+    end
+
+    def conflict?
+      outcome == :conflict
+    end
+  end
+
   attr_reader :sync_session, :errors, :metrics_collector
 
   DUPLICATE_THRESHOLD = 90.0 # 90% similarity = duplicate
@@ -25,7 +62,7 @@ module Services
   def perform_conflict_detection(new_expense_data)
     # Find potential duplicates based on key fields
     candidates = find_candidate_expenses(new_expense_data)
-    return nil if candidates.empty?
+    return no_conflict_result if candidates.empty?
 
     # Calculate similarity scores and find best match
     best_match = nil
@@ -40,7 +77,7 @@ module Services
       end
     end
 
-    return nil unless best_match && highest_score >= SIMILAR_THRESHOLD
+    return no_conflict_result unless best_match && highest_score >= SIMILAR_THRESHOLD
 
     # Determine conflict type
     conflict_type = determine_conflict_type(highest_score, best_match, new_expense_data)
@@ -48,7 +85,7 @@ module Services
     # Calculate differences
     differences = calculate_differences(best_match, new_expense_data)
 
-    # Create conflict record
+    # Create conflict record (or silently skip, for obvious duplicates)
     create_conflict(
       existing_expense: best_match,
       new_expense_data: new_expense_data,
@@ -58,24 +95,31 @@ module Services
     )
   end
 
+  # Returns an Array of the SyncConflict records actually persisted.
+  # :duplicate_skipped and :no_conflict outcomes contribute nothing to the
+  # array — they were never conflicts a human needs to review.
   def detect_conflicts_batch(new_expenses_data)
-    conflicts = []
-
-    new_expenses_data.each do |expense_data|
-      conflict = detect_conflict_for_expense(expense_data)
-      conflicts << conflict if conflict
+    new_expenses_data.filter_map do |expense_data|
+      result = detect_conflict_for_expense(expense_data)
+      result.conflict if result.conflict?
     end
-
-    conflicts
   end
 
+  # Historically this resolved SyncConflict rows that create_conflict had
+  # created despite scoring >= DUPLICATE_THRESHOLD (an "obvious duplicate,
+  # auto-resolve later" pattern). Now that create_conflict silently skips
+  # duplicate creation altogether (see Result::duplicate_skipped), no new
+  # conflicts in this score range are ever created — this method is a
+  # defense-in-depth sweep for legacy rows (or any future path that
+  # bypasses the silent-skip logic) rather than a load-bearing part of the
+  # normal flow.
   def auto_resolve_obvious_duplicates
     resolved_count = 0
 
     # Find high-confidence duplicates
     high_confidence_duplicates = sync_session.sync_conflicts
       .unresolved
-      .where("similarity_score >= ?", 95.0)
+      .where("similarity_score >= ?", DUPLICATE_THRESHOLD)
       .where(conflict_type: "duplicate")
 
     high_confidence_duplicates.find_each do |conflict|
@@ -284,12 +328,17 @@ module Services
   end
 
   def create_conflict(existing_expense:, new_expense_data:, conflict_type:, similarity_score:, differences:)
-    # Skip creating conflict records for obvious duplicates (≥95% similarity).
-    # These are noise — the existing expense is always kept and the duplicate is discarded.
-    if conflict_type == "duplicate" && similarity_score >= 95.0
-      Rails.logger.info "[ConflictDetection] Skipped obvious duplicate (#{similarity_score}%): " \
-                        "existing=##{existing_expense.id} merchant=#{existing_expense.merchant_name}"
-      return nil
+    # determine_conflict_type only ever assigns "duplicate" when
+    # score >= DUPLICATE_THRESHOLD, so this is exactly the silent-skip range.
+    # An exact/duplicate re-detection is NOT a conflict for human review —
+    # it's the same expense seen again — so no SyncConflict row is created.
+    # Only genuinely ambiguous "similar" (70-89%) scores still create one.
+    if conflict_type == "duplicate"
+      return skip_silent_duplicate(
+        existing_expense: existing_expense,
+        new_expense_data: new_expense_data,
+        similarity_score: similarity_score
+      )
     end
 
     # Create temporary expense for new data (will be saved if resolution keeps it)
@@ -299,10 +348,11 @@ module Services
       currency: new_expense_data[:currency] || "crc"
     )
 
-    # Soft-delete duplicate expenses so they are excluded from the unique partial
+    # Soft-delete "similar" expenses so they are excluded from the unique partial
     # index on (email_account_id, amount, transaction_date, merchant_name)
     # WHERE deleted_at IS NULL. The expense is retained for conflict resolution.
-    expense_attrs[:deleted_at] = Time.current if conflict_type.in?(%w[duplicate similar])
+    # ("duplicate" never reaches here — it returns via skip_silent_duplicate above.)
+    expense_attrs[:deleted_at] = Time.current if conflict_type == "similar"
 
     new_expense = Expense.new(expense_attrs)
     # PR 5: expenses require user_id (NOT NULL). Inherit from the target
@@ -311,7 +361,7 @@ module Services
     new_expense.user ||= new_expense.email_account&.user
 
     conflict = ActiveRecord::Base.transaction(requires_new: true) do
-      new_expense.save! if conflict_type == "duplicate" || conflict_type == "similar"
+      new_expense.save! if conflict_type == "similar"
 
       sync_session.sync_conflicts.create!(
         user: sync_session.user,
@@ -331,11 +381,48 @@ module Services
     # Broadcast AFTER transaction commits to avoid sending stale IDs
     broadcast_conflict_detected(conflict)
 
-    conflict
+    Result.new(outcome: :conflict, conflict: conflict, existing_expense: existing_expense, similarity_score: similarity_score)
   rescue => e
     Rails.logger.error "[ConflictDetection] Failed to create conflict: #{e.message}"
     add_error("Failed to create conflict: #{e.message}")
-    nil
+    no_conflict_result
+  end
+
+  # Duplicate re-detection (>= DUPLICATE_THRESHOLD) is not ambiguous — it's
+  # the same expense seen again — so it is handled silently: the incoming
+  # duplicate is saved soft-deleted (same bookkeeping as the "similar" path,
+  # for audit/history and to satisfy the unique partial index), but no
+  # SyncConflict row is created. This is what eliminates the ghost-conflict
+  # noise (SyncConflict rows whose new_expense gets cleaned up later, leaving
+  # an unresolvable "conflict" with nothing left to resolve).
+  def skip_silent_duplicate(existing_expense:, new_expense_data:, similarity_score:)
+    expense_attrs = new_expense_data.merge(
+      status: "duplicate",
+      currency: new_expense_data[:currency] || "crc",
+      deleted_at: Time.current
+    )
+
+    new_expense = Expense.new(expense_attrs)
+    new_expense.user ||= new_expense.email_account&.user
+    new_expense.save!
+
+    Rails.logger.info "[ConflictDetection] Silently skipped duplicate (#{similarity_score}%): " \
+                      "existing=##{existing_expense.id} new=##{new_expense.id} merchant=#{existing_expense.merchant_name}"
+
+    Result.new(
+      outcome: :duplicate_skipped,
+      existing_expense: existing_expense,
+      duplicate_expense: new_expense,
+      similarity_score: similarity_score
+    )
+  rescue => e
+    Rails.logger.error "[ConflictDetection] Failed to save silently-skipped duplicate: #{e.message}"
+    add_error("Failed to save silently-skipped duplicate: #{e.message}")
+    no_conflict_result
+  end
+
+  def no_conflict_result
+    Result.new(outcome: :no_conflict)
   end
 
   def broadcast_conflict_detected(conflict)

--- a/app/services/conflict_detection_service.rb
+++ b/app/services/conflict_detection_service.rb
@@ -396,15 +396,24 @@ module Services
   # noise (SyncConflict rows whose new_expense gets cleaned up later, leaving
   # an unresolvable "conflict" with nothing left to resolve).
   def skip_silent_duplicate(existing_expense:, new_expense_data:, similarity_score:)
-    expense_attrs = new_expense_data.merge(
-      status: "duplicate",
-      currency: new_expense_data[:currency] || "crc",
-      deleted_at: Time.current
-    )
+    # The batch path (SyncService#detect_conflicts) sends already-persisted
+    # expenses WITH their :id (needed upstream for self-match exclusion).
+    # Re-inserting those would raise a PK collision — mark the existing row
+    # instead of creating an audit copy.
+    if (persisted = new_expense_data[:id] && Expense.unscoped.find_by(id: new_expense_data[:id]))
+      persisted.update!(status: "duplicate", deleted_at: persisted.deleted_at || Time.current)
+      new_expense = persisted
+    else
+      expense_attrs = new_expense_data.merge(
+        status: "duplicate",
+        currency: new_expense_data[:currency] || "crc",
+        deleted_at: Time.current
+      )
 
-    new_expense = Expense.new(expense_attrs)
-    new_expense.user ||= new_expense.email_account&.user
-    new_expense.save!
+      new_expense = Expense.new(expense_attrs.except(:id))
+      new_expense.user ||= new_expense.email_account&.user
+      new_expense.save!
+    end
 
     Rails.logger.info "[ConflictDetection] Silently skipped duplicate (#{similarity_score}%): " \
                       "existing=##{existing_expense.id} new=##{new_expense.id} merchant=#{existing_expense.merchant_name}"

--- a/app/services/conflict_detection_service.rb
+++ b/app/services/conflict_detection_service.rb
@@ -341,27 +341,38 @@ module Services
       )
     end
 
-    # Create temporary expense for new data (will be saved if resolution keeps it)
-    # Ensure all required fields are present
-    expense_attrs = new_expense_data.merge(
-      status: "duplicate",
-      currency: new_expense_data[:currency] || "crc"
-    )
+    # The batch path (SyncService#detect_conflicts) sends already-persisted
+    # expenses WITH their :id (needed upstream for self-match exclusion).
+    # Reference that row as-is — resolution (keep_existing/keep_new) decides
+    # its fate — instead of inserting a copy that PK-collides on the
+    # carried-over :id (same landmine skip_silent_duplicate defuses).
+    persisted = new_expense_data[:id] && Expense.unscoped.find_by(id: new_expense_data[:id])
 
-    # Soft-delete "similar" expenses so they are excluded from the unique partial
-    # index on (email_account_id, amount, transaction_date, merchant_name)
-    # WHERE deleted_at IS NULL. The expense is retained for conflict resolution.
-    # ("duplicate" never reaches here — it returns via skip_silent_duplicate above.)
-    expense_attrs[:deleted_at] = Time.current if conflict_type == "similar"
+    if persisted
+      new_expense = persisted
+    else
+      # Create temporary expense for new data (will be saved if resolution keeps it)
+      # Ensure all required fields are present
+      expense_attrs = new_expense_data.merge(
+        status: "duplicate",
+        currency: new_expense_data[:currency] || "crc"
+      )
 
-    new_expense = Expense.new(expense_attrs)
-    # PR 5: expenses require user_id (NOT NULL). Inherit from the target
-    # email_account so this service works both in the webhook flow (attrs
-    # carry email_account_id) and when a caller pre-sets user_id explicitly.
-    new_expense.user ||= new_expense.email_account&.user
+      # Soft-delete "similar" expenses so they are excluded from the unique partial
+      # index on (email_account_id, amount, transaction_date, merchant_name)
+      # WHERE deleted_at IS NULL. The expense is retained for conflict resolution.
+      # ("duplicate" never reaches here — it returns via skip_silent_duplicate above.)
+      expense_attrs[:deleted_at] = Time.current if conflict_type == "similar"
+
+      new_expense = Expense.new(expense_attrs.except(:id))
+      # PR 5: expenses require user_id (NOT NULL). Inherit from the target
+      # email_account so this service works both in the webhook flow (attrs
+      # carry email_account_id) and when a caller pre-sets user_id explicitly.
+      new_expense.user ||= new_expense.email_account&.user
+    end
 
     conflict = ActiveRecord::Base.transaction(requires_new: true) do
-      new_expense.save! if conflict_type == "similar"
+      new_expense.save! if conflict_type == "similar" && !persisted
 
       sync_session.sync_conflicts.create!(
         user: sync_session.user,

--- a/app/services/email_processing/processor.rb
+++ b/app/services/email_processing/processor.rb
@@ -92,11 +92,20 @@ module Services::EmailProcessing
       # Check for conflicts before creating expense
       conflict_result = detect_and_handle_conflict(email_data)
 
-      if conflict_result.nil?
-        # Conflict detected — this email will never be re-processed successfully,
-        # so record it now (terminal outcome).
+      case conflict_result
+      when :conflict, :duplicate_skipped
+        # Both outcomes are terminal — a SyncConflict was persisted for human
+        # review (:conflict), or the incoming email was recognized as an
+        # already-seen duplicate and silently discarded (:duplicate_skipped).
+        # Either way this email will never be re-processed successfully, so
+        # record it now (terminal-outcome pattern from PR #548).
         record_processed_email(email_data[:rfc_message_id], subject: email_data[:subject], from_address: email_data[:from])
-        { processed: true, expense_created: false, conflict_detected: true }
+        {
+          processed: true,
+          expense_created: false,
+          conflict_detected: conflict_result == :conflict,
+          duplicate_skipped: conflict_result == :duplicate_skipped
+        }
       else
         # No conflict — pass pre-parsed data if available
         pre_parsed = if conflict_result.is_a?(Hash)
@@ -288,9 +297,10 @@ module Services::EmailProcessing
     end
 
     # Returns:
-    #   nil        — conflict detected, processing should stop
-    #   Hash       — no conflict, pre-parsed expense data for reuse
-    #   false      — parsing failed or no rule, continue without pre-parsed data
+    #   :conflict          — SyncConflict persisted for human review; stop, do NOT create the expense
+    #   :duplicate_skipped — exact/near-exact duplicate silently discarded (no SyncConflict); stop, do NOT create the expense
+    #   Hash               — no conflict, pre-parsed expense data for reuse
+    #   false              — parsing failed or no rule, continue without pre-parsed data
     def detect_and_handle_conflict(email_data)
       # Parse expense data from email to extract fields without creating expense
       parsing_rule = ParsingRule.active.for_bank(email_account.bank_name).first
@@ -317,9 +327,14 @@ module Services::EmailProcessing
       if sync_session
         # Use conflict detection service with metrics tracking
         detector = Services::ConflictDetectionService.new(sync_session, metrics_collector: @metrics_collector)
-        conflict = detector.detect_conflict_for_expense(expense_data)
+        result = detector.detect_conflict_for_expense(expense_data)
 
-        return nil if conflict # Conflict detected — stop processing
+        # Explicit outcome check — replaces the old `return nil if conflict`
+        # ambiguity, where a bare nil from the service could mean either
+        # "no conflict, proceed" or "duplicate silently skipped, stop" and
+        # the two were indistinguishable here.
+        return :conflict if result.conflict?
+        return :duplicate_skipped if result.duplicate_skipped?
       end
 
       expense_data # No conflict — return parsed data for reuse

--- a/lib/tasks/sync_conflicts_cleanup.rake
+++ b/lib/tasks/sync_conflicts_cleanup.rake
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# fix/silent-duplicate-skip: One-off cleanup for the SyncConflict ghost rows
+# that predate the silent-duplicate-skip policy change.
+#
+# Before this fix, ConflictDetectionService created a SyncConflict row for
+# every "duplicate" detection (>=90% similarity) and soft-deleted the
+# incoming new_expense. Nothing ever un-persists the SyncConflict row itself,
+# so once the soft-deleted new_expense is later hard-deleted (or simply
+# excluded by Expense's default_scope, which hides deleted_at rows), the
+# conflict becomes an unresolvable ghost: "the same expense seen again", with
+# nothing left to actually resolve. Production accumulated 75 such rows, all
+# status=pending.
+#
+# Usage:
+#   bin/rails sync_conflicts:cleanup_orphaned
+#
+# Idempotent — re-running finds zero matching rows once cleaned up, and only
+# ever touches status=pending rows whose new_expense is gone or soft-deleted.
+# Resolved/ignored/auto_resolved conflicts and conflicts with a live
+# new_expense are never touched.
+namespace :sync_conflicts do
+  desc "Delete orphaned pending SyncConflict rows whose new_expense is missing or soft-deleted"
+  task cleanup_orphaned: :environment do
+    orphaned_scope = SyncConflict
+      .where(status: "pending")
+      .where(
+        "new_expense_id IS NULL OR NOT EXISTS (" \
+        "SELECT 1 FROM expenses e WHERE e.id = sync_conflicts.new_expense_id AND e.deleted_at IS NULL" \
+        ")"
+      )
+
+    found = orphaned_scope.count
+    # destroy_all (not delete_all) so dependent conflict_resolutions rows are
+    # cleaned up too, even though pending conflicts rarely have any.
+    deleted = orphaned_scope.destroy_all.size
+
+    message = "[SyncConflict cleanup] pending+orphaned rows found=#{found} deleted=#{deleted}"
+    Rails.logger.info message
+    puts message
+  end
+end

--- a/spec/services/conflict_detection_service_spec.rb
+++ b/spec/services/conflict_detection_service_spec.rb
@@ -89,6 +89,35 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       end
     end
 
+    context 'when the incoming duplicate is an already-persisted expense (batch path sends :id)' do
+      before { existing_expense }
+
+      it 'marks the persisted row duplicate instead of inserting an audit copy' do
+        # Case-variant merchant_name: dodges the exact-string unique index
+        # (as real bank emails do) while normalizing/scoring identically.
+        persisted_dup = create(:expense, email_account: existing_expense.email_account,
+                                         user: existing_expense.user,
+                                         amount: existing_expense.amount,
+                                         transaction_date: existing_expense.transaction_date,
+                                         merchant_name: existing_expense.merchant_name.upcase,
+                                         merchant_normalized: existing_expense.merchant_normalized,
+                                         description: existing_expense.description,
+                                         status: 'processed')
+        data = persisted_dup.attributes.symbolize_keys
+
+        expect {
+          result = service.detect_conflict_for_expense(data)
+          expect(result).to be_duplicate_skipped
+          expect(result.duplicate_expense.id).to eq(persisted_dup.id)
+        }.not_to change { Expense.unscoped.count }
+
+        persisted_dup.reload
+        expect(persisted_dup.status).to eq('duplicate')
+        expect(persisted_dup.deleted_at).to be_present
+        expect(SyncConflict.count).to eq(0)
+      end
+    end
+
     context 'when conflict_type is similar' do
       before do
         existing_expense.update(amount: 95.00)

--- a/spec/services/conflict_detection_service_spec.rb
+++ b/spec/services/conflict_detection_service_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
     context 'when exact duplicate exists' do
       before { existing_expense }
 
-      it 'skips obvious duplicates with high similarity (>=95%)' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
-        expect(conflict).to be_nil
+      it 'silently skips obvious duplicates (>=90% similarity)' do
+        result = service.detect_conflict_for_expense(new_expense_data)
+        expect(result).to be_duplicate_skipped
       end
 
       it 'does not create a conflict record for obvious duplicates' do
@@ -41,19 +41,41 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
           service.detect_conflict_for_expense(new_expense_data)
         }.not_to change(SyncConflict, :count)
       end
+
+      it 'still soft-deletes and saves the incoming duplicate expense (audit trail)' do
+        # Expense has a default_scope excluding deleted_at rows (SoftDelete concern),
+        # so assert against .unscoped rather than the plain .count.
+        expect {
+          service.detect_conflict_for_expense(new_expense_data)
+        }.to change { Expense.unscoped.count }.by(1)
+
+        duplicate = Expense.unscoped.order(:created_at).last
+        expect(duplicate.status).to eq('duplicate')
+        expect(duplicate.deleted_at).to be_present
+      end
+
+      it 'logs the skip at info level with both expense ids and the score' do
+        allow(Rails.logger).to receive(:info).and_call_original
+        result = service.detect_conflict_for_expense(new_expense_data)
+
+        expect(Rails.logger).to have_received(:info).with(
+          a_string_matching(/Silently skipped duplicate.*existing=##{existing_expense.id}.*new=##{result.duplicate_expense.id}/)
+        )
+      end
     end
 
-    context 'when similar expense exists' do
+    context 'when similar expense exists (70-89% similarity)' do
       before do
         existing_expense.update(amount: 95.00) # Slightly different amount
       end
 
-      it 'creates a similar conflict' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
+      it 'creates a similar conflict for human review' do
+        result = service.detect_conflict_for_expense(new_expense_data)
 
-        expect(conflict).to be_present
-        expect(conflict.conflict_type).to eq('similar')
-        expect(conflict.similarity_score).to be_between(70, 90)
+        expect(result).to be_conflict
+        expect(result.conflict).to be_present
+        expect(result.conflict.conflict_type).to eq('similar')
+        expect(result.conflict.similarity_score).to be_between(70, 90)
       end
     end
 
@@ -61,8 +83,9 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       before { existing_expense }
 
       it 'skips creating conflict for obvious duplicates' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
-        expect(conflict).to be_nil
+        result = service.detect_conflict_for_expense(new_expense_data)
+        expect(result).to be_duplicate_skipped
+        expect(result.conflict).to be_nil
       end
     end
 
@@ -72,11 +95,11 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       end
 
       it 'saves the new expense with deleted_at set' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
+        result = service.detect_conflict_for_expense(new_expense_data)
 
-        expect(conflict).to be_present
-        expect(conflict.conflict_type).to eq('similar')
-        expect(conflict.new_expense.deleted_at).to be_present
+        expect(result).to be_conflict
+        expect(result.conflict.conflict_type).to eq('similar')
+        expect(result.conflict.new_expense.deleted_at).to be_present
       end
     end
 
@@ -89,9 +112,10 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
         )
       end
 
-      it 'returns nil' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
-        expect(conflict).to be_nil
+      it 'returns a no_conflict result' do
+        result = service.detect_conflict_for_expense(new_expense_data)
+        expect(result).to be_no_conflict
+        expect(result.conflict).to be_nil
       end
     end
 
@@ -117,8 +141,8 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       end
 
       it 'selects the best match' do
-        conflict = service.detect_conflict_for_expense(new_expense_data)
-        expect(conflict.existing_expense).to eq(exact_match)
+        result = service.detect_conflict_for_expense(new_expense_data)
+        expect(result.existing_expense).to eq(exact_match)
       end
     end
   end
@@ -158,11 +182,12 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
         )
       end
 
-      it 'returns array (obvious duplicates are skipped)' do
+      it 'returns only persisted SyncConflict records (obvious duplicates are skipped)' do
         conflicts = service.detect_conflicts_batch(new_expenses_data)
 
         expect(conflicts).to be_an(Array)
-        # Obvious duplicates (>=95% similarity) are now skipped entirely
+        # Obvious duplicates (>=90% similarity) are silently skipped and never
+        # produce a SyncConflict, so they never show up in this array either.
         expect(conflicts.compact).to be_empty
       end
     end
@@ -220,6 +245,31 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       service.auto_resolve_obvious_duplicates
 
       expect(high_confidence_conflict.reload.resolution_action).to eq('keep_existing')
+    end
+
+    context 'with a legacy conflict scored in the 90-94% band' do
+      let!(:existing_expense_for_boundary) { create(:expense, email_account: email_account) }
+      let!(:new_expense_for_boundary) { create(:expense, email_account: email_account, status: :pending) }
+
+      let!(:boundary_conflict) do
+        conflict = create(:sync_conflict,
+          sync_session: sync_session,
+          existing_expense: existing_expense_for_boundary,
+          new_expense: new_expense_for_boundary,
+          similarity_score: 92.0,
+          conflict_type: 'duplicate',
+          status: 'pending'
+        )
+        conflict.update_column(:similarity_score, 92.0)
+        conflict
+      end
+
+      it 'also resolves it (threshold now matches DUPLICATE_THRESHOLD, not the old 95% cutoff)' do
+        resolved_count = service.auto_resolve_obvious_duplicates
+
+        expect(boundary_conflict.reload.status).to eq('resolved')
+        expect(resolved_count).to eq(2) # high_confidence_conflict + boundary_conflict
+      end
     end
   end
 
@@ -321,20 +371,59 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       }.not_to change(Expense, :count)
     end
 
-    it 'skips obvious duplicates (>=95% similarity) without creating records' do
+    it 'skips creating a SyncConflict for obvious duplicates (>=95% similarity) but still saves the soft-deleted duplicate' do
+      result = nil
+      # Expense has a default_scope excluding deleted_at rows (SoftDelete concern),
+      # so assert against .unscoped rather than the plain .count.
+      expect {
+        result = service.send(
+          :create_conflict,
+          existing_expense: existing_expense,
+          new_expense_data: new_expense_data,
+          conflict_type: 'duplicate',
+          similarity_score: 95.0,
+          differences: {}
+        )
+      }.to change { Expense.unscoped.count }.by(1)
+      expect(SyncConflict.count).to eq(0)
+
+      expect(result).to be_duplicate_skipped
+      expect(result.duplicate_expense.deleted_at).to be_present
+      expect(result.duplicate_expense.status).to eq('duplicate')
+    end
+
+    it 'skips creating a SyncConflict for duplicates right at the 90% boundary' do
       result = service.send(
         :create_conflict,
         existing_expense: existing_expense,
         new_expense_data: new_expense_data,
         conflict_type: 'duplicate',
-        similarity_score: 95.0,
+        similarity_score: 90.0,
         differences: {}
       )
 
-      expect(result).to be_nil
+      expect(result).to be_duplicate_skipped
+      expect(SyncConflict.count).to eq(0)
     end
 
-    it 'returns nil and adds an error when the transaction fails' do
+    it 'still creates a SyncConflict for the 70-89% "similar" band' do
+      result = nil
+      expect {
+        result = service.send(
+          :create_conflict,
+          existing_expense: existing_expense,
+          new_expense_data: new_expense_data,
+          conflict_type: 'similar',
+          similarity_score: 85.0,
+          differences: {}
+        )
+      }.to change(SyncConflict, :count).by(1)
+
+      expect(result).to be_conflict
+      expect(result.conflict.conflict_type).to eq('similar')
+    end
+
+    it 'returns a no_conflict result and adds an error when the transaction fails' do
       allow_any_instance_of(SyncConflict).to receive(:save!).and_raise(
         ActiveRecord::RecordInvalid.new(SyncConflict.new)
       )
@@ -349,7 +438,7 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
         differences: {}
       )
 
-      expect(result).to be_nil
+      expect(result).to be_no_conflict
       expect(service.errors).not_to be_empty
     end
   end

--- a/spec/services/conflict_detection_service_spec.rb
+++ b/spec/services/conflict_detection_service_spec.rb
@@ -118,6 +118,32 @@ RSpec.describe Services::ConflictDetectionService, integration: true do
       end
     end
 
+    context 'when a persisted expense scores in the similar band (batch path sends :id)' do
+      before { existing_expense.update(amount: 95.00) }
+
+      it 'creates the conflict referencing the persisted row without inserting a copy' do
+        persisted_similar = create(:expense, email_account: existing_expense.email_account,
+                                             user: existing_expense.user,
+                                             amount: 100.00,
+                                             transaction_date: existing_expense.transaction_date,
+                                             merchant_name: existing_expense.merchant_name.upcase,
+                                             merchant_normalized: existing_expense.merchant_normalized,
+                                             description: existing_expense.description,
+                                             status: 'processed')
+        data = persisted_similar.attributes.symbolize_keys
+
+        result = nil
+        expect {
+          result = service.detect_conflict_for_expense(data)
+        }.not_to change { Expense.unscoped.count }
+
+        expect(result).to be_conflict
+        expect(result.conflict.conflict_type).to eq('similar')
+        expect(result.conflict.new_expense_id).to eq(persisted_similar.id)
+        expect(persisted_similar.reload.status).to eq('processed') # live row untouched pending resolution
+      end
+    end
+
     context 'when conflict_type is similar' do
       before do
         existing_expense.update(amount: 95.00)

--- a/spec/services/email_processing/processor/conflict_detection_spec.rb
+++ b/spec/services/email_processing/processor/conflict_detection_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
           ).and_return(conflict_detector)
 
           allow(parsing_strategy).to receive(:parse_email).and_return({ amount: 100 })
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           email_data = { body: 'Transaction $100', date: Time.current }
           processor_with_session2.send(:detect_and_handle_conflict, email_data)
@@ -44,7 +44,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
         it 'consistently uses the same sync session across multiple calls' do
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
           allow(parsing_strategy).to receive(:parse_email).and_return({ amount: 100 })
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           email_data = { body: 'Transaction $100', date: Time.current }
 
@@ -67,7 +67,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
           expense_data = { amount: 100, description: 'Purchase' }
           allow(parsing_strategy).to receive(:parse_email).and_return(expense_data)
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
@@ -84,7 +84,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
           partial_data = { amount: nil, description: 'Unknown' }
           allow(parsing_strategy).to receive(:parse_email).and_return(partial_data)
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
@@ -162,12 +162,12 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
         end
 
-        it 'returns nil for exact duplicate transactions (conflict detected)' do
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(true)
+        it 'returns :conflict for exact duplicate transactions (conflict detected)' do
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
-          expect(result).to be_nil
+          expect(result).to eq(:conflict)
           expect(conflict_detector).to have_received(:detect_conflict_for_expense).with(
             hash_including(
               amount: 50.00,
@@ -179,27 +179,37 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
           )
         end
 
-        it 'returns nil for near-duplicate transactions' do
+        it 'returns :conflict for near-duplicate transactions' do
           # Simulate a near-duplicate (same amount, similar time)
           similar_expense_data = expense_data.merge(
             transaction_date: Time.parse('2024-01-15 10:01:00')
           )
 
           allow(parsing_strategy).to receive(:parse_email).and_return(similar_expense_data)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(true)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
-          expect(result).to be_nil
+          expect(result).to eq(:conflict)
         end
 
         it 'returns expense data hash for similar but distinct transactions' do
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
           expect(result).to be_a(Hash)
           expect(result[:amount]).to eq(50.00)
+        end
+
+        it 'returns :duplicate_skipped when the service silently discards an obvious duplicate' do
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+            Services::ConflictDetectionService::Result.new(outcome: :duplicate_skipped)
+          )
+
+          result = processor.send(:detect_and_handle_conflict, email_data)
+
+          expect(result).to eq(:duplicate_skipped)
         end
       end
 
@@ -289,7 +299,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
             metrics_collector: metrics_collector
           ).and_return(conflict_detector)
 
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           processor.send(:detect_and_handle_conflict, email_data)
         end
@@ -317,7 +327,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
 
           allow(SyncSession).to receive_message_chain(:active, :last).and_return(sync_session)
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
@@ -332,7 +342,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
 
           allow(SyncSession).to receive_message_chain(:active, :last).and_return(sync_session)
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 
@@ -348,7 +358,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Conflict Detection', type
 
           allow(SyncSession).to receive_message_chain(:active, :last).and_return(sync_session)
           allow(Services::ConflictDetectionService).to receive(:new).and_return(conflict_detector)
-          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+          allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
           result = processor.send(:detect_and_handle_conflict, email_data)
 

--- a/spec/services/email_processing/processor/duplicate_skip_spec.rb
+++ b/spec/services/email_processing/processor/duplicate_skip_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+require 'support/email_processing_processor_test_helper'
+
+# fix/silent-duplicate-skip: PR #548 made a re-sync of the IDENTICAL email
+# (same RFC822 Message-ID) skip via ProcessedEmail before conflict detection
+# is ever reached. This spec covers the case that still reaches
+# ConflictDetectionService: the SAME transaction arriving under two
+# DIFFERENT Message-IDs within the same sync window (e.g. the bank resends
+# the notification, or two overlapping sync windows both pick it up).
+#
+# Exercises the real ConflictDetectionService (no mocks) end-to-end through
+# Processor#process_emails, to prove the duplicate is discarded silently —
+# no SyncConflict row — while still leaving an auditable soft-deleted
+# Expense and a normal ProcessedEmail record.
+RSpec.describe 'Services::EmailProcessing::Processor - Silent Duplicate Skip', type: :job, integration: true do
+  include EmailProcessingProcessorTestHelper
+  include ActiveJob::TestHelper
+
+  let!(:parsing_rule) { create(:parsing_rule, :bac) }
+  let(:email_account) { create(:email_account, :bac) }
+  let(:sync_session) { create(:sync_session, user: email_account.user) }
+  let(:mock_imap_service) { create_mock_imap_service }
+
+  let(:sample_bac_email) do
+    <<~EMAIL
+      Estimado cliente,
+
+      Le informamos sobre una transacción realizada con su tarjeta de débito BAC:
+
+      Comercio: PTA LEONA SOC
+      Ciudad: SAN JOSE
+      Fecha: Ago 1, 2025, 14:16
+      Monto: CRC 95,000.00
+      Tipo de Transacción: COMPRA
+
+      Si no reconoce esta transacción, contacte inmediatamente al centro de atención al cliente.
+    EMAIL
+  end
+
+  def configure_message(seq, message_id:, body:)
+    mock_imap_service.configure_envelope(seq, create_transaction_envelope('Notificación de transacción', message_id: message_id))
+    mock_imap_service.configure_body_structure(seq, create_plain_text_body_structure)
+    mock_imap_service.configure_text_body(seq, body)
+  end
+
+  def run_sync(sequence_number)
+    result = nil
+    perform_enqueued_jobs do
+      result = Services::EmailProcessing::Processor.new(email_account, sync_session: sync_session)
+                                                     .process_emails([ sequence_number ], mock_imap_service)
+    end
+    result
+  end
+
+  it 'silently skips a same-window duplicate (different Message-ID) without creating a SyncConflict' do
+    configure_message(1, message_id: '<first-55@mail.bank.example>', body: sample_bac_email)
+    configure_message(2, message_id: '<second-55@mail.bank.example>', body: sample_bac_email)
+
+    first_result = run_sync(1)
+    expect(first_result[:processed_count]).to eq(1)
+    expect(first_result[:detected_expenses_count]).to eq(1)
+    expect(Expense.count).to eq(1)
+
+    second_result = run_sync(2)
+
+    # Processed (terminal outcome reached) but no new expense was enqueued.
+    expect(second_result[:processed_count]).to eq(1)
+    expect(second_result[:detected_expenses_count]).to eq(0)
+
+    # No real second expense — only the original, real one is visible...
+    expect(Expense.count).to eq(1)
+    # ...but the incoming duplicate WAS saved (soft-deleted) for audit/history.
+    expect(Expense.unscoped.count).to eq(2)
+    duplicate = Expense.unscoped.order(:created_at).last
+    expect(duplicate.status).to eq('duplicate')
+    expect(duplicate.deleted_at).to be_present
+
+    # The whole point of this fix: no SyncConflict noise for exact/duplicate
+    # re-detections — only genuinely ambiguous (70-89%) cases would create one.
+    expect(SyncConflict.count).to eq(0)
+
+    # Both emails reached a terminal outcome and are recorded so a future
+    # re-sync of either Message-ID short-circuits before conflict detection.
+    expect(ProcessedEmail.count).to eq(2)
+  end
+end

--- a/spec/services/email_processing/processor/metrics_tracking_spec.rb
+++ b/spec/services/email_processing/processor/metrics_tracking_spec.rb
@@ -133,7 +133,9 @@ RSpec.describe 'Services::EmailProcessing::Processor - Metrics Tracking', type: 
           metrics_collector: metrics_collector
         ).and_return(conflict_detector)
 
-        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+          Services::ConflictDetectionService::Result.new(outcome: :no_conflict)
+        )
 
         processor.send(:detect_and_handle_conflict, email_data)
       end
@@ -148,7 +150,7 @@ RSpec.describe 'Services::EmailProcessing::Processor - Metrics Tracking', type: 
             email_account_id: email_account.id,
             raw_email_content: email_data[:body]
           )
-        )
+        ).and_return(Services::ConflictDetectionService::Result.new(outcome: :no_conflict))
 
         processor.send(:detect_and_handle_conflict, email_data)
       end

--- a/spec/services/email_processing/processor_spec.rb
+++ b/spec/services/email_processing/processor_spec.rb
@@ -715,15 +715,28 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
         allow(Services::ConflictDetectionService).to receive(:new).with(sync_session, metrics_collector: metrics_collector).and_return(conflict_detector)
       end
 
-      it 'returns nil when conflict is detected' do
-        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(true)
+      it 'returns :conflict when a conflict is detected' do
+        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+          Services::ConflictDetectionService::Result.new(outcome: :conflict)
+        )
 
         result = processor_with_session.send(:detect_and_handle_conflict, email_data)
-        expect(result).to be_nil
+        expect(result).to eq(:conflict)
+      end
+
+      it 'returns :duplicate_skipped when the service silently discards a duplicate' do
+        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+          Services::ConflictDetectionService::Result.new(outcome: :duplicate_skipped)
+        )
+
+        result = processor_with_session.send(:detect_and_handle_conflict, email_data)
+        expect(result).to eq(:duplicate_skipped)
       end
 
       it 'returns expense data hash when no conflict' do
-        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+          Services::ConflictDetectionService::Result.new(outcome: :no_conflict)
+        )
 
         result = processor_with_session.send(:detect_and_handle_conflict, email_data)
         expect(result).to be_a(Hash)
@@ -733,7 +746,9 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
       end
 
       it 'does not call SyncSession.active.last' do
-        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(false)
+        allow(conflict_detector).to receive(:detect_conflict_for_expense).and_return(
+          Services::ConflictDetectionService::Result.new(outcome: :no_conflict)
+        )
         expect(SyncSession).not_to receive(:active)
 
         processor_with_session.send(:detect_and_handle_conflict, email_data)
@@ -949,7 +964,7 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
           date: Time.current,
           body: 'body'
         })
-        allow(processor_with_session).to receive(:detect_and_handle_conflict).and_return(nil)
+        allow(processor_with_session).to receive(:detect_and_handle_conflict).and_return(:conflict)
         allow(ProcessEmailJob).to receive(:perform_later)
       end
 
@@ -965,6 +980,48 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
         processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
 
         expect(ProcessEmailJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context 'when a duplicate is silently skipped for a transaction email' do
+      let(:sync_session_for_conflict) { instance_double(SyncSession, id: 1) }
+      let(:processor_with_session) { described_class.new(email_account, sync_session: sync_session_for_conflict) }
+      let(:transaction_envelope) do
+        double('envelope', subject: 'Notificación de transacción', from: [ double('from', mailbox: 'bank', host: 'bac.co.cr') ], date: Time.current, message_id: rfc_message_id)
+      end
+
+      before do
+        allow(mock_imap_service).to receive(:fetch_envelope).and_return(transaction_envelope)
+        allow(processor_with_session).to receive(:extract_email_data).and_return({
+          message_id: message_id,
+          rfc_message_id: rfc_message_id,
+          from: 'bank@bac.co.cr',
+          subject: 'Notificación de transacción',
+          date: Time.current,
+          body: 'body'
+        })
+        allow(processor_with_session).to receive(:detect_and_handle_conflict).and_return(:duplicate_skipped)
+        allow(ProcessEmailJob).to receive(:perform_later)
+      end
+
+      it 'records a ProcessedEmail keyed on the normalized RFC822 Message-ID' do
+        expect {
+          processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
+        }.to change(ProcessedEmail, :count).by(1)
+
+        expect(ProcessedEmail.last.message_id).to eq('terminal-55@mail.bank.example')
+      end
+
+      it 'does not enqueue ProcessEmailJob (no new expense is created)' do
+        processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
+
+        expect(ProcessEmailJob).not_to have_received(:perform_later)
+      end
+
+      it 'reports duplicate_skipped: true and conflict_detected: false in the result' do
+        result = processor_with_session.send(:process_email_with_metrics, message_id, mock_imap_service)
+
+        expect(result).to include(processed: true, expense_created: false, conflict_detected: false, duplicate_skipped: true)
       end
     end
   end

--- a/spec/tasks/sync_conflicts_cleanup_rake_spec.rb
+++ b/spec/tasks/sync_conflicts_cleanup_rake_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# fix/silent-duplicate-skip: Spec for the sync_conflicts:cleanup_orphaned
+# rake task, which removes the pending SyncConflict ghost rows left behind
+# by the pre-fix behaviour (a SyncConflict created for every duplicate, with
+# no way to un-persist it once the new_expense is gone or soft-deleted).
+RSpec.describe "sync_conflicts:cleanup_orphaned", :unit, type: :task do
+  let(:rake_app) { Rake::Application.new }
+
+  before do
+    Rake.application = rake_app
+    Rake::Task.define_task(:environment)
+    load Rails.root.join("lib/tasks/sync_conflicts_cleanup.rake")
+  end
+
+  after { Rake::Task.clear }
+
+  def run_task
+    Rake::Task["sync_conflicts:cleanup_orphaned"].reenable
+    Rake::Task["sync_conflicts:cleanup_orphaned"].invoke
+  end
+
+  let(:email_account) { create(:email_account) }
+
+  it "deletes a pending conflict whose new_expense has been soft-deleted" do
+    conflict = create(:sync_conflict, :with_new_expense, status: "pending")
+    conflict.new_expense.update_columns(deleted_at: Time.current)
+
+    expect { run_task }.to change(SyncConflict, :count).by(-1)
+    expect(SyncConflict.where(id: conflict.id)).not_to exist
+  end
+
+  it "deletes a pending conflict with no new_expense at all (new_expense_id is NULL)" do
+    # A DB-level FK (RESTRICT) prevents hard-deleting an Expense still
+    # referenced by a SyncConflict, so in practice "gone" means soft-deleted
+    # (covered above). This covers the defensive NULL branch of the query.
+    conflict = create(:sync_conflict, status: "pending", new_expense: nil)
+
+    expect { run_task }.to change(SyncConflict, :count).by(-1)
+    expect(SyncConflict.where(id: conflict.id)).not_to exist
+  end
+
+  it "keeps a pending conflict whose new_expense is still live" do
+    conflict = create(:sync_conflict, :with_new_expense, status: "pending")
+
+    expect { run_task }.not_to change(SyncConflict, :count)
+    expect(SyncConflict.where(id: conflict.id)).to exist
+  end
+
+  it "keeps a resolved conflict even if its new_expense is orphaned" do
+    conflict = create(:sync_conflict, :with_new_expense, :resolved)
+    conflict.new_expense.update_columns(deleted_at: Time.current)
+
+    expect { run_task }.not_to change(SyncConflict, :count)
+    expect(SyncConflict.where(id: conflict.id)).to exist
+  end
+
+  it "is idempotent — a second run finds nothing left to delete" do
+    conflict = create(:sync_conflict, :with_new_expense, status: "pending")
+    conflict.new_expense.update_columns(deleted_at: Time.current)
+
+    run_task
+    expect(SyncConflict.where(id: conflict.id)).not_to exist
+
+    expect { run_task }.not_to change(SyncConflict, :count)
+  end
+
+  it "reports the found and deleted counts to STDOUT" do
+    conflict = create(:sync_conflict, :with_new_expense, status: "pending")
+    conflict.new_expense.update_columns(deleted_at: Time.current)
+
+    expect { run_task }.to output(/found=1 deleted=1/).to_stdout
+  end
+end


### PR DESCRIPTION
## Why

Prod: **75 SyncConflicts, all pending, all pointing at soft-deleted expenses, 0 ever resolved.** Root causes: (1) duplicate detections (≥90%) persisted a SyncConflict AND soft-deleted the new expense → permanent unresolvable ghosts; (2) the service's nil return was ambiguous — the processor read 'silent skip' as 'no conflict' and **re-created the duplicate expense anyway** via ProcessEmailJob (the burned-ID trail in prod confirms it).

## What

- `ConflictDetectionService` returns a `Result` struct (`:no_conflict` / `:duplicate_skipped` / `:conflict` + predicates) from EVERY path — nil ambiguity eliminated.
- ≥90 duplicates: incoming duplicate marked/soft-deleted as before, **no SyncConflict row**, logged with score + both ids. 70–89 'similar' unchanged (still human-review conflicts). `auto_resolve_obvious_duplicates` re-scoped to `DUPLICATE_THRESHOLD` as legacy defense-in-depth.
- Processor stops expense creation on `:duplicate_skipped` and records `ProcessedEmail` at both terminal outcomes (#548 pattern).
- Batch path (`SyncService#detect_conflicts`) sends persisted expenses WITH `:id` (needed for self-match exclusion) — `skip_silent_duplicate` now marks those rows in place instead of PK-colliding on an audit insert (architect follow-up, taken with regression spec).
- **Cleanup**: `rake sync_conflicts:cleanup_orphaned` — destroys pending conflicts whose new_expense is gone/soft-deleted (the 75 prod ghosts), cascades conflict_resolutions, idempotent, leaves resolved/live untouched.

## Review trail

Backend-architect: **ship** — Result contract verified complete (no nil paths), unique-index interaction sound, rake task safe vs FK RESTRICT, no downstream breakage of process_emails consumers. Non-blocking notes: retention job for soft-deleted duplicate audit rows (→ Obsidian backlog), the batch-path PK-collision noise (fixed in `5d25fd3` — NOT by stripping `:id`, which the architect suggested but would break self-match exclusion).

## Tests

Unmocked integration spec (same window, different Message-IDs → 0 SyncConflicts, 1 live expense, soft-deleted audit row, 2 ProcessedEmails); threshold boundaries (85/90/95); persisted-batch-input regression; cleanup task matrix (orphaned-pending deleted / live-pending kept / resolved kept / idempotent). Full unit suite: 9204+ examples, 0 failures. RuboCop + Brakeman clean.

## Post-merge

Deploy, run the cleanup task in prod (empties the 75-ghost conflict list), then Playwright + live double-sync verification.