### PR TITLE
test: move all wall-clock assertions out of the unit tier

### DIFF
--- a/spec/services/categorization/confidence_calculator_spec.rb
+++ b/spec/services/categorization/confidence_calculator_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe Services::Categorization::ConfidenceCalculator do
   end
 
   describe "performance" do
-    it "completes calculation within reasonable threshold" do
+    it "completes calculation within reasonable threshold", performance: true do
       # Warm up to avoid first-run overhead
       calculator.calculate(expense, pattern, 0.85)
 
@@ -472,7 +472,7 @@ RSpec.describe Services::Categorization::ConfidenceCalculator do
       expect(duration_ms).to be < 5.0
     end
 
-    it "handles batch calculations efficiently" do
+    it "handles batch calculations efficiently", performance: true do
       patterns = create_list(:categorization_pattern, 10, category: category)
 
       # Warm up to avoid first-run overhead

--- a/spec/services/categorization/matchers/fuzzy_matcher_fixes_spec.rb
+++ b/spec/services/categorization/matchers/fuzzy_matcher_fixes_spec.rb
@@ -177,7 +177,9 @@ RSpec.describe Services::Categorization::Matchers::FuzzyMatcher, type: :service 
   describe "Performance Requirements" do
     let(:matcher) { described_class.new }
 
-    it "completes matching within reasonable threshold" do
+    # performance: wall-clock assertion — belongs in the benchmark lane, not
+    # the unit tier (flaked on a busy CI runner when folded to unit).
+    it "completes matching within reasonable threshold", performance: true do
       # Use 50 candidates for more realistic performance test
       candidates = 50.times.map { |i| "Merchant #{i}" }
 

--- a/spec/services/categorization/orchestrator_integration_spec.rb
+++ b/spec/services/categorization/orchestrator_integration_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Services::Categorization::Orchestrator Integration", type: :serv
         ]
       end
 
-      it "processes multiple expenses efficiently" do
+      it "processes multiple expenses efficiently", performance: true do
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         results = orchestrator.batch_categorize(expenses)
         elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000

--- a/spec/services/categorization/pattern_learner_spec.rb
+++ b/spec/services/categorization/pattern_learner_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Services::Categorization::PatternLearner do
     end
 
     context "performance" do
-      it "completes within 200ms for single correction" do
+      it "completes within 200ms for single correction", performance: true do
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         learner.learn_from_correction(expense, food_category)
         duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000

--- a/spec/services/expense_filter_service_spec.rb
+++ b/spec/services/expense_filter_service_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Services::ExpenseFilterService, type: :service do
         end
       end
 
-      it "completes complex queries within 50ms" do
+      it "completes complex queries within 50ms", performance: true do
         service = described_class.new(
           account_ids: [ email_account.id ],
           start_date: 30.days.ago,

--- a/spec/services/metrics_calculator_budget_spec.rb
+++ b/spec/services/metrics_calculator_budget_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Services::MetricsCalculator, 'budget calculations' do
       end
     end
 
-    it 'calculates budget data within performance target' do
+    it 'calculates budget data within performance target', performance: true do
       time = Benchmark.realtime do
         calculator.calculate
       end

--- a/spec/services/metrics_calculator_spec.rb
+++ b/spec/services/metrics_calculator_spec.rb
@@ -779,7 +779,7 @@ RSpec.describe Services::MetricsCalculator, type: :service do
       end
     end
 
-    it 'completes calculation within 100ms' do
+    it 'completes calculation within 100ms', performance: true do
       # Warm up
       calculator.calculate
       Rails.cache.clear


### PR DESCRIPTION
## Summary
Main-branch Unit Tests flaked on `fuzzy_matcher_fixes_spec`'s 50ms wall-clock assertion (busy runner), blocking the Test Suite trigger. Rather than fix one, this sweeps the entire unit tier for timing assertions: all 8 `expect(duration).to be < N` examples across 7 files are tagged `performance: true`, moving them to the benchmark lane where runner variance is expected and tolerated.

Unit tier now contains zero wall-clock assertions. Performance lane: 76 examples, 0 failures locally under CI conditions.

## Review notes
Example-level tags only — no assertions changed, no examples deleted. Each moved example keeps its original threshold.