### PR TITLE
security(jobs): encrypt bank-email bodies before they hit Solid Queue arguments

### DIFF
--- a/app/jobs/process_email_job.rb
+++ b/app/jobs/process_email_job.rb
@@ -12,13 +12,23 @@ class ProcessEmailJob < ApplicationJob
 
   TRUNCATE_SIZE = 10_000  # Store only 10KB for large emails
 
-  def perform(email_account_id, email_data, sync_session_id = nil, pre_parsed_data = nil)
+  # Security fix (2026-08 audit): `email_data_or_payload_id` is now either an
+  # Integer/String QueuedEmailPayload id (current producer path) or, for
+  # deploy-window compatibility, a legacy plaintext Hash (jobs already
+  # enqueued by Services::EmailProcessing::Processor before this fix
+  # shipped). See #resolve_email_payload for the branch. `legacy_pre_parsed_data`
+  # is only ever populated on that legacy Hash path — the current path folds
+  # pre_parsed data into the encrypted QueuedEmailPayload record instead.
+  def perform(email_account_id, email_data_or_payload_id, sync_session_id = nil, legacy_pre_parsed_data = nil)
     email_account = EmailAccount.find_by(id: email_account_id)
 
     unless email_account
       Rails.logger.error "EmailAccount not found: #{email_account_id}"
       return
     end
+
+    payload_record, email_data, pre_parsed_data = resolve_email_payload(email_data_or_payload_id, legacy_pre_parsed_data)
+    return if email_data.nil?
 
     Rails.logger.info "Processing individual email for: #{email_account.email}"
     # Do NOT log email_data.inspect — the :body contains plaintext bank PII and is
@@ -30,17 +40,62 @@ class ProcessEmailJob < ApplicationJob
     metrics_collector = Services::SyncMetricsCollector.new(sync_session) if sync_session
 
     # Track expense detection operation
-    if metrics_collector
-      metrics_collector.track_operation(:detect_expense, email_account, { email_subject: email_data&.dig(:subject) }) do
+    result = if metrics_collector
+      outcome = metrics_collector.track_operation(:detect_expense, email_account, { email_subject: email_data&.dig(:subject) }) do
         parse_and_save_expense(email_account, email_data, pre_parsed_data)
       end
       metrics_collector.flush_buffer
+      outcome
     else
       parse_and_save_expense(email_account, email_data, pre_parsed_data)
     end
+
+    # Only reached once processing has actually completed (success or a
+    # handled parsing failure) — if anything above raises, execution never
+    # gets here and the record is left unprocessed so a retry_on retry (or a
+    # manual re-run) still has data to work with.
+    payload_record&.mark_processed!
+
+    result
   end
 
   private
+
+  # Resolves the (payload_record, email_data, pre_parsed_data) tuple the rest
+  # of #perform needs, supporting two argument shapes:
+  #
+  #   - Integer/String id (current path): looks up the encrypted
+  #     QueuedEmailPayload record created by
+  #     Services::EmailProcessing::Processor and unpacks its payload_data.
+  #   - Hash (legacy path, deploy-window compatibility): jobs enqueued by the
+  #     old signature — a plaintext email_data Hash plus pre_parsed_data as
+  #     the 4th positional argument — before this fix shipped. In-flight
+  #     Solid Queue jobs from before the deploy must still process
+  #     successfully, so this path stays supported (it's cheap to keep).
+  #
+  # A missing/deleted payload record (already processed + purged, or an
+  # invalid id) or an unrecognized argument type both return a nil email_data,
+  # which #perform treats as "log it, discard, don't crash-loop through the
+  # retry budget."
+  def resolve_email_payload(email_data_or_payload_id, legacy_pre_parsed_data)
+    case email_data_or_payload_id
+    when Integer, String
+      payload_record = QueuedEmailPayload.find_by(id: email_data_or_payload_id)
+      unless payload_record
+        Rails.logger.error "[ProcessEmailJob] QueuedEmailPayload #{email_data_or_payload_id.inspect} not found (already processed/purged, or invalid id) — discarding."
+        return [ nil, nil, nil ]
+      end
+
+      data = payload_record.payload_data || {}
+      [ payload_record, data[:email_data], data[:pre_parsed] ]
+    when Hash
+      Rails.logger.warn "[ProcessEmailJob] Deprecated: received a legacy plaintext email_data Hash directly in job arguments (enqueued before the encrypted-payload fix shipped). Processing for deploy-window compatibility."
+      [ nil, email_data_or_payload_id, legacy_pre_parsed_data ]
+    else
+      Rails.logger.error "[ProcessEmailJob] Unrecognized argument type for email_data_or_payload_id: #{email_data_or_payload_id.class} — discarding."
+      [ nil, nil, nil ]
+    end
+  end
 
   def parse_and_save_expense(email_account, email_data, pre_parsed_data = nil)
     parser = Services::EmailProcessing::Parser.new(email_account, email_data, pre_parsed_data: pre_parsed_data)

--- a/app/jobs/process_email_job.rb
+++ b/app/jobs/process_email_job.rb
@@ -54,7 +54,18 @@ class ProcessEmailJob < ApplicationJob
     # handled parsing failure) — if anything above raises, execution never
     # gets here and the record is left unprocessed so a retry_on retry (or a
     # manual re-run) still has data to work with.
-    payload_record&.mark_processed!
+    begin
+      payload_record&.mark_processed!
+    rescue StandardError => e
+      # A processed-but-unmarked payload is harmless: QueuedEmailPayload's
+      # UNPROCESSED_RETENTION (30 days) purges it eventually regardless. But
+      # letting this raise escape would re-trigger this job's own retry_on
+      # (e.g. ActiveRecord::Deadlocked), which re-parses the email and, since
+      # the expense was already persisted above, flips it to status:
+      # :duplicate via Parser's duplicate branch — silent data corruption on
+      # an already-successful outcome. Log and swallow instead.
+      Rails.logger.error "[ProcessEmailJob] Failed to mark QueuedEmailPayload #{payload_record&.id.inspect} as processed: #{e.class}: #{e.message}"
+    end
 
     result
   end
