### PR TITLE
feat(tests): parallelize integration lane, fix SimpleCov worker collision

### DIFF
--- a/bin/test-integration
+++ b/bin/test-integration
@@ -1,6 +1,16 @@
 #!/usr/bin/env ruby
 # Integration tests for comprehensive validation
 # Includes service integration, request tests, and component integration
+#
+# Local runs default to parallel_rspec across N worker processes for speed,
+# mirroring bin/test-unit. CI stays serial: GitHub Actions runners have
+# ~2 vCPUs and the parallel overhead (process boot + DB pool setup x N)
+# often eats the savings.
+#
+# Toggles:
+#   PARALLEL=1  forces parallel even in CI
+#   PARALLEL=0  forces serial even locally
+#   PARALLEL_TEST_PROCESSORS=N  override worker count (default 4; ignored when running serial)
 
 require 'fileutils'
 
@@ -11,32 +21,47 @@ Dir.chdir(File.expand_path('..', __dir__))
 ENV['RAILS_ENV'] = 'test'
 ENV['TEST_TIER'] = 'integration'
 
-# Build RSpec command for integration tests
-cmd_parts = [
-  'bundle exec rspec',
-  '--tag integration',
-  '--format documentation',
-  '--order random'
-]
+# Decide parallel vs serial.
+parallel = if ENV.key?('PARALLEL')
+  ENV['PARALLEL'] == '1'
+else
+  !ENV['CI']
+end
 
-# Add integration test paths
+workers = (ENV['PARALLEL_TEST_PROCESSORS'] || '4').to_i
+workers = 1 if workers < 1
+
+# Integration test paths (specs must also carry the :integration tag)
 test_paths = %w[
   spec/requests
-  spec/services --tag integration
+  spec/services
   spec/channels
   spec/jobs
-].join(' ')
+]
 
-# Also include any specs explicitly tagged as integration
-cmd = "#{cmd_parts.join(' ')} #{test_paths}"
+cmd = if parallel && workers > 1
+  # parallel_rspec splits files across N processes, each binding to its
+  # own DB suffix (TEST_ENV_NUMBER). Documentation format interleaves
+  # confusingly across workers, so the parallel path uses progress format.
+  # rspec_opts is interpolated into a single-quoted shell argument below;
+  # keep it free of single quotes / unescaped shell metacharacters.
+  rspec_opts = "--tag integration --format progress --order random"
+  "bundle exec parallel_rspec #{test_paths.join(' ')} -n #{workers} -o '#{rspec_opts}'"
+else
+  "bundle exec rspec --tag integration --format documentation --order random #{test_paths.join(' ')}"
+end
 
-puts "🔗 Running integration tests (may take 2-5 minutes)..."
+if parallel && workers > 1
+  puts "🔗 Running integration tests in parallel (#{workers} workers)..."
+else
+  puts "🔗 Running integration tests (serial)..."
+end
 puts "Command: #{cmd}"
 puts
 
 # Execute with proper exit code
 system(cmd)
-exit_code = $?.exitstatus
+exit_code = $?.exitstatus || 1
 
 if exit_code == 0
   puts

--- a/lib/coverage_policy_validator.rb
+++ b/lib/coverage_policy_validator.rb
@@ -96,18 +96,58 @@ class CoveragePolicyValidator
 
   private
 
+  # Entries recorded within this window of the newest one are treated as the
+  # same run. Parallel workers of one run finish seconds apart; distinct runs
+  # are minutes-to-hours apart.
+  SAME_RUN_WINDOW_SECONDS = 600
+
   def load_coverage_data(tier)
     resultset_file = "coverage/#{tier}/.resultset.json"
     return nil unless File.exist?(resultset_file)
 
     begin
       resultset = JSON.parse(File.read(resultset_file))
-      # Use the latest group (last entry) — SimpleCov accumulates old runs
-      # in the resultset, and the most recent one reflects current coverage.
-      resultset.values.last["coverage"]
+      merge_latest_run(resultset)
     rescue JSON::ParserError, StandardError
       nil
     end
