### PR TITLE
fix(metrics): build tz-aware date ranges so period boundaries respect app timezone

### DIFF
--- a/app/services/metrics_calculator.rb
+++ b/app/services/metrics_calculator.rb
@@ -127,16 +127,24 @@ module Services
   # Pre-load and cache expense data for multiple periods to optimize batch calculations
   private_class_method def self.preload_data_for_batch(email_account, periods, reference_date)
     # Determine the widest date range needed
+    #
+    # NOTE: ranges must be built in the app's configured time zone (not the
+    # server/Postgres session zone). Bare Date#beginning_of_day/end_of_day
+    # convert via the system local zone, and Date..Date ranges get emitted
+    # as naive date literals that Postgres casts in its own session zone —
+    # both land expenses near local midnight on the wrong side of the
+    # boundary. See calculate_date_range for the same fix applied to the
+    # single-instance date range.
     date_ranges = periods.map do |period|
       case period.to_sym
       when :day
-        reference_date.beginning_of_day..reference_date.end_of_day
+        reference_date.in_time_zone.all_day
       when :week
-        reference_date.beginning_of_week..reference_date.end_of_week
+        reference_date.in_time_zone.beginning_of_week..reference_date.in_time_zone.end_of_week
       when :month
-        reference_date.beginning_of_month..reference_date.end_of_month
+        reference_date.in_time_zone.beginning_of_month..reference_date.in_time_zone.end_of_month
       when :year
-        reference_date.beginning_of_year..reference_date.end_of_year
+        reference_date.in_time_zone.beginning_of_year..reference_date.in_time_zone.end_of_year
       end
     end
 
@@ -207,16 +215,26 @@ module Services
     @previous_date_range ||= calculate_previous_date_range
   end
 
+  # Builds a tz-aware range for the current period.
+  #
+  # IMPORTANT: must NOT return a bare Date..Date range or a Time built via
+  # Date#to_time (which uses the system/local zone, not the app's
+  # configured Time.zone). ActiveRecord queries transaction_date (a
+  # tz-aware datetime column) with these ranges; a naive Date endpoint gets
+  # emitted as a naive date literal that Postgres casts in its own session
+  # time zone rather than the app's, so expenses near local midnight can
+  # land on the wrong side of the period boundary. Explicitly anchoring
+  # every endpoint in Time.zone via #in_time_zone avoids that ambiguity.
   def calculate_date_range
     case period
     when :day
-      reference_date.beginning_of_day..reference_date.end_of_day
+      reference_date.in_time_zone.all_day
     when :week
-      reference_date.beginning_of_week..reference_date.end_of_week
+      reference_date.in_time_zone.beginning_of_week..reference_date.in_time_zone.end_of_week
     when :month
-      reference_date.beginning_of_month..reference_date.end_of_month
+      reference_date.in_time_zone.beginning_of_month..reference_date.in_time_zone.end_of_month
     when :year
-      reference_date.beginning_of_year..reference_date.end_of_year
+      reference_date.in_time_zone.beginning_of_year..reference_date.in_time_zone.end_of_year
     end
   end
 
@@ -224,16 +242,16 @@ module Services
     case period
     when :day
       previous_date = reference_date - 1.day
-      previous_date.beginning_of_day..previous_date.end_of_day
+      previous_date.in_time_zone.all_day
     when :week
       previous_date = reference_date - 1.week
-      previous_date.beginning_of_week..previous_date.end_of_week
+      previous_date.in_time_zone.beginning_of_week..previous_date.in_time_zone.end_of_week
     when :month
       previous_date = reference_date - 1.month
-      previous_date.beginning_of_month..previous_date.end_of_month
+      previous_date.in_time_zone.beginning_of_month..previous_date.in_time_zone.end_of_month
     when :year
       previous_date = reference_date - 1.year
-      previous_date.beginning_of_year..previous_date.end_of_year
+      previous_date.in_time_zone.beginning_of_year..previous_date.in_time_zone.end_of_year
     end
   end
 
@@ -343,8 +361,12 @@ module Services
 
     # Get daily totals for the past 7 days
     # Group by date (not datetime) to ensure proper matching