@@ -86,9 +97,38 @@ class ProcessEmailJob < ApplicationJob
         return [ nil, nil, nil ]
       end
 
-      data = payload_record.payload_data || {}
+      # Replayed/duplicate enqueue of the same payload id (e.g. a retry_on
+      # retry after mark_processed! itself failed — see the rescue around
+      # mark_processed! in #perform). The record was already fully processed,
+      # so re-parsing here would call Parser again on an already-persisted
+      # expense, which flips it to status: :duplicate via Parser's duplicate
+      # branch. Skip straight to the "nothing to do" tuple instead.
+      if payload_record.processed_at.present?
+        Rails.logger.warn "[ProcessEmailJob] QueuedEmailPayload #{payload_record.id} already processed at #{payload_record.processed_at} — skipping re-parse on replayed enqueue."
+        return [ payload_record, nil, nil ]
+      end
+
+      data = payload_record.payload_data
+      if data.blank?
+        # Distinct from the "not found" branch above: the record exists but
+        # its payload came back unreadable (see
+        # QueuedEmailPayload#payload_data, which rescues deserialization
+        # failures and returns nil instead of raising). Corruption must be
+        # observable, not silently swallowed into an empty hash.
+        Rails.logger.error "[ProcessEmailJob] QueuedEmailPayload #{payload_record.id} found but payload_data is blank (corrupted/unreadable) — discarding."
+        return [ payload_record, nil, nil ]
+      end
+
       [ payload_record, data[:email_data], data[:pre_parsed] ]
     when Hash
+      # Legacy branch — deploy-window compatibility only, not a supported
+      # long-term argument shape. Removal condition: once Solid Queue's
+      # ready/scheduled/failed job tables show zero jobs whose second
+      # argument is a Hash (i.e. no pre-deploy enqueues left to drain) — in
+      # practice ~30 days post-deploy, matching
+      # QueuedEmailPayload::UNPROCESSED_RETENTION, since anything older would
+      # already be past its retry budget. Tracked as a follow-up; do not
+      # remove this branch until that check has been done.
       Rails.logger.warn "[ProcessEmailJob] Deprecated: received a legacy plaintext email_data Hash directly in job arguments (enqueued before the encrypted-payload fix shipped). Processing for deploy-window compatibility."
       [ nil, email_data_or_payload_id, legacy_pre_parsed_data ]
     else

--- a/app/jobs/queued_email_payload_cleanup_job.rb
+++ b/app/jobs/queued_email_payload_cleanup_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Background job that purges QueuedEmailPayload rows past their retention
+# window.
+#
+# QueuedEmailPayload holds the encrypted bank-email body/pre-parsed data that
+# ProcessEmailJob consumes (2026-08 audit fix — see QueuedEmailPayload for the
+# full rationale). Two retention windows, matching the model's constants:
+#
+#   - processed rows (ProcessEmailJob already consumed them): purge quickly
+#     (QueuedEmailPayload::PROCESSED_RETENTION, 7 days) — they're transient
+#     scratch data with no further use.
+#   - unprocessed rows (still awaiting a retry, or stuck): kept much longer
+#     (QueuedEmailPayload::UNPROCESSED_RETENTION, 30 days) so retries and a
+#     backlogged/paused queue still have data to work with, and so an
+#     operator has time to notice a stuck queue before payload data
+#     disappears.
+#
+# Scheduled daily via config/recurring.yml, alongside the other PII retention
+# jobs (EmailParsingFailureCleanupJob, SolidQueueFailedExecutionCleanupJob).
+class QueuedEmailPayloadCleanupJob < ApplicationJob
+  queue_as :low
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform
+    Rails.logger.info "[QueuedEmailPayloadCleanup] Starting cleanup " \
+      "(processed_retention=#{QueuedEmailPayload::PROCESSED_RETENTION.inspect}, " \
+      "unprocessed_retention=#{QueuedEmailPayload::UNPROCESSED_RETENTION.inspect})..."
+
+    # delete_all (not destroy_all): no before/after_destroy callbacks on
+    # QueuedEmailPayload, so bulk SQL DELETE is correct and fast (matches the
+    # EmailParsingFailureCleanupJob / SolidQueueFailedExecutionCleanupJob
+    # pattern).
+    processed_count = QueuedEmailPayload.expired_processed.delete_all
+    unprocessed_count = QueuedEmailPayload.expired_unprocessed.delete_all
+
+    Rails.logger.info "[QueuedEmailPayloadCleanup] Cleanup complete: " \
+      "processed_cleaned_up=#{processed_count}, unprocessed_cleaned_up=#{unprocessed_count}"
+  rescue StandardError => e
+    Rails.logger.error "[QueuedEmailPayloadCleanup] Cleanup failed: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise
+  end
+end

--- a/app/models/email_account.rb
+++ b/app/models/email_account.rb
@@ -14,6 +14,7 @@ class EmailAccount < ApplicationRecord
   has_many :categories, through: :expenses
   has_many :sync_metrics, dependent: :destroy
   has_many :email_parsing_failures, dependent: :destroy
+  has_many :queued_email_payloads, dependent: :destroy
   has_one :external_budget_source, dependent: :destroy
 
   # Validations

--- a/app/models/queued_email_payload.rb
+++ b/app/models/queued_email_payload.rb
@@ -42,11 +42,17 @@ class QueuedEmailPayload < ApplicationRecord
   end
 
   # @return [Hash, nil] the original hash passed to `payload_data=`, with
-  #   Symbol keys and Time/BigDecimal values restored.
+  #   Symbol keys and Time/BigDecimal values restored. Returns nil (instead of
+  #   raising) if the stored blob is corrupted or otherwise unreadable —
+  #   callers (see ProcessEmailJob#resolve_email_payload) treat a nil/blank
+  #   result as "nothing to process" rather than crash-looping a job retry.
   def payload_data
     return nil if encrypted_payload.blank?
 
     ActiveJob::Arguments.deserialize(JSON.parse(encrypted_payload)).first
+  rescue JSON::ParserError, ActiveJob::DeserializationError, ArgumentError => e
+    Rails.logger.error "[QueuedEmailPayload] Failed to deserialize payload_data for record #{id}: #{e.class}: #{e.message}"
+    nil
   end
 
   def mark_processed!