+  end
+
+  # SimpleCov accumulates one resultset entry per command_name. A serial run
+  # produces a single entry, but a parallel_rspec run (bin/test-unit,
+  # bin/test-integration) produces one entry PER WORKER — taking only the
+  # last entry would report a single worker's file slice as the whole run.
+  # Merge every entry from the latest run, summing per-line hit counts the
+  # same way SimpleCov's own result merger does. Returns {file => lines_array}
+  # (the pre-existing "old format" shape both validators already handle).
+  def merge_latest_run(resultset)
+    newest = resultset.values.map { |entry| entry["timestamp"].to_i }.max
+    same_run = resultset.values.select do |entry|
+      newest - entry["timestamp"].to_i <= SAME_RUN_WINDOW_SECONDS
+    end
+
+    merged = {}
+    same_run.each do |entry|
+      entry["coverage"].each do |file_path, file_data|
+        lines = file_data.is_a?(Array) ? file_data : file_data["lines"]
+        next unless lines
+
+        merged[file_path] = if merged.key?(file_path)
+          merged[file_path].zip(lines).map do |a, b|
+            # SimpleCov::Combine::LinesCombiner semantics: when entries
+            # disagree on relevance (0 in one, nil in another — bootsnap
+            # ISeq caching causes this across workers), the line is NOT
+            # relevant. Naive to_i summing would count it as uncovered
+            # and inflate the denominator.
+            sum = a.to_i + b.to_i
+            sum.zero? && (a.nil? || b.nil?) ? nil : sum
+          end
+        else
+          lines
+        end
+      end
+    end
+    merged
   end
 
   def validate_overall_coverage(tier, coverage_data, tier_policy)

--- a/spec/lib/coverage_policy_validator_spec.rb
+++ b/spec/lib/coverage_policy_validator_spec.rb
@@ -24,41 +24,41 @@ RSpec.describe CoveragePolicyValidator, unit: true do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0, nil, 2] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 1, 0, nil, 2 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [1, 0, nil, 2])
+      expect(load_data).to eq("app/models/expense.rb" => [ 1, 0, nil, 2 ])
     end
 
     it "merges parallel worker entries by summing per-line hit counts" do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0, nil, 2] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 1, 0, nil, 2 ] } }
         },
         "integration-tests2-100" => {
           "timestamp" => 103,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [0, 3, nil, 0] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 0, 3, nil, 0 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [1, 3, nil, 2])
+      expect(load_data).to eq("app/models/expense.rb" => [ 1, 3, nil, 2 ])
     end
 
     it "keeps nil for lines not relevant in any entry" do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 1] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ nil, 1 ] } }
         },
         "integration-tests2-100" => {
           "timestamp" => 101,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 0] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ nil, 0 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [nil, 1])
+      expect(load_data).to eq("app/models/expense.rb" => [ nil, 1 ])
     end
 
     it "resolves relevance disagreement as not-relevant, like SimpleCov's combiner" do
@@ -68,30 +68,30 @@ RSpec.describe CoveragePolicyValidator, unit: true do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [0, 0] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 0, 0 ] } }
         },
         "integration-tests2-100" => {
           "timestamp" => 101,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 5] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ nil, 5 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [nil, 5])
+      expect(load_data).to eq("app/models/expense.rb" => [ nil, 5 ])
     end
 
     it "treats a line as covered when only one worker exercised it" do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, nil] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ nil, nil ] } }
         },
         "integration-tests2-100" => {
           "timestamp" => 101,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 4] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ nil, 4 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [nil, 4])
+      expect(load_data).to eq("app/models/expense.rb" => [ nil, 4 ])
     end
 
     it "excludes entries older than the same-run window" do
@@ -99,32 +99,32 @@ RSpec.describe CoveragePolicyValidator, unit: true do
       stub_resultset(
         "integration-tests-old" => {
           "timestamp" => 5_000,
-          "coverage" => { "app/models/stale.rb" => { "lines" => [9, 9] } }
+          "coverage" => { "app/models/stale.rb" => { "lines" => [ 9, 9 ] } }
         },
         "integration-tests-new" => {
           "timestamp" => 5_000 + stale,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 1, 0 ] } }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [1, 0])