+    #
+    # Range endpoints are anchored in the app's Time.zone (not the system/
+    # Postgres session zone) for the same reason as calculate_date_range —
+    # otherwise expenses near local midnight can fall outside the window.
     daily_totals = email_account.expenses
-      .where(transaction_date: start_date.beginning_of_day..end_date.end_of_day)
+      .where(transaction_date: start_date.in_time_zone.beginning_of_day..end_date.in_time_zone.end_of_day)
       .group("DATE(transaction_date)")
       .sum(:amount)
 

--- a/spec/services/metrics_calculator_spec.rb
+++ b/spec/services/metrics_calculator_spec.rb
@@ -251,8 +251,10 @@ RSpec.describe Services::MetricsCalculator, type: :service do
           calculated_at: be_a(Time)
         )
 
+        # date_range is built via #in_time_zone (app tz), not bare Date
+        # boundaries — see calculate_date_range for why.
         expect(result[:date_range]).to eq(
-          current_date.beginning_of_month..current_date.end_of_month
+          current_date.in_time_zone.beginning_of_month..current_date.in_time_zone.end_of_month
         )
       end
 
@@ -297,24 +299,19 @@ RSpec.describe Services::MetricsCalculator, type: :service do
         })
       end
 
-      # PENDING: real bug found while folding this spec into the unit tier
-      # (batch 3). MetricsCalculator#calculate_date_range /
-      # #calculate_previous_date_range build Date..Date ranges (Date#end_of_month
-      # etc. on a Date stays a Date). ActiveRecord then emits a naive
-      # `BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'` against the `transaction_date`
-      # datetime column instead of extending the upper bound to end-of-day.
-      # Postgres casts those literals in its own session time zone, which does
-      # not match the app's local zone (Costa Rica, -06:00) used to store
-      # midnight timestamps — so records land on the wrong side of the
-      # boundary depending on the UTC offset at that exact date. Not caused by
-      # or fixable via fixture/user-scoping changes; needs a real fix to the
-      # date-range construction (e.g. explicit `.end_of_day` cast in the app's
-      # time zone) with its own review, since it affects every period type and
-      # every MetricsCalculator consumer. See also the identical failures on
-      # ':month period calculates trends correctly', '.batch_calculate
-      # calculates metrics for each requested period', and 'edge cases with
-      # expenses on period boundaries' in this file.
-      it 'calculates trends correctly', pending: "real bug: date-range boundary excludes/includes records across local-vs-UTC midnight offset (see comment above); not a fixture issue" do
+      # REGRESSION (was pending): MetricsCalculator#calculate_date_range /
+      # #calculate_previous_date_range used to build Date..Date ranges
+      # (Date#end_of_month etc. on a Date stays a Date), which ActiveRecord
+      # emitted as a naive `BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'` against the
+      # `transaction_date` datetime column instead of extending the upper
+      # bound to end-of-day. Postgres cast those literals in its own session
+      # time zone, which didn't match the app's local zone (Costa Rica,
+      # -06:00) used to store midnight timestamps — so records landed on the
+      # wrong side of the boundary depending on the UTC offset at that exact
+      # date. Fixed by anchoring every range endpoint via `#in_time_zone`.
+      # See also '.batch_calculate calculates metrics for each requested
+      # period' and 'edge cases with expenses on period boundaries' below.
+      it 'calculates trends correctly' do
         Rails.cache.clear
         result = calculator.calculate
         trends = result[:trends]
@@ -377,9 +374,9 @@ RSpec.describe Services::MetricsCalculator, type: :service do
         # Only 1 expense on August 10
         expect(metrics[:total_amount]).to eq(100.50)
         expect(metrics[:transaction_count]).to eq(1)
-        expect(result[:date_range]).to eq(
-          current_date.beginning_of_day..current_date.end_of_day
-        )
+        # date_range is built via #in_time_zone (app tz), not bare Date
+        # boundaries — see calculate_date_range for why.
+        expect(result[:date_range]).to eq(current_date.in_time_zone.all_day)
       end
 
       it 'does not include daily breakdown for day period' do
@@ -394,8 +391,10 @@ RSpec.describe Services::MetricsCalculator, type: :service do
       it 'calculates metrics for week' do
         result = calculator.calculate
 