--- a/app/models/queued_email_payload.rb
+++ b/app/models/queued_email_payload.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Holds the full email payload (bank notification body + any pre-parsed
+# expense data) that ProcessEmailJob needs, encrypted at rest.
+#
+# Security fix (2026-08 audit): this table exists so ProcessEmailJob.perform_later
+# only receives an id in its job arguments — never the raw bank-email body.
+# Active Job serializes job arguments into solid_queue_jobs.arguments (and the
+# ready/failed_executions tables) as plaintext text, which is readable by
+# anyone with DB access on the shared personal-blog-db host. Encrypting the
+# payload here — the same `encrypts` mechanism already used for
+# expenses.email_body and email_parsing_failures.raw_email_content — closes
+# that gap.
+#
+# `encrypted_payload` stores an ActiveJob::Arguments-serialized JSON blob
+# (not a plain `hash.to_json`) so Symbol keys, Time/BigDecimal values, etc.
+# round-trip exactly as ProcessEmailJob previously received them as raw job
+# arguments. Use `payload_data` / `payload_data=` rather than touching the
+# encrypted column directly.
+class QueuedEmailPayload < ApplicationRecord
+  encrypts :encrypted_payload
+
+  belongs_to :email_account
+  belongs_to :sync_session, optional: true
+
+  # Retention: processed rows are transient scratch data, purge quickly.
+  # Unprocessed rows are kept longer so retries/backlogged jobs still have
+  # something to consume; a much longer window also gives an operator time to
+  # notice a stuck queue before payload data disappears.
+  PROCESSED_RETENTION = 7.days
+  UNPROCESSED_RETENTION = 30.days
+
+  scope :processed, -> { where.not(processed_at: nil) }
+  scope :unprocessed, -> { where(processed_at: nil) }
+  scope :expired_processed, -> { processed.where(processed_at: ..PROCESSED_RETENTION.ago) }
+  scope :expired_unprocessed, -> { unprocessed.where(created_at: ..UNPROCESSED_RETENTION.ago) }
+
+  # @param data [Hash] arbitrary job-argument-shaped data (e.g.
+  #   { email_data: {...}, pre_parsed: {...} })
+  def payload_data=(data)
+    self.encrypted_payload = ActiveJob::Arguments.serialize([ data ]).to_json
+  end
+
+  # @return [Hash, nil] the original hash passed to `payload_data=`, with
+  #   Symbol keys and Time/BigDecimal values restored.
+  def payload_data
+    return nil if encrypted_payload.blank?
+
+    ActiveJob::Arguments.deserialize(JSON.parse(encrypted_payload)).first
+  end
+
+  def mark_processed!
+    update!(processed_at: Time.current)
+  end
+end

--- a/app/models/sync_session.rb
+++ b/app/models/sync_session.rb
@@ -7,6 +7,7 @@ class SyncSession < ApplicationRecord
   has_many :email_accounts, through: :sync_session_accounts
   has_many :sync_conflicts, dependent: :destroy
   has_many :sync_metrics, dependent: :destroy
+  has_many :queued_email_payloads, dependent: :nullify
 
   scope :for_user, ->(u) { where(user_id: u.id) }
 

--- a/app/services/email_processing/processor.rb
+++ b/app/services/email_processing/processor.rb
@@ -113,7 +113,21 @@ module Services::EmailProcessing
           # to avoid Float rounding on financial values
           conflict_result.merge(amount: conflict_result[:amount]&.to_s)
         end
-        ProcessEmailJob.perform_later(email_account.id, email_data, @sync_session&.id, pre_parsed)
+
+        # Security fix (2026-08 audit): email_data[:body] is the full decoded
+        # bank notification (transaction PII), and pre_parsed[:raw_email_content]
+        # is a copy of the same body. Neither may travel as a plain
+        # ProcessEmailJob argument — Active Job serializes job arguments into
+        # solid_queue_jobs.arguments (and ready/failed_executions) as
+        # plaintext text, readable by anyone with DB access on the shared
+        # personal-blog-db host. Persist both behind QueuedEmailPayload's
+        # `encrypts` column instead, and pass only its id.
+        payload = QueuedEmailPayload.create!(
+          email_account: email_account,
+          sync_session: @sync_session,
+          payload_data: { email_data: email_data, pre_parsed: pre_parsed }
+        )
+        ProcessEmailJob.perform_later(email_account.id, payload.id, @sync_session&.id)
 
         {
           processed: true,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -37,7 +37,11 @@ Rails.application.config.filter_parameters += [
 # email_parsing_failures (PER-496) — Rails `encrypts` decrypts transparently
 # on attribute read, so an unfiltered `Model#inspect` would leak decrypted
 # bank PII.
+#
+# `:encrypted_payload` protects QueuedEmailPayload (2026-08 audit fix) — the
+# same decrypt-on-read concern applies to the bank-email bodies formerly
+# passed as plaintext ProcessEmailJob arguments.
 ActiveRecord::Base.filter_attributes += [
   :passw, :encrypted_password, :encrypted_settings, :token, :secret,
-  :raw_email_content
+  :raw_email_content, :encrypted_payload
 ]

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -94,6 +94,17 @@ default: &default
     schedule: every day at 4:15am
     description: "Purge failed job executions older than 30 days (PER-503 retention)"
 
+  # Purge QueuedEmailPayload rows past their retention window (2026-08 audit
+  # fix). Processed rows purge after 7 days, unprocessed rows after 30 days
+  # (see QueuedEmailPayload for the split rationale). Offset to 4:30am to
+  # avoid colliding with the two cleanup jobs above.
+  cleanup_queued_email_payloads:
+    class: QueuedEmailPayloadCleanupJob
+    queue: low
+    priority: 10
+    schedule: every day at 4:30am
+    description: "Purge encrypted queued-email payloads past their retention window (2026-08 audit)"
+
   # Pull the latest monthly budget from each active external budget source
   # (e.g. salary_calculator). Deactivated sources are skipped automatically.
   external_budgets_daily_sync:

--- a/db/migrate/20260801133817_create_queued_email_payloads.rb
+++ b/db/migrate/20260801133817_create_queued_email_payloads.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Security fix (2026-08 audit): ProcessEmailJob previously received the full
+# decoded bank-email body (transaction PII) as a plain job argument. Active
+# Job serializes arguments into solid_queue_jobs.arguments (and the
+# ready/failed_executions tables) as PLAINTEXT text — readable by anyone with
+# DB access on the shared personal-blog-db host. The app already encrypts
+# expenses.email_body and email_parsing_failures.raw_email_content; this table
+# closes the queue-table gap by moving the payload out of job arguments and
+# into an encrypted record, referenced by id.
+class CreateQueuedEmailPayloads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :queued_email_payloads do |t|
+      t.references :email_account, null: false, foreign_key: true
+      t.references :sync_session, null: true, foreign_key: true
+
+      # Encrypted JSON blob holding the original email_data hash plus any
+      # pre-parsed expense data (both may contain the full bank-email body).
+      # Serialized via ActiveJob::Arguments so Symbol keys, Time/BigDecimal
+      # values, etc. round-trip exactly as ProcessEmailJob previously
+      # received them as raw job arguments.
+      t.text :encrypted_payload, null: false
+
+      # Set once ProcessEmailJob has consumed the record. Drives retention:
+      # processed rows purge quickly, unprocessed ones stick around longer
+      # so retries still have data to work with.
+      t.datetime :processed_at
+
+      t.timestamps
+    end
+
+    add_index :queued_email_payloads, :processed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_052320) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_01_133817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -548,6 +548,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_052320) do
     t.index ["user_id"], name: "index_processed_emails_on_user_id"
   end
 
+  create_table "queued_email_payloads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "email_account_id", null: false
+    t.text "encrypted_payload", null: false
+    t.datetime "processed_at"
+    t.bigint "sync_session_id"
+    t.datetime "updated_at", null: false
+    t.index ["email_account_id"], name: "index_queued_email_payloads_on_email_account_id"
+    t.index ["processed_at"], name: "index_queued_email_payloads_on_processed_at"
+    t.index ["sync_session_id"], name: "index_queued_email_payloads_on_sync_session_id"
+  end
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.string "concurrency_key", null: false
     t.datetime "created_at", null: false
@@ -876,6 +888,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_052320) do
   add_foreign_key "pattern_learning_events", "users"
   add_foreign_key "processed_emails", "email_accounts"
   add_foreign_key "processed_emails", "users"