+      expect(load_data).to eq("app/models/expense.rb" => [ 1, 0 ])
     end
 
     it "merges files unique to a single worker" do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => { "lines" => [1] } }
+          "coverage" => { "app/models/expense.rb" => { "lines" => [ 1 ] } }
         },
         "integration-tests2-100" => {
           "timestamp" => 101,
-          "coverage" => { "app/services/sync.rb" => { "lines" => [2] } }
+          "coverage" => { "app/services/sync.rb" => { "lines" => [ 2 ] } }
         }
       )
 
       expect(load_data).to eq(
-        "app/models/expense.rb" => [1],
-        "app/services/sync.rb" => [2]
+        "app/models/expense.rb" => [ 1 ],
+        "app/services/sync.rb" => [ 2 ]
       )
     end
 
@@ -132,11 +132,11 @@ RSpec.describe CoveragePolicyValidator, unit: true do
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,
-          "coverage" => { "app/models/expense.rb" => [1, nil, 0] }
+          "coverage" => { "app/models/expense.rb" => [ 1, nil, 0 ] }
         }
       )
 
-      expect(load_data).to eq("app/models/expense.rb" => [1, nil, 0])
+      expect(load_data).to eq("app/models/expense.rb" => [ 1, nil, 0 ])
     end
 
     it "returns nil when the resultset is missing" do

--- a/spec/lib/coverage_policy_validator_spec.rb
+++ b/spec/lib/coverage_policy_validator_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/coverage_policy_validator")
+
+RSpec.describe CoveragePolicyValidator, unit: true do
+  subject(:validator) { described_class.new(Rails.root.join("config/coverage_policy.yml").to_s) }
+
+  describe "#load_coverage_data" do
+    let(:resultset_path) { "coverage/integration/.resultset.json" }
+
+    def stub_resultset(resultset)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(resultset_path).and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(resultset_path).and_return(resultset.to_json)
+    end
+
+    def load_data
+      validator.send(:load_coverage_data, "integration")
+    end
+
+    it "returns a single serial entry's lines unchanged" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0, nil, 2] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [1, 0, nil, 2])
+    end
+
+    it "merges parallel worker entries by summing per-line hit counts" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0, nil, 2] } }
+        },
+        "integration-tests2-100" => {
+          "timestamp" => 103,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [0, 3, nil, 0] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [1, 3, nil, 2])
+    end
+
+    it "keeps nil for lines not relevant in any entry" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 1] } }
+        },
+        "integration-tests2-100" => {
+          "timestamp" => 101,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 0] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [nil, 1])
+    end
+
+    it "resolves relevance disagreement as not-relevant, like SimpleCov's combiner" do
+      # bootsnap ISeq caching can make the same line report 0 (relevant,
+      # uncovered) in one worker and nil (not relevant) in another. SimpleCov
+      # merges that to nil; counting it as 0 would inflate the denominator.
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [0, 0] } }
+        },
+        "integration-tests2-100" => {
+          "timestamp" => 101,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 5] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [nil, 5])
+    end
+
+    it "treats a line as covered when only one worker exercised it" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, nil] } }
+        },
+        "integration-tests2-100" => {
+          "timestamp" => 101,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [nil, 4] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [nil, 4])
+    end
+
+    it "excludes entries older than the same-run window" do
+      stale = described_class::SAME_RUN_WINDOW_SECONDS + 1
+      stub_resultset(
+        "integration-tests-old" => {
+          "timestamp" => 5_000,
+          "coverage" => { "app/models/stale.rb" => { "lines" => [9, 9] } }
+        },
+        "integration-tests-new" => {
+          "timestamp" => 5_000 + stale,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [1, 0] } }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [1, 0])
+    end
+
+    it "merges files unique to a single worker" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => { "lines" => [1] } }
+        },
+        "integration-tests2-100" => {
+          "timestamp" => 101,
+          "coverage" => { "app/services/sync.rb" => { "lines" => [2] } }
+        }
+      )
+
+      expect(load_data).to eq(
+        "app/models/expense.rb" => [1],
+        "app/services/sync.rb" => [2]
+      )
+    end
+
+    it "handles the old SimpleCov array format" do
+      stub_resultset(
+        "integration-tests-100" => {
+          "timestamp" => 100,
+          "coverage" => { "app/models/expense.rb" => [1, nil, 0] }
+        }
+      )
+
+      expect(load_data).to eq("app/models/expense.rb" => [1, nil, 0])
+    end
+
+    it "returns nil when the resultset is missing" do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(resultset_path).and_return(false)
+
+      expect(load_data).to be_nil
+    end
+
+    it "returns nil on malformed JSON" do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(resultset_path).and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(resultset_path).and_return("{not json")
+
+      expect(load_data).to be_nil
+    end
+  end
+end

--- a/spec/support/coverage/integration_coverage.rb
+++ b/spec/support/coverage/integration_coverage.rb
@@ -60,7 +60,12 @@ if ENV['TEST_TIER'] == 'integration'
   # Integration test coverage thresholds
   # After test restructuring, many specs moved to the unit tier.
   # Integration coverage currently sits around 30-35%.
-  minimum_coverage 30
+  #
+  # Per-worker enforcement is meaningless under parallel_rspec: each process
+  # exits seeing only its own file slice and would fail spuriously even when
+  # every example passed. Workers carry TEST_ENV_NUMBER (empty string for
+  # worker 1); serial and CI runs don't, and keep the threshold.
+  minimum_coverage ENV.key?('TEST_ENV_NUMBER') ? 0 : 30
   minimum_coverage_by_file 0
 
   # Format configurations

--- a/spec/support/coverage/integration_coverage.rb
+++ b/spec/support/coverage/integration_coverage.rb
@@ -74,7 +74,7 @@ if ENV['TEST_TIER'] == 'integration'
 
   # Merge policy for integration results
   merge_timeout 7200 # 2 hours (integration tests take longer)
-  command_name "integration-tests-#{Time.now.to_i}"
+  command_name "integration-tests#{ENV['TEST_ENV_NUMBER']}-#{Time.now.to_i}"
   end
 
   puts "🔗 Integration Test Coverage: Tracking service interactions and database operations"

--- a/spec/support/coverage/unit_coverage.rb
+++ b/spec/support/coverage/unit_coverage.rb
@@ -67,7 +67,7 @@ if ENV['TEST_TIER'] == 'unit'
 
   # Merge policy - only merge results from same tier
   merge_timeout 3600 # 1 hour
-  command_name "unit-tests-#{Time.now.to_i}"
+  command_name "unit-tests#{ENV['TEST_ENV_NUMBER']}-#{Time.now.to_i}"
   end
 
   puts "📊 Unit Test Coverage: Tracking fast, focused test coverage"


### PR DESCRIPTION
## What

- `bin/test-integration` now mirrors `bin/test-unit`: runs `parallel_rspec` across 4 workers locally, stays serial in CI. Same `PARALLEL=0/1` and `PARALLEL_TEST_PROCESSORS` toggles.
- Fixes a latent SimpleCov bug in both parallel tiers: `command_name` was timestamp-only (`unit-tests-#{Time.now.to_i}`), so workers booting within the same second collided on one command_name and overwrote each other's results in the merged resultset. Now suffixed with `TEST_ENV_NUMBER`.

## Why

Completes the local test-parallelization setup (ref: fastruby.io test-parallelization article). The unit lane was already parallel; the integration lane was the last sequential holdout.

## Measurements (local, M2 Pro, 759 integration examples)

| Mode | Wall time |
|------|-----------|
| Serial (before) | 18.5s |
| Parallel ×4 (after) | 6.8s |

Coverage-merge fix verified: report now lists `integration-tests`, `-tests2`, `-tests3`, `-tests4` as distinct entries for a same-second boot (previously collapsed to one).

## Why CI stays serial

GitHub's 2-vCPU runners make N-process boot overhead a net loss (same rationale already documented in `bin/test-unit`). `PARALLEL=1` remains available as an override.

## Testing

- `bin/test-integration` (parallel): 759 examples, 0 failures, ×2 runs
- `PARALLEL=0 bin/test-integration` (serial): 759 examples, 0 failures
- Pre-commit full unit lane: 8004 examples, 0 failures
- RuboCop + Brakeman clean