+        # date_range is built via #in_time_zone (app tz), not bare Date
+        # boundaries — see calculate_date_range for why.
         expect(result[:date_range]).to eq(
-          current_date.beginning_of_week..current_date.end_of_week
+          current_date.in_time_zone.beginning_of_week..current_date.in_time_zone.end_of_week
         )
       end
 
@@ -412,8 +411,10 @@ RSpec.describe Services::MetricsCalculator, type: :service do
         Rails.cache.clear
         result = calculator.calculate
 
+        # date_range is built via #in_time_zone (app tz), not bare Date
+        # boundaries — see calculate_date_range for why.
         expect(result[:date_range]).to eq(
-          current_date.beginning_of_year..current_date.end_of_year
+          current_date.in_time_zone.beginning_of_year..current_date.in_time_zone.end_of_year
         )
 
         # Should include all 5 expenses (2 in August + 2 in July + 1 from 45 days ago which is still in 2025)
@@ -639,10 +640,10 @@ RSpec.describe Services::MetricsCalculator, type: :service do
       expect(result.keys).to match_array([ :day, :week, :month ])
     end
 
-    # PENDING: same date-range timezone boundary bug documented above
-    # '#calculate with month period calculates trends correctly' — see that
-    # comment for the root cause. Not a fixture/user-scoping issue.
-    it 'calculates metrics for each requested period', pending: "real bug: date-range boundary excludes/includes records across local-vs-UTC midnight offset; not a fixture issue" do
+    # REGRESSION (was pending): same date-range timezone boundary bug
+    # documented above '#calculate with month period calculates trends
+    # correctly' — see that comment for the root cause and fix.
+    it 'calculates metrics for each requested period' do
       Rails.cache.clear
 
       result = described_class.batch_calculate(
@@ -862,16 +863,51 @@ RSpec.describe Services::MetricsCalculator, type: :service do
                transaction_date: current_date.end_of_month)
       end
 
-      # PENDING: same date-range timezone boundary bug documented above
-      # '#calculate with month period calculates trends correctly' — see that
-      # comment for the root cause. Not a fixture/user-scoping issue.
-      it 'includes only expenses within period boundaries', pending: "real bug: date-range boundary excludes/includes records across local-vs-UTC midnight offset; not a fixture issue" do
+      # REGRESSION (was pending): same date-range timezone boundary bug
+      # documented above '#calculate with month period calculates trends
+      # correctly' — see that comment for the root cause and fix.
+      it 'includes only expenses within period boundaries' do
         Rails.cache.clear
         result = calculator.calculate
 
         # Should include expenses from beginning to end of month
         expect(result[:metrics][:transaction_count]).to eq(2)
         expect(result[:metrics][:total_amount]).to eq(500.00)
+      end
+    end
+
+    # New boundary regression coverage: exact midnight endpoints in the app's
+    # time zone, not just "near" the boundary. Pins down the tz-aware fix in
+    # calculate_date_range directly, independent of the other 3 specs above.
+    context 'with expenses exactly at local midnight boundaries' do
+      let(:period) { :month }
+
+      before do
+        # 00:00:00 local time on the period's first day — must count
+        create(:expense,
+               email_account: email_account,
+               amount: 10.00,
+               transaction_date: current_date.beginning_of_month.in_time_zone.beginning_of_day)
+
+        # 23:59:59 local time on the period's last day — must count
+        create(:expense,
+               email_account: email_account,
+               amount: 20.00,
+               transaction_date: current_date.end_of_month.in_time_zone.end_of_day)
+
+        # 00:00:00 local time the day AFTER the period ends — must NOT count
+        create(:expense,
+               email_account: email_account,
+               amount: 999.00,
+               transaction_date: (current_date.end_of_month + 1.day).in_time_zone.beginning_of_day)
+      end
+
+      it 'includes both midnight-boundary expenses and excludes the one after the period ends' do
+        Rails.cache.clear
+        result = calculator.calculate
+
+        expect(result[:metrics][:transaction_count]).to eq(2)
+        expect(result[:metrics][:total_amount]).to eq(30.00)
       end
     end
   end


### PR DESCRIPTION
## Bug

`Services::MetricsCalculator#calculate_date_range` / `#calculate_previous_date_range` built period ranges in a way that didn't respect the app's configured time zone (`Central America`, -06:00):

- **week/month/year**: `reference_date.beginning_of_week` etc. on a `Date` stays a `Date` (`Date#beginning_of_week` returns `Date`, not `Time`). ActiveRecord then queried the tz-aware `transaction_date` datetime column with a bare `Date..Date` range, which Postgres cast in **its own session time zone**, not the app's.
- **day**: `reference_date.beginning_of_day`/`end_of_day` go through `Date#to_time`, which uses the **system/local** time zone, not `Time.zone`.

Either way, expenses stored near local midnight could land on the wrong side of a period boundary. This affected every period type and every consumer (dashboards, budgets, trends), since `date_range`/`previous_date_range` back every query in the class.

The same pattern also existed in two other call sites in this class:
- `preload_data_for_batch` (widest-range preload query for `batch_calculate`)
- `calculate_trend_data` (7-day sparkline window)

## Fix

Anchor every range endpoint via `#in_time_zone` so ranges are always built against the app's actual configured zone:
- `date.in_time_zone.all_day` for single days
- `start.in_time_zone.beginning_of_X..end.in_time_zone.end_of_X` for week/month/year spans

Public API (period types, arguments) is unchanged. `date_range`'s *return type* changes from `Date..Date` (week/month/year) to tz-aware `Time..Time`, which is the actual bug fix — see "Before/after" below.

## Before / after boundary behavior

| Period | Before | After |
|---|---|---|
| day | `Date#to_time` range (system tz) | `Date#in_time_zone.all_day` (app tz) |
| week/month/year | bare `Date..Date` (Postgres casts in its own session tz) | `Time.zone`-anchored `Time..Time` |

Example: an expense stored at `2025-08-01 00:00:00 -06:00` (first local moment of August) previously could be excluded from the August `month` range depending on Postgres's session tz; now it's reliably included.

## Regression specs

Un-pended 3 specs in `spec/services/metrics_calculator_spec.rb` (assertions kept exactly as originally written):
- `#calculate with month period calculates trends correctly` (total_amount 500.00 / previous_period_total 100.00 path via the trends assertions)
- `.batch_calculate calculates metrics for each requested period` (week total 150.00)
- `edge cases with expenses on period boundaries includes only expenses within period boundaries` (total_amount 500.00)

Also:
- Updated 3 pre-existing `date_range` equality assertions that compared against bare `Date` ranges, since `date_range`'s return type for week/month/year periods is now correctly tz-aware `Time` instead of `Date`.
- Added one new boundary regression spec (`with expenses exactly at local midnight boundaries`) pinning the exact requested scenario: an expense at `00:00:00` local on the period's first day and one at `23:59:59` local on the last day both count; one at `00:00:00` local the day after does not.

## Consumers checked

- `Services::ExtendedCacheMetricsCalculator` (subclass) — doesn't override the changed methods, unaffected.
- `app/views/expenses/dashboard.html.erb` / `_metric_card.html.erb` render `date_range.first`/`.last` into `data-dashboard-card-navigation-date-from/to-value`, consumed by the `dashboard-card-navigation` Stimulus controller, which round-trips them as `date_from`/`date_to` query params into `ExpensesController#parse_date_param` (`Date.parse`). `Date.parse` is tolerant of the appended zone-offset text in a `Time#to_s`, so the date component still extracts correctly. Verified via `spec/requests/dashboard_v2_metric_cards_spec.rb` and `spec/system/dashboard_card_navigation_spec.rb` — both green.

**Flagging, not fixing (out of scope for this PR):** `ExpensesController#calculate_period_range` and `#apply_filters` build their own date ranges the same buggy way — `Date#beginning_of_day`/`end_of_day` off `Date.current` or a `Date.parse`'d param, not `Time.zone`. This is the identical bug class in a different file/service and should get its own fix + review.

## Test plan

- [x] `bundle exec rspec spec/services/metrics_calculator_spec.rb spec/services/metrics_calculator_budget_spec.rb spec/services/metrics_calculator_trend_data_spec.rb` — 85 examples, 0 failures, 0 pending
- [x] `bin/test-unit` (full unit tier) — 8557 examples, 0 failures, 5 pending (all pre-existing/unrelated)
- [x] `bundle exec rubocop -a` on touched files — no offenses
- [x] `bundle exec brakeman` (via pre-commit hook) — no warnings