+  add_foreign_key "queued_email_payloads", "email_accounts"
+  add_foreign_key "queued_email_payloads", "sync_sessions"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/factories/queued_email_payloads.rb
+++ b/spec/factories/queued_email_payloads.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :queued_email_payload do
+    association :email_account
+    sync_session { nil }
+    payload_data do
+      {
+        email_data: {
+          body: "Transaction notification: $100.00 at Store ABC",
+          subject: "Transaction Alert",
+          from: "bank@example.com",
+          message_id: 1,
+          rfc_message_id: "<msg-1@example.com>",
+          date: Time.current
+        },
+        pre_parsed: nil
+      }
+    end
+
+    trait :processed do
+      processed_at { Time.current }
+    end
+  end
+end

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -379,4 +379,119 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
       )
     end
   end
+
+  # Security fix (2026-08 audit): ProcessEmailJob's second argument used to
+  # always be the raw email_data Hash (plaintext bank PII, serialized into
+  # solid_queue_jobs.arguments). It is now a QueuedEmailPayload id, with a
+  # Hash still accepted for deploy-window compatibility (in-flight jobs
+  # enqueued before this fix shipped).
+  describe 'QueuedEmailPayload argument handling (2026-08 security fix)', integration: true do
+    context 'with a QueuedEmailPayload id (current path)' do
+      let!(:payload) do
+        QueuedEmailPayload.create!(
+          email_account: email_account,
+          payload_data: { email_data: email_data, pre_parsed: nil }
+        )
+      end
+
+      it 'creates an expense from the payload record data' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, payload.id)
+        }.to change(Expense, :count).by(1)
+      end
+
+      it 'marks the payload record as processed' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, payload.id)
+        }.to change { payload.reload.processed_at }.from(nil)
+      end
+
+      it 'passes the sync_session id through unchanged' do
+        sync_session = create(:sync_session, user: email_account.user)
+        payload_with_session = QueuedEmailPayload.create!(
+          email_account: email_account,
+          sync_session: sync_session,
+          payload_data: { email_data: email_data, pre_parsed: nil }
+        )
+
+        expect(Services::SyncMetricsCollector).to receive(:new).with(sync_session).and_call_original
+
+        ProcessEmailJob.new.perform(email_account.id, payload_with_session.id, sync_session.id)
+      end
+
+      it 'restores pre_parsed data (e.g. String amount) from the payload record' do
+        pre_parsed = {
+          amount: "95000.50",
+          transaction_date: Date.current.to_s,
+          merchant_name: "PTA LEONA SOC",
+          description: "Purchase",
+          email_account_id: email_account.id,
+          raw_email_content: sample_bac_email
+        }
+        payload_with_pre_parsed = QueuedEmailPayload.create!(
+          email_account: email_account,
+          payload_data: { email_data: email_data, pre_parsed: pre_parsed }
+        )
+
+        ProcessEmailJob.new.perform(email_account.id, payload_with_pre_parsed.id)
+
+        expect(Expense.last.amount).to eq(95000.50)
+      end
+    end
+
+    context 'with a legacy plaintext Hash (deploy-window compatibility)' do
+      it 'still creates an expense (in-flight pre-deploy jobs must keep working)' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, email_data)
+        }.to change(Expense, :count).by(1)
+      end
+
+      it 'logs a deprecation warning' do
+        allow(Rails.logger).to receive(:warn)
+
+        ProcessEmailJob.new.perform(email_account.id, email_data)
+
+        expect(Rails.logger).to have_received(:warn).with(a_string_matching(/Deprecated.*legacy plaintext email_data Hash/))
+      end
+
+      it 'does not touch QueuedEmailPayload at all' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, email_data)
+        }.not_to change(QueuedEmailPayload, :count)
+      end
+    end
+
+    context 'with a missing/deleted payload record' do
+      it 'does not raise and does not create an expense' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, 999_999_999)
+        }.not_to change(Expense, :count)
+      end
+
+      it 'logs an error identifying the missing payload id' do
+        allow(Rails.logger).to receive(:error)
+
+        ProcessEmailJob.new.perform(email_account.id, 999_999_999)
+
+        expect(Rails.logger).to have_received(:error).with(a_string_matching(/QueuedEmailPayload 999999999 not found/))
+      end
+
+      it 'does not call the parser at all' do
+        expect(Services::EmailProcessing::Parser).not_to receive(:new)
+        ProcessEmailJob.new.perform(email_account.id, 999_999_999)
+      end
+    end
+
+    context 'with an unrecognized argument type' do
+      it 'logs an error and does not raise' do
+        allow(Rails.logger).to receive(:error)
+
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, 3.14)
+        }.not_to raise_error
+
+        expect(Rails.logger).to have_received(:error).with(a_string_matching(/Unrecognized argument type/))
+      end
+    end
+  end
 end

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -494,4 +494,92 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
       end
     end
   end
