### PR TITLE
test: fold passing performance-lane specs into unit tier (batch 1)

### DIFF
--- a/spec/models/categorization_pattern_edge_cases_spec.rb
+++ b/spec/models/categorization_pattern_edge_cases_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "benchmark"
 
-RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: true do
+RSpec.describe "Categorization Pattern Edge Cases", type: :model do
   let(:category) { create(:category, name: "Test Category") }
 
-  describe CategorizationPattern, performance: true do
-    describe "concurrent updates", performance: true do
+  describe CategorizationPattern do
+    describe "concurrent updates" do
       it "handles race conditions with optimistic locking" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -29,7 +30,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "boundary value testing", performance: true do
+    describe "boundary value testing" do
       it "handles maximum confidence weight" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -69,7 +70,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "special characters and encoding", performance: true do
+    describe "special characters and encoding" do
       it "handles Unicode characters in pattern values" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -104,7 +105,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "metadata handling", performance: true do
+    describe "metadata handling" do
       it "handles complex nested metadata" do
         metadata = {
           source: "user_input",
@@ -142,7 +143,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "amount range edge cases", performance: true do
+    describe "amount range edge cases" do
       it "handles very small amounts" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -178,7 +179,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "time pattern edge cases", performance: true do
+    describe "time pattern edge cases" do
       it "handles midnight boundary" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -204,19 +205,9 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "regex pattern security", performance: true do
-      it "prevents ReDoS attacks" do
-        # Potentially dangerous regex
-        pattern = CategorizationPattern.new(
-          category: category,
-          pattern_type: "regex",
-          pattern_value: "(a+)+" # Catastrophic backtracking
-        )
-
-        expect(pattern).not_to be_valid
-        expect(pattern.errors[:pattern_value]).to include("contains potentially dangerous regex pattern (ReDoS vulnerability)")
-      end
-
+    describe "regex pattern security" do
+      # Note: ReDoS rejection itself is covered by
+      # categorization_pattern_unit_spec.rb "rejects dangerous ReDoS patterns"
       it "handles complex but safe regex patterns" do
         pattern = CategorizationPattern.create!(
           category: category,
@@ -230,41 +221,12 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "deactivation thresholds", performance: true do
-      it "deactivates after consistent failures" do
-        pattern = CategorizationPattern.create!(
-          category: category,
-          pattern_type: "merchant",
-          pattern_value: "Test",
-          usage_count: 100,
-          success_count: 10,
-          active: true
-        )
-
-        pattern.check_and_deactivate_if_poor_performance
-
-        expect(pattern.active).to be false
-      end
-
-      it "preserves user-created patterns even with poor performance" do
-        pattern = CategorizationPattern.create!(
-          category: category,
-          pattern_type: "merchant",
-          pattern_value: "Test",
-          usage_count: 100,
-          success_count: 10,
-          user_created: true,
-          active: true
-        )
-
-        pattern.check_and_deactivate_if_poor_performance
-
-        expect(pattern.active).to be true # User patterns not auto-deactivated
-      end
-    end
+    # Note: deactivation-threshold behavior (poor performance, user-created
+    # exemption) is covered by categorization_pattern_unit_spec.rb
+    # "#check_and_deactivate_if_poor_performance"
   end
 
-  describe CompositePattern, performance: true do
+  describe CompositePattern do
     let!(:pattern1) do
       CategorizationPattern.create!(
         category: category,
@@ -281,7 +243,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       )
     end
 
-    describe "circular reference prevention", performance: true do
+    describe "circular reference prevention" do
       it "prevents self-reference" do
         composite = CompositePattern.create!(
           category: category,
@@ -298,7 +260,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "operator edge cases", performance: true do
+    describe "operator edge cases" do
       it "handles empty pattern_ids with OR operator" do
         composite = CompositePattern.new(
           category: category,
@@ -327,7 +289,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "complex conditions", performance: true do
+    describe "complex conditions" do
       it "handles multiple condition types together" do
         conditions = {
           min_amount: 100,
@@ -392,7 +354,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
       end
     end
 
-    describe "description generation", performance: true do
+    describe "description generation" do
       it "handles very long pattern lists" do
         patterns = 10.times.map do |i|
           CategorizationPattern.create!(
@@ -417,7 +379,7 @@ RSpec.describe "Categorization Pattern Edge Cases", type: :model, performance: t
     end
   end
 
-  describe "Integration between patterns and composites", performance: true do
+  describe "Integration between patterns and composites" do
     it "handles pattern deletion with composite references" do
       pattern = CategorizationPattern.create!(
         category: category,

--- a/spec/services/categorization/matchers/match_result_spec.rb
+++ b/spec/services/categorization/matchers/match_result_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Services::Categorization::Matchers::MatchResult, performance: true do
+RSpec.describe Services::Categorization::Matchers::MatchResult do
   let(:matches) do
     [
       { id: 1, text: "Starbucks", score: 0.95 },
@@ -20,8 +20,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     )
   end
 
-  describe "factory methods", performance: true do
-    describe ".empty", performance: true do
+  describe "factory methods" do
+    describe ".empty" do
       it "creates an empty result" do
         result = described_class.empty
 
@@ -31,7 +31,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe ".timeout", performance: true do
+    describe ".timeout" do
       it "creates a timeout result" do
         result = described_class.timeout
 
@@ -41,7 +41,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe ".error", performance: true do
+    describe ".error" do
       it "creates an error result" do
         result = described_class.error("Something went wrong")
 
@@ -52,8 +52,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "query methods", performance: true do
-    describe "#success?", performance: true do
+  describe "query methods" do
+    describe "#success?" do
       it "returns true for successful results" do
         expect(result).to be_success
       end
@@ -64,13 +64,13 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#failure?", performance: true do
+    describe "#failure?" do
       it "returns opposite of success?" do
         expect(result.failure?).to eq(!result.success?)
       end
     end
 
-    describe "#empty?", performance: true do
+    describe "#empty?" do
       it "returns true when no matches" do
         empty_result = described_class.new(success: true, matches: [])
         expect(empty_result).to be_empty
@@ -81,7 +81,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#present?", performance: true do
+    describe "#present?" do
       it "returns true when matches exist" do
         expect(result).to be_present
       end
@@ -93,8 +93,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "access methods", performance: true do
-    describe "#best_match", performance: true do
+  describe "access methods" do
+    describe "#best_match" do
       it "returns the first match" do
         expect(result.best_match).to eq(matches.first)
       end
@@ -105,7 +105,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#best_score", performance: true do
+    describe "#best_score" do
       it "returns the highest score" do
         expect(result.best_score).to eq(0.95)
       end
@@ -116,7 +116,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#count and #size", performance: true do
+    describe "#count and #size" do
       it "returns the number of matches" do
         expect(result.count).to eq(3)
         expect(result.size).to eq(3)
@@ -124,8 +124,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "filter methods", performance: true do
-    describe "#above_threshold", performance: true do
+  describe "filter methods" do
+    describe "#above_threshold" do
       it "filters matches above threshold" do
         filtered = result.above_threshold(0.70)
 
@@ -141,7 +141,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#top", performance: true do
+    describe "#top" do
       it "returns top N matches" do
         top_2 = result.top(2)
 
@@ -157,8 +157,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "confidence methods", performance: true do
-    describe "#high_confidence_matches", performance: true do
+  describe "confidence methods" do
+    describe "#high_confidence_matches" do
       it "returns matches with score >= 0.85" do
         high = result.high_confidence_matches
 
@@ -172,7 +172,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#medium_confidence_matches", performance: true do
+    describe "#medium_confidence_matches" do
       it "returns matches with 0.70 <= score < 0.85" do
         medium = result.medium_confidence_matches
 
@@ -180,7 +180,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#low_confidence_matches", performance: true do
+    describe "#low_confidence_matches" do
       it "returns matches with 0.50 <= score < 0.70" do
         low = result.low_confidence_matches
 
@@ -188,7 +188,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#confidence_level", performance: true do
+    describe "#confidence_level" do
       it "returns :exact for scores >= 0.95" do
         expect(result.confidence_level).to eq(:exact)
       end
@@ -232,7 +232,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "pattern-specific methods", performance: true do
+  describe "pattern-specific methods" do
     let(:pattern) { create(:categorization_pattern) }
     let(:pattern_matches) do
       [
@@ -244,40 +244,40 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       described_class.new(success: true, matches: pattern_matches)
     end
 
-    describe "#best_pattern", performance: true do
+    describe "#best_pattern" do
       it "returns the pattern from best match" do
         expect(pattern_result.best_pattern).to eq(pattern)
       end
     end
 
-    describe "#best_category_id", performance: true do
+    describe "#best_category_id" do
       it "returns category_id from best match" do
         expect(pattern_result.best_category_id).to eq(pattern.category_id)
       end
     end
 
-    describe "#patterns", performance: true do
+    describe "#patterns" do
       it "returns all patterns from matches" do
         expect(pattern_result.patterns).to eq([ pattern ])
       end
     end
 
-    describe "#category_ids", performance: true do
+    describe "#category_ids" do
       it "returns unique category IDs" do
         expect(pattern_result.category_ids).to eq([ pattern.category_id ])
       end
     end
   end
 
-  describe "transformation methods", performance: true do
-    describe "#map", performance: true do
+  describe "transformation methods" do
+    describe "#map" do
       it "maps over matches" do
         scores = result.map { |m| m[:score] }
         expect(scores).to eq([ 0.95, 0.75, 0.60 ])
       end
     end
 
-    describe "#select", performance: true do
+    describe "#select" do
       it "filters matches and returns new MatchResult" do
         filtered = result.select { |m| m[:score] > 0.70 }
 
@@ -286,7 +286,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#reject", performance: true do
+    describe "#reject" do
       it "rejects matches and returns new MatchResult" do
         filtered = result.reject { |m| m[:score] < 0.70 }
 
@@ -296,7 +296,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "#merge", performance: true do
+  describe "#merge" do
     let(:other_matches) do
       [
         { id: 4, text: "Tea Shop", score: 0.85 },
@@ -339,8 +339,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "enumerable-like methods", performance: true do
-    describe "#each", performance: true do
+  describe "enumerable-like methods" do
+    describe "#each" do
       it "iterates over matches" do
         texts = []
         result.each { |m| texts << m[:text] }
@@ -349,19 +349,19 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#first", performance: true do
+    describe "#first" do
       it "returns first match" do
         expect(result.first).to eq(matches.first)
       end
     end
 
-    describe "#last", performance: true do
+    describe "#last" do
       it "returns last match" do
         expect(result.last).to eq(matches.last)
       end
     end
 
-    describe "#[]", performance: true do
+    describe "#[]" do
       it "accesses matches by index" do
         expect(result[0]).to eq(matches[0])
         expect(result[1]).to eq(matches[1])
@@ -370,14 +370,14 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "export methods", performance: true do
-    describe "#to_a", performance: true do
+  describe "export methods" do
+    describe "#to_a" do
       it "returns matches array" do
         expect(result.to_a).to eq(matches)
       end
     end
 
-    describe "#to_h", performance: true do
+    describe "#to_h" do
       it "returns hash representation" do
         hash = result.to_h
 
@@ -393,7 +393,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#to_json", performance: true do
+    describe "#to_json" do
       it "returns JSON representation" do
         json = result.to_json
         parsed = JSON.parse(json)
@@ -404,8 +404,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "comparison operators", performance: true do
-    describe "#==", performance: true do
+  describe "comparison operators" do
+    describe "#==" do
       it "returns true for equal results" do
         other = described_class.new(
           success: true,
@@ -428,7 +428,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "#match_details", performance: true do
+  describe "#match_details" do
     it "returns detailed match information" do
       details = result.match_details
 
@@ -442,8 +442,8 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "debugging methods", performance: true do
-    describe "#inspect", performance: true do
+  describe "debugging methods" do
+    describe "#inspect" do
       it "returns concise representation" do
         expect(result.inspect).to include("MatchResult")
         expect(result.inspect).to include("success=true")
@@ -451,7 +451,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       end
     end
 
-    describe "#to_s", performance: true do
+    describe "#to_s" do
       it "returns human-readable string for success" do
         expect(result.to_s).to include("3 match(es) found")
         expect(result.to_s).to include("best score: 0.95")
@@ -469,7 +469,7 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
     end
   end
 
-  describe "performance metrics", performance: true do
+  describe "performance metrics" do
     let(:result_with_metrics) do
       described_class.new(
         success: true,
@@ -481,13 +481,13 @@ RSpec.describe Services::Categorization::Matchers::MatchResult, performance: tru
       )
     end
 
-    describe "#processing_time", performance: true do
+    describe "#processing_time" do
       it "returns processing time from metadata" do
         expect(result_with_metrics.processing_time).to eq(5.2)
       end
     end
 
-    describe "#cache_hit?", performance: true do
+    describe "#cache_hit?" do
       it "returns true when cache was hit" do
         expect(result_with_metrics).to be_cache_hit
       end

--- a/spec/services/categorization/monitoring/health_check_spec.rb
+++ b/spec/services/categorization/monitoring/health_check_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: true do
+RSpec.describe Services::Categorization::Monitoring::HealthCheck do
   let(:health_check) { described_class.new }
 
-  describe "#check_all", performance: true do
+  describe "#check_all" do
     it "performs all health checks" do
       result = health_check.check_all
 
@@ -139,7 +139,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#check_database", performance: true do
+  describe "#check_database" do
     it "checks database connectivity and performance" do
       # Create some test data
       create(:category)
@@ -166,7 +166,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#check_pattern_cache", performance: true do
+  describe "#check_pattern_cache" do
     it "checks pattern cache status" do
       cache = instance_double(Services::Categorization::PatternCache)
       allow(Services::Categorization::PatternCache).to receive(:instance).and_return(cache)
@@ -224,7 +224,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#check_service_metrics", performance: true do
+  describe "#check_service_metrics" do
     before do
       create_list(:expense, 5, category: create(:category))
       create_list(:expense, 3, category: nil)
@@ -242,7 +242,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#healthy?", performance: true do
+  describe "#healthy?" do
     it "returns true when all critical checks pass" do
       health_check.instance_variable_set(:@checks, {
         database: { status: :healthy },
@@ -272,7 +272,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#ready?", performance: true do
+  describe "#ready?" do
     it "returns true when database and cache are available" do
       health_check.instance_variable_set(:@checks, {
         database: { status: :healthy },
@@ -301,7 +301,7 @@ RSpec.describe Services::Categorization::Monitoring::HealthCheck, performance: t
     end
   end
 
-  describe "#live?", performance: true do
+  describe "#live?" do
     it "always returns true unless there's an exception" do
       expect(health_check.live?).to be true
     end

--- a/spec/services/categorization/monitoring/structured_logger_spec.rb
+++ b/spec/services/categorization/monitoring/structured_logger_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 require "ostruct"
 
-RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performance: true do
+RSpec.describe Services::Categorization::Monitoring::StructuredLogger do
   let(:mock_logger) { instance_double(Logger) }
   let(:structured_logger) { described_class.new(logger: mock_logger) }
 
-  describe "#log_categorization", performance: true do
+  describe "#log_categorization" do
     let(:expense) { create(:expense, description: "Test purchase at Store") }
     let(:category) { create(:category, name: "Shopping") }
     let(:result) do
@@ -62,7 +62,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "#log_learning", performance: true do
+  describe "#log_learning" do
     let(:pattern) { create(:categorization_pattern) }
 
     it "logs learning events with changes" do
@@ -83,7 +83,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "#log_error", performance: true do
+  describe "#log_error" do
     let(:error) { StandardError.new("Test error message") }
 
     before do
@@ -116,7 +116,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "#with_correlation_id", performance: true do
+  describe "#with_correlation_id" do
     it "uses provided correlation ID for all logs in block" do
       correlation_id = "test_correlation_123"
 
@@ -142,7 +142,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "#with_context", performance: true do
+  describe "#with_context" do
     it "adds context to logs within block" do
       expect(mock_logger).to receive(:add).with(
         Logger::INFO,
@@ -165,7 +165,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "#child", performance: true do
+  describe "#child" do
     it "creates child logger with inherited context" do
       parent = described_class.new(logger: mock_logger, context: { parent_key: "parent_value" })
       child = parent.child(child_key: "child_value")
@@ -186,7 +186,7 @@ RSpec.describe Services::Categorization::Monitoring::StructuredLogger, performan
     end
   end
 
-  describe "class methods", performance: true do
+  describe "class methods" do
     it "provides convenience class methods" do
       expect(described_class).to respond_to(:log_categorization)
       expect(described_class).to respond_to(:log_learning)

--- a/spec/services/categorization/pattern_cache_spec.rb
+++ b/spec/services/categorization/pattern_cache_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Services::Categorization::PatternCache, performance: true do
+RSpec.describe Services::Categorization::PatternCache do
   let(:cache) { described_class.new }
   let(:category) { create(:category, name: "Food & Dining") }
   let(:pattern) do
@@ -43,7 +43,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     Services::Categorization::PatternCache::MetricsCollector.reset_window!
   end
 
-  describe "#initialize", performance: true do
+  describe "#initialize" do
     it "initializes with memory cache" do
       expect(cache.instance_variable_get(:@memory_cache)).to be_present
     end
@@ -54,7 +54,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_pattern", performance: true do
+  describe "#get_pattern" do
     context "with no cached data" do
       it "fetches from database and caches result" do
         expect(CategorizationPattern).to receive(:active).and_call_original
@@ -98,7 +98,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_patterns", performance: true do
+  describe "#get_patterns" do
     let(:patterns) do
       3.times.map do |i|
         create(:categorization_pattern,
@@ -133,7 +133,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_patterns_by_type", performance: true do
+  describe "#get_patterns_by_type" do
     let!(:merchant_patterns) do
       2.times.map do |i|
         create(:categorization_pattern,
@@ -167,7 +167,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_composite_pattern", performance: true do
+  describe "#get_composite_pattern" do
     it "fetches and caches composite pattern" do
       result = cache.get_composite_pattern(composite.id)
 
@@ -186,7 +186,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_user_preference", performance: true do
+  describe "#get_user_preference" do
     it "fetches and caches user preference by merchant name" do
       # Ensure user_preference is created
       user_preference
@@ -225,7 +225,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#get_all_active_patterns", performance: true do
+  describe "#get_all_active_patterns" do
     let!(:active_patterns) do
       3.times.map { create(:categorization_pattern, active: true, category: category) }
     end
@@ -249,7 +249,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#invalidate", performance: true do
+  describe "#invalidate" do
     context "with CategorizationPattern" do
       before { cache.get_pattern(pattern.id) }
 
@@ -300,7 +300,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#invalidate_all", performance: true do
+  describe "#invalidate_all" do
     before do
       cache.get_pattern(pattern.id)
       cache.get_composite_pattern(composite.id)
@@ -326,7 +326,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#warm_cache", performance: true do
+  describe "#warm_cache" do
     let!(:frequently_used_patterns) do
       3.times.map do |i|
         create(:categorization_pattern,
@@ -371,7 +371,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#metrics", performance: true do
+  describe "#metrics" do
     before do
       cache.get_pattern(pattern.id)
       cache.get_pattern(pattern.id) # Hit
@@ -409,7 +409,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "metrics behavior — PER-549 fixes", performance: true do
+  describe "metrics behavior — PER-549 fixes" do
     let(:fresh_cache) { described_class.new }
 
     before do
@@ -495,7 +495,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "#preload_for_expenses", performance: true do
+  describe "#preload_for_expenses" do
     let(:preload_account) { create(:email_account) }
     let(:expenses) do
       [
@@ -567,7 +567,7 @@ RSpec.describe Services::Categorization::PatternCache, performance: true do
     end
   end
 
-  describe "TTL configuration", performance: true do
+  describe "TTL configuration" do
     it "respects configured TTL values" do
       allow(Rails.application.config).to receive(:pattern_cache_memory_ttl).and_return(10.seconds)
       allow(Rails.application.config).to receive(:pattern_cache_l2_ttl).and_return(1.hour)

--- a/spec/services/sync_session_performance_optimizer_spec.rb
+++ b/spec/services/sync_session_performance_optimizer_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
+RSpec.describe Services::SyncSessionPerformanceOptimizer do
   let(:email_account1) { create(:email_account) }
   let(:email_account2) { create(:email_account) }
   let(:sync_session) { create(:sync_session, :running) }
 
-  describe '.preload_for_index', performance: true do
+  describe '.preload_for_index' do
     let!(:session1) { create(:sync_session) }
     let!(:session2) { create(:sync_session) }
 
@@ -31,7 +31,7 @@ RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
     end
   end
 
-  describe '.preload_for_show', performance: true do
+  describe '.preload_for_show' do
     let!(:account1) { create(:sync_session_account, sync_session: sync_session, email_account: email_account1) }
     let!(:account2) { create(:sync_session_account, sync_session: sync_session, email_account: email_account2) }
 
@@ -52,7 +52,7 @@ RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
     end
   end
 
-  describe '.batch_update_progress', performance: true do
+  describe '.batch_update_progress' do
     let!(:session1) { create(:sync_session) }
     let!(:session2) { create(:sync_session) }
     let!(:account1) do
@@ -89,7 +89,7 @@ RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
     end
   end
 
-  describe '.cache_key_for_session', performance: true do
+  describe '.cache_key_for_session' do
     it 'returns a cache key with id and updated_at' do
       timestamp = Time.parse('2025-01-01 12:00:00 UTC')
       sync_session.update!(updated_at: timestamp)
@@ -99,14 +99,14 @@ RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
     end
   end
 
-  describe '.cache_key_for_status', performance: true do
+  describe '.cache_key_for_status' do
     it 'returns a cache key for status' do
       key = described_class.cache_key_for_status(123)
       expect(key).to eq("sync_session_status/123")
     end
   end
 
-  describe '.active_session_exists?', performance: true do
+  describe '.active_session_exists?' do
     it 'returns true when active session exists' do
       create(:sync_session, status: 'running')
       expect(described_class.active_session_exists?).to be true
@@ -128,14 +128,14 @@ RSpec.describe Services::SyncSessionPerformanceOptimizer, performance: true do
     end
   end
 
-  describe '.clear_active_session_cache', performance: true do
+  describe '.clear_active_session_cache' do
     it 'deletes the cache key' do
       expect(Rails.cache).to receive(:delete).with("active_sync_session_exists")
       described_class.clear_active_session_cache
     end
   end
 
-  describe '.calculate_metrics', performance: true do
+  describe '.calculate_metrics' do
     context 'with a running session' do
       let(:sync_session) do
         create(:sync_session,


### PR DESCRIPTION
## Summary

The performance-tagged RSpec lane has been red for months and isn't run as part of `bin/test-unit`. This is batch 1 of folding zero-risk, ordinary-behavior specs out of that lane and into the unit tier — all examples here pass today and don't depend on wall-clock timing (aside from the two explicit benchmark blocks called out below, which stay performance-tagged).

Path-based auto-tagging in `spec/support/configs/test_tiers.rb` already gives `/spec/services/` and `/spec/models/` files `unit: true` with no explicit override — so "fold to unit" just meant removing the explicit `performance: true` (and any `slow: true`) tags that were excluding these files from `bin/test-unit`.

**Fully folded (every example now runs in the unit lane):**
- `spec/services/categorization/matchers/match_result_spec.rb`
- `spec/services/categorization/monitoring/health_check_spec.rb`
- `spec/services/categorization/monitoring/structured_logger_spec.rb`
- `spec/services/sync_session_performance_optimizer_spec.rb`

**Split folds** (file-level tag removed; the timing-sensitive block keeps `performance: true` and stays out of the unit lane):
- `spec/services/categorization/pattern_cache_spec.rb` — only the `"Performance benchmarks"` describe (`< 1ms` cached lookup, high-concurrency test) stays performance-tagged. Everything else, including `"TTL configuration"`, folds to unit.
- `spec/models/categorization_pattern_edge_cases_spec.rb` — only `"performance with large pattern sets"` (a `Benchmark.realtime` timing assertion) stays performance-tagged. Added the missing `require "benchmark"` (was implicitly relying on it being loaded elsewhere and would error standalone).
  - Also removed two exact duplicates of coverage already in `categorization_pattern_unit_spec.rb`: the `"deactivation thresholds"` describe and the `"prevents ReDoS attacks"` example — both assert identical behavior with equivalent inputs.
  - Every other `CategorizationPattern`/`CompositePattern` edge case in this file (concurrent updates, boundary values, unicode/SQL-injection/regex-special-char handling, metadata edge cases, amount-range edge cases, time-pattern edge cases, the CompositePattern circular-reference/operator/complex-condition/description-generation cases, and pattern-composite integration) has no equivalent in the unit sibling and was kept in place, untagged, per repo lesson #431 (port unique edge cases rather than deleting them).

## Unit-suite runtime impact

These files add ~168 examples to `bin/test-unit` (57 + 19 + 13 + 15 + 39 + 22, minus the 3 duplicates/moved examples removed). Local pre-commit run: 8179 examples, 0 failures, ~38s — no material slowdown.

## Test plan
- [x] `RUN_ALL_TESTS=1 bundle exec rspec <each changed file>` — all pass
- [x] `bundle exec rspec <each changed file> --tag unit` — examples now run in the unit lane (39/41 for pattern_cache, 22/23 for edge_cases — 2 and 1 respectively withheld as performance-tagged)
- [x] `bundle exec rspec spec/services/categorization/pattern_cache_spec.rb --tag performance` — only the 2 benchmark examples run
- [x] `bundle exec rspec spec/models/categorization_pattern_edge_cases_spec.rb --tag performance` — only the 1 benchmark example runs
- [x] `bundle exec rubocop` on changed files — no offenses
- [x] Pre-commit hook (unit suite + RuboCop + Brakeman + Rails Best Practices) — all green