+
+  # Review findings (2026-08 audit follow-up): a failure in mark_processed!
+  # used to propagate all the way up through perform, which would re-trigger
+  # this job's own retry_on and re-parse an already-persisted expense —
+  # flipping it to status: :duplicate via Parser's duplicate branch. See the
+  # rescue around mark_processed! and the processed_at early exit in
+  # #resolve_email_payload.
+  describe 'retry-corruption hardening (review findings)', integration: true do
+    let!(:payload) do
+      QueuedEmailPayload.create!(
+        email_account: email_account,
+        payload_data: { email_data: email_data, pre_parsed: nil }
+      )
+    end
+
+    context 'when mark_processed! raises' do
+      it 'does not raise, leaves the expense processed, and logs the error' do
+        allow_any_instance_of(QueuedEmailPayload).to receive(:update!).and_raise(ActiveRecord::Deadlocked)
+        allow(Rails.logger).to receive(:error)
+
+        expense = nil
+        expect {
+          expense = ProcessEmailJob.new.perform(email_account.id, payload.id)
+        }.not_to raise_error
+
+        expect(expense.status).to eq('processed')
+        expect(Rails.logger).to have_received(:error).with(
+          a_string_matching(/Failed to mark QueuedEmailPayload #{payload.id} as processed.*ActiveRecord::Deadlocked/)
+        )
+      end
+    end
+
+    context 'when the same payload id is replayed after it was already processed' do
+      it 'does not invoke the parser again and leaves the expense unchanged' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, payload.id)
+        }.to change(Expense, :count).by(1)
+
+        expense = Expense.last
+        expect(payload.reload.processed_at).to be_present
+
+        expect(Services::EmailProcessing::Parser).not_to receive(:new)
+
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, payload.id)
+        }.not_to change(Expense, :count)
+
+        expect(expense.reload.status).to eq('processed')
+      end
+
+      it 'logs that the replayed enqueue was skipped' do
+        ProcessEmailJob.new.perform(email_account.id, payload.id)
+
+        allow(Rails.logger).to receive(:warn)
+        ProcessEmailJob.new.perform(email_account.id, payload.id)
+
+        expect(Rails.logger).to have_received(:warn).with(
+          a_string_matching(/QueuedEmailPayload #{payload.id} already processed at.*skipping re-parse/)
+        )
+      end
+    end
+
+    context 'when the stored payload is corrupted' do
+      let!(:corrupted_payload) do
+        QueuedEmailPayload.create!(email_account: email_account, payload_data: { email_data: email_data, pre_parsed: nil })
+      end
+
+      before { corrupted_payload.update_column(:encrypted_payload, "not valid json or ciphertext") }
+
+      it 'does not crash and logs a distinct corruption error' do
+        allow(Rails.logger).to receive(:error)
+
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, corrupted_payload.id)
+        }.not_to raise_error
+
+        expect(Rails.logger).to have_received(:error).with(
+          a_string_matching(/QueuedEmailPayload #{corrupted_payload.id} found but payload_data is blank \(corrupted\/unreadable\)/)
+        )
+      end
+
+      it 'does not create an expense' do
+        expect {
+          ProcessEmailJob.new.perform(email_account.id, corrupted_payload.id)
+        }.not_to change(Expense, :count)
+      end
+    end
+  end
 end

--- a/spec/jobs/queued_email_payload_cleanup_job_spec.rb
+++ b/spec/jobs/queued_email_payload_cleanup_job_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QueuedEmailPayloadCleanupJob, type: :job, unit: true do
+  let(:job) { described_class.new }
+
+  before do
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  describe "retention policy" do
+    it "purges processed rows after QueuedEmailPayload::PROCESSED_RETENTION (7 days)" do
+      expect(QueuedEmailPayload::PROCESSED_RETENTION).to eq(7.days)
+    end
+
+    it "purges unprocessed rows after QueuedEmailPayload::UNPROCESSED_RETENTION (30 days)" do
+      expect(QueuedEmailPayload::UNPROCESSED_RETENTION).to eq(30.days)
+    end
+  end
+
+  describe "#perform" do
+    it "runs without error when no payloads exist" do
+      expect { job.perform }.not_to raise_error
+    end
+
+    it "logs a completion line with both counts" do
+      expect(Rails.logger).to receive(:info).with(/processed_cleaned_up=0, unprocessed_cleaned_up=0/)
+      job.perform
+    end
+
+    context "with a mix of processed and unprocessed payloads at various ages" do
+      around do |example|
+        travel_to(Time.zone.local(2026, 8, 1, 4, 30, 0)) { example.run }
+      end
+
+      let!(:stale_processed) do
+        create(:queued_email_payload, :processed).tap do |p|
+          p.update_columns(processed_at: 8.days.ago)
+        end
+      end
+
+      let!(:recent_processed) do
+        create(:queued_email_payload, :processed).tap do |p|
+          p.update_columns(processed_at: 6.days.ago)
+        end
+      end
+
+      let!(:stale_unprocessed) do
+        create(:queued_email_payload).tap do |p|
+          p.update_columns(created_at: 31.days.ago)
+        end
+      end
+
+      let!(:recent_unprocessed) do
+        create(:queued_email_payload).tap do |p|
+          p.update_columns(created_at: 29.days.ago)
+        end
+      end
+
+      it "deletes only the stale processed row" do
+        job.perform
+        expect(QueuedEmailPayload.exists?(stale_processed.id)).to be false
+        expect(QueuedEmailPayload.exists?(recent_processed.id)).to be true
+      end
+
+      it "deletes only the stale unprocessed row" do
+        job.perform
+        expect(QueuedEmailPayload.exists?(stale_unprocessed.id)).to be false
+        expect(QueuedEmailPayload.exists?(recent_unprocessed.id)).to be true
+      end
+
+      it "judges a processed row only against PROCESSED_RETENTION, ignoring created_at" do
+        # created_at is old enough to be past UNPROCESSED_RETENTION, but that
+        # window only applies to unprocessed rows — this row is processed, so
+        # only PROCESSED_RETENTION (measured from processed_at) applies.
+        recent_processed.update_columns(processed_at: 6.days.ago, created_at: 40.days.ago)
+
+        job.perform
+
+        expect(QueuedEmailPayload.exists?(recent_processed.id)).to be true
+      end
+
+      it "changes the total count by exactly -2" do
+        expect { job.perform }.to change(QueuedEmailPayload, :count).by(-2)
+      end
+
+      it "logs the completion line with the correct counts" do
+        expect(Rails.logger).to receive(:info).with(/processed_cleaned_up=1, unprocessed_cleaned_up=1/)
+        job.perform
+      end
+    end
+  end
+
+  describe "job configuration" do
+    it "is queued on the low-priority queue" do
+      expect(described_class.new.queue_name).to eq("low")
+    end
+  end
+end

--- a/spec/models/queued_email_payload_spec.rb
+++ b/spec/models/queued_email_payload_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+# Security fix (2026-08 audit): QueuedEmailPayload exists so ProcessEmailJob
+# never receives the raw bank-email body as a plain job argument — Active Job
+# would otherwise serialize it into solid_queue_jobs.arguments (and
+# ready/failed_executions) as plaintext, readable by anyone with DB access on
+# the shared personal-blog-db host.
+RSpec.describe QueuedEmailPayload, type: :model, unit: true do
+  describe 'associations' do
+    it { is_expected.to belong_to(:email_account) }
+    it { is_expected.to belong_to(:sync_session).optional }
+  end
+
+  describe 'factory' do
+    it 'creates a valid record' do
+      payload = build(:queued_email_payload)
+      expect(payload).to be_valid
+    end
+  end
+
+  describe 'dependent destroy from email_account' do
+    it 'is destroyed when email_account is destroyed' do
+      payload = create(:queued_email_payload)
+      email_account = payload.email_account
+
+      expect { email_account.destroy }.to change(described_class, :count).by(-1)
+    end
+  end
+
+  describe 'dependent nullify from sync_session' do
+    it 'nullifies sync_session_id when sync_session is destroyed' do
+      sync_session = create(:sync_session)
+      payload = create(:queued_email_payload, sync_session: sync_session)
+
+      sync_session.destroy
+
+      expect(payload.reload.sync_session_id).to be_nil
+    end
+  end
+
+  # THE core encryption guarantee: the encrypted column must never hold
+  # readable plaintext, and it must round-trip transparently for the
+  # application.
+  describe 'encryption' do
+    it 'encrypts encrypted_payload at rest' do
+      expect(described_class.type_for_attribute(:encrypted_payload).class).to be(
+        ActiveRecord::Encryption::EncryptedAttributeType
+      )
+    end
+
+    it 'stores ciphertext in the underlying column (not plaintext)' do
+      plaintext_marker = "BANK PII #{SecureRandom.hex(8)}"
+      create(:queued_email_payload, payload_data: { email_data: { body: plaintext_marker } })
+
+      raw_row = ActiveRecord::Base.connection.execute(
+        "SELECT encrypted_payload FROM queued_email_payloads ORDER BY id DESC LIMIT 1"
+      ).first
+      expect(raw_row["encrypted_payload"]).not_to include(plaintext_marker)
+    end
+
+    it 'round-trips a hash with symbol keys, a Time value, and nested pre_parsed data' do
+      now = Time.zone.parse("2026-08-01 12:00:00")
+      data = {
+        email_data: { body: "some bank text", subject: "Alert", date: now },
+        pre_parsed: { amount: "123.45", merchant_name: "Store ABC" }
+      }
+      payload = create(:queued_email_payload, payload_data: data)
+      payload.reload
+
+      restored = payload.payload_data
+      expect(restored[:email_data][:body]).to eq("some bank text")
+      expect(restored[:email_data][:subject]).to eq("Alert")
+      expect(restored[:email_data][:date]).to eq(now)
+      expect(restored[:pre_parsed][:amount]).to eq("123.45")
+      expect(restored[:pre_parsed][:merchant_name]).to eq("Store ABC")
+    end
+
+    it 'returns nil payload_data when encrypted_payload is blank' do
+      payload = build(:queued_email_payload)
+      payload.encrypted_payload = nil
+      expect(payload.payload_data).to be_nil
+    end
+  end
+
+  describe 'scopes' do
+    let!(:processed_recent) { create(:queued_email_payload, :processed) }
+    let!(:unprocessed_recent) { create(:queued_email_payload) }
+
+    let!(:processed_expired) do
+      create(:queued_email_payload, :processed).tap do |p|
+        p.update_columns(processed_at: (QueuedEmailPayload::PROCESSED_RETENTION + 1.day).ago)
+      end
+    end
+
+    let!(:unprocessed_expired) do
+      create(:queued_email_payload).tap do |p|
+        p.update_columns(created_at: (QueuedEmailPayload::UNPROCESSED_RETENTION + 1.day).ago)
+      end
+    end
+
+    describe '.processed' do
+      it 'returns only rows with a processed_at' do
+        expect(described_class.processed).to contain_exactly(processed_recent, processed_expired)
+      end
+    end
+
+    describe '.unprocessed' do
+      it 'returns only rows without a processed_at' do
+        expect(described_class.unprocessed).to contain_exactly(unprocessed_recent, unprocessed_expired)
+      end
+    end
+
+    describe '.expired_processed' do
+      it 'returns only processed rows past PROCESSED_RETENTION' do
+        expect(described_class.expired_processed).to contain_exactly(processed_expired)
+      end
+    end
+
+    describe '.expired_unprocessed' do
+      it 'returns only unprocessed rows past UNPROCESSED_RETENTION' do
+        expect(described_class.expired_unprocessed).to contain_exactly(unprocessed_expired)
+      end
+    end
+  end
+
+  describe '#mark_processed!' do
+    it 'sets processed_at' do
+      payload = create(:queued_email_payload)
+      expect { payload.mark_processed! }.to change { payload.reload.processed_at }.from(nil)
+    end
+  end
+end

--- a/spec/models/queued_email_payload_spec.rb
+++ b/spec/models/queued_email_payload_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe QueuedEmailPayload, type: :model, unit: true do
       payload.encrypted_payload = nil
       expect(payload.payload_data).to be_nil
     end
+
+    # Review finding (2026-08 audit follow-up): a corrupted/unreadable blob
+    # used to raise out of the getter (JSON::ParserError, a decryption error,
+    # etc), which ProcessEmailJob had no rescue for. It must degrade to nil
+    # and be logged instead — see ProcessEmailJob#resolve_email_payload's
+    # blank-data branch for the caller-side half of this fix.
+    it 'returns nil and logs an error when the stored blob is corrupted/unreadable' do
+      payload = create(:queued_email_payload)
+      payload.update_column(:encrypted_payload, "not valid json or ciphertext")
+      allow(Rails.logger).to receive(:error)
+
+      result = nil
+      expect { result = payload.reload.payload_data }.not_to raise_error
+
+      expect(result).to be_nil
+      expect(Rails.logger).to have_received(:error).with(
+        a_string_matching(/Failed to deserialize payload_data for record #{payload.id}/)
+      )
+    end
   end
 
   describe 'scopes' do

--- a/spec/services/email_processing/processor_spec.rb
+++ b/spec/services/email_processing/processor_spec.rb
@@ -1025,4 +1025,82 @@ RSpec.describe Services::EmailProcessing::Processor, type: :service, unit: true 
       end
     end
   end
+
+  # Security fix (2026-08 audit): ProcessEmailJob.perform_later used to receive
+  # the full decoded bank-email body as a plain job argument. Active Job
+  # serializes job arguments into solid_queue_jobs.arguments as plaintext
+  # text — readable by anyone with DB access on the shared personal-blog-db
+  # host. This section proves that gap is closed: it exercises the real
+  # Solid Queue adapter (not Active Job's :test adapter) end-to-end and
+  # inspects the actual persisted row.
+  describe 'plaintext PII regression (2026-08 security audit)', integration: true do
+    let(:message_ids) { [ 1 ] }
+    let(:bank_pii_marker) { "BANK PII #{SecureRandom.hex(8)}: Comercio MERCHANT ABC monto $543.21" }
+    let(:transaction_envelope) do
+      double('envelope', subject: 'BAC - Notificación de transacción', from: nil, message_id: '<txn-regression@example.com>')
+    end
+
+    # Bypass Active Job's :test adapter (the suite default) so perform_later
+    # actually lands a row in solid_queue_jobs, matching how
+    # MetricsCalculationJob's dispatch spec proves Solid Queue behavior
+    # end-to-end (see spec/jobs/metrics_calculation_job_dispatch_spec.rb).
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :solid_queue
+      SolidQueue::Job.delete_all
+      example.run
+      SolidQueue::Job.delete_all
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    before do
+      allow(mock_imap_service).to receive(:fetch_envelope).with(1).and_return(transaction_envelope)
+      allow(processor_without_metrics).to receive(:extract_email_data).and_return({
+        message_id: 1,
+        rfc_message_id: '<txn-regression@example.com>',
+        from: 'bank@bac.co.cr',
+        subject: 'Transaction Alert',
+        date: Time.current,
+        body: bank_pii_marker
+      })
+    end
+
+    it 'does NOT persist the bank-email body anywhere in SolidQueue::Job#arguments' do
+      processor_without_metrics.process_emails(message_ids, mock_imap_service)
+
+      job = SolidQueue::Job.where(class_name: 'ProcessEmailJob').last
+      expect(job).to be_present
+      expect(job.arguments.to_s).not_to include(bank_pii_marker)
+    end
+
+    it 'passes only plain ids (email_account_id, payload_id, sync_session_id) as job arguments' do
+      processor_without_metrics.process_emails(message_ids, mock_imap_service)
+
+      job = SolidQueue::Job.where(class_name: 'ProcessEmailJob').last
+      serialized_args = job.arguments['arguments']
+
+      expect(serialized_args[0]).to eq(email_account.id)
+      expect(serialized_args[1]).to be_a(Integer) # QueuedEmailPayload id, never a Hash
+      expect(serialized_args.none? { |arg| arg.is_a?(Hash) }).to be true
+    end
+
+    it 'persists the bank-email body only inside an encrypted QueuedEmailPayload record' do
+      expect {
+        processor_without_metrics.process_emails(message_ids, mock_imap_service)
+      }.to change(QueuedEmailPayload, :count).by(1)
+
+      payload = QueuedEmailPayload.last
+      expect(payload.payload_data[:email_data][:body]).to eq(bank_pii_marker)
+    end
+
+    it 'does NOT store the bank-email body as plaintext in the queued_email_payloads column' do
+      processor_without_metrics.process_emails(message_ids, mock_imap_service)
+
+      payload = QueuedEmailPayload.last
+      raw_row = ActiveRecord::Base.connection.execute(
+        "SELECT encrypted_payload FROM queued_email_payloads WHERE id = #{payload.id}"
+      ).first
+      expect(raw_row['encrypted_payload']).not_to include(bank_pii_marker)
+    end
+  end
 end


### PR DESCRIPTION
## Finding (2026-08 security audit)

`Services::EmailProcessing::Processor#process_email_with_metrics` called:

```ruby
ProcessEmailJob.perform_later(email_account.id, email_data, sync_session_id, pre_parsed)
```

`email_data[:body]` is the full decoded bank notification (transaction PII — amounts, merchants, account references). Active Job serializes all job arguments into `solid_queue_jobs.arguments` (and the `ready`/`failed_executions` tables) as **plaintext text**, readable by anyone with DB access on the shared personal-blog-db host. The app already encrypts `expenses.email_body` and `email_parsing_failures.raw_email_content` (both via Rails `encrypts`) — the queue tables were the remaining gap. `pre_parsed[:raw_email_content]` (set when conflict detection pre-parses the expense) carries the same body a second time and had the same exposure.

## Design

- **New model `QueuedEmailPayload`** (migration `CreateQueuedEmailPayloads`): `encrypts :encrypted_payload` on a `text` column, `belongs_to :email_account`, `belongs_to :sync_session, optional: true`, `processed_at` for lifecycle tracking. The `payload_data=`/`payload_data` accessors serialize through **`ActiveJob::Arguments.serialize/deserialize`** rather than plain `to_json`/`JSON.parse` — this preserves Symbol keys, `Time`, and `BigDecimal` values exactly as `ProcessEmailJob` previously received them as raw job arguments (a plain JSON round-trip would have silently degraded those types).
- **Producer** (`Services::EmailProcessing::Processor`): persists `{ email_data:, pre_parsed: }` into a `QueuedEmailPayload` record, then enqueues `ProcessEmailJob.perform_later(email_account.id, payload.id, sync_session_id)` — the job arguments are now just integers.
- **Consumer** (`ProcessEmailJob`): `#perform`'s second argument is now polymorphic — `Integer/String` → look up the `QueuedEmailPayload` and unpack it; `Hash` → legacy path, still fully supported. A missing/deleted payload record is logged and discarded (not raised), so a stray job can't crash-loop through the retry budget. `payload_record.mark_processed!` only runs after processing actually completes, so if the job raises (e.g. `ActiveRecord::Deadlocked`, already retried via `retry_on`), the record stays unprocessed and the retry has data to work with.
- **Cleanup**: new `QueuedEmailPayloadCleanupJob`, scheduled daily at 4:30am in `config/recurring.yml` (same slot pattern as `EmailParsingFailureCleanupJob` / `SolidQueueFailedExecutionCleanupJob`). Processed rows purge after 7 days; unprocessed rows (still needed for retries) after 30 days.
- `config/initializers/filter_parameter_logging.rb`: added `:encrypted_payload` to `filter_attributes` (matches the existing `:raw_email_content` entry) so `Model#inspect` never decrypts it into logs/error reports.

### Deploy-window compatibility

In-flight jobs already enqueued with the old signature (a plaintext `email_data` Hash as the 2nd argument, `pre_parsed_data` as the 4th) will still be sitting in `solid_queue_jobs` when this deploys. `ProcessEmailJob#perform` branches on the argument's class: `Hash` → processed via the legacy path with a `Rails.logger.warn` deprecation line, kept indefinitely since it's cheap to support rather than removed on a timer.

### Regression proof

`spec/services/email_processing/processor_spec.rb` — `"plaintext PII regression (2026-08 security audit)"`:
- Temporarily swaps `ActiveJob::Base.queue_adapter` to `:solid_queue` (bypassing the test-suite's `:test` adapter, mirroring the pattern in `spec/jobs/metrics_calculation_job_dispatch_spec.rb`) so `perform_later` lands a real row in `solid_queue_jobs`.
- Asserts `SolidQueue::Job.where(class_name: 'ProcessEmailJob').last.arguments.to_s` does **not** contain the bank-email body.
- Asserts the serialized job arguments are `[email_account_id, payload_id, sync_session_id]` — plain integers, no `Hash` anywhere in the array.
- Asserts the body is recoverable only via `QueuedEmailPayload#payload_data`, and that the raw `encrypted_payload` column never contains the plaintext marker.

All 4 pass. Additional coverage:
- `spec/models/queued_email_payload_spec.rb` (14 examples): encryption type, ciphertext-not-plaintext, round-trip fidelity for symbol keys/Time/nested pre_parsed, `dependent: :destroy`/`:nullify`, retention scopes, `mark_processed!`.
- `spec/jobs/process_email_job_spec.rb` (new `"QueuedEmailPayload argument handling"` block): id-path creates an expense and marks the payload processed; sync_session id still threads through; pre-parsed `String` amount still round-trips correctly; legacy Hash path still works end-to-end + logs deprecation warning + never touches `QueuedEmailPayload`; missing/deleted payload id logs and returns cleanly without raising or calling the parser; unrecognized argument type logs and returns cleanly.
- `spec/jobs/queued_email_payload_cleanup_job_spec.rb` (10 examples): purges expired processed/unprocessed rows independently, respects each retention window, leaves recent rows alone.

### Migration

`CreateQueuedEmailPayloads`: `queued_email_payloads` table — `email_account_id` (FK, not null), `sync_session_id` (FK, nullable), `encrypted_payload` (text, not null), `processed_at` (nullable, indexed), timestamps. `db/schema.rb` diff is minimal (one new table + two FKs).

### Out-of-scope audit

Grepped every `perform_later` call site in `app/` for body-like payloads: `ProcessEmailsJob`, `SyncSessionMonitorJob`, `ExternalBudgets::PullJob`, `BulkCategorizationJob`, `Budgets::SuggestMappingsJob`, and the webhook/controller call sites all pass only ids, dates, or small option hashes — never email bodies. `ProcessEmailJob` was the only site carrying full bank-email content as a job argument.

## Test plan

- [x] `bin/test-unit` — 8581 examples, 0 failures
- [x] `bin/test-integration` — 775 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses (916 files)
- [x] `bundle exec brakeman` — no warnings
- [x] Regression spec proves `SolidQueue::Job#arguments` is clean end-to-end
- [x] Migration applied cleanly in the worktree test DB; `schema.rb` diff reviewed