### PR TITLE
fix(expenses): build filter/period date ranges in the app time zone (twin of #561)

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -729,10 +729,18 @@ class ExpensesController < ApplicationController
       scope = scope.where(transaction_date: date_range) if date_range
     elsif params[:date_from].present? && params[:date_to].present?
       # Handle explicit date range from dashboard
-      scope = scope.where(transaction_date: parse_date_param(params[:date_from]).beginning_of_day..parse_date_param(params[:date_to]).end_of_day)
+      #
+      # transaction_date is a timestamp column, so range endpoints must be
+      # anchored in the app's configured Time.zone (not the system/Postgres
+      # session zone). Bare Date#beginning_of_day/end_of_day convert via the
+      # system local zone, so expenses near local midnight can land on the
+      # wrong side of the boundary. Anchoring via #in_time_zone avoids that
+      # ambiguity (same fix as Services::MetricsCalculator#calculate_date_range,
+      # PR #561).
+      scope = scope.where(transaction_date: parse_date_param(params[:date_from]).in_time_zone.beginning_of_day..parse_date_param(params[:date_to]).in_time_zone.end_of_day)
     elsif date_range_present?
-      # Handle traditional date range filters
-      scope = scope.where(transaction_date: parse_date_param(params[:start_date]).beginning_of_day..parse_date_param(params[:end_date]).end_of_day)
+      # Handle traditional date range filters (see comment above)
+      scope = scope.where(transaction_date: parse_date_param(params[:start_date]).in_time_zone.beginning_of_day..parse_date_param(params[:end_date]).in_time_zone.end_of_day)
     end
 
     # Use left_joins instead of joins to maintain includes
@@ -752,18 +760,24 @@ class ExpensesController < ApplicationController
   end
 
   def calculate_period_range(period)
-    # transaction_date is a timestamp column, so boundaries must be Times
-    # (not Dates) to bracket the full day in the app's configured zone.
+    # transaction_date is a timestamp column, so boundaries must be anchored
+    # in the app's configured Time.zone (not the system/Postgres session
+    # zone). Bare Date#beginning_of_day/end_of_day convert via the system
+    # local zone, and Date..Date ranges get emitted as naive date literals
+    # that Postgres casts in its own session zone — both land expenses near
+    # local midnight on the wrong side of the period boundary. Anchoring
+    # every endpoint via #in_time_zone avoids that ambiguity (same fix as
+    # Services::MetricsCalculator#calculate_date_range, PR #561).
     today = Date.current
     case period
     when "day", "today"
-      today.beginning_of_day..today.end_of_day
+      today.in_time_zone.all_day
     when "week"
-      today.beginning_of_week.beginning_of_day..today.end_of_week.end_of_day
+      today.in_time_zone.beginning_of_week..today.in_time_zone.end_of_week
     when "month"
-      today.beginning_of_month.beginning_of_day..today.end_of_month.end_of_day
+      today.in_time_zone.beginning_of_month..today.in_time_zone.end_of_month
     when "year"
-      today.beginning_of_year.beginning_of_day..today.end_of_year.end_of_day
+      today.in_time_zone.beginning_of_year..today.in_time_zone.end_of_year
     else
       nil
     end

--- a/spec/controllers/expenses_controller_spec.rb
+++ b/spec/controllers/expenses_controller_spec.rb
@@ -261,6 +261,131 @@ RSpec.describe ExpensesController, type: :controller, integration: true do
         expect(assigns(:from_dashboard)).to be false
       end
     end
+
+    # REGRESSION: twin of the MetricsCalculator timezone boundary bug (PR
+    # #561). #calculate_period_range and #apply_filters used to build
+    # transaction_date range endpoints via bare Date#beginning_of_day/
+    # end_of_day (or naive Date..Date ranges), which convert through the
+    # system/Postgres session time zone rather than the app's configured
+    # Time.zone ("Central America", -06:00) — so expenses exactly at local
+    # midnight could land on the wrong side of a period/filter boundary.
+    # Fixed by anchoring every endpoint via #in_time_zone. These specs pin
+    # the fix down at the summary-statistics level (@total_amount /
+    # @expense_count), which is what #calculate_period_range and
+    # #apply_filters actually drive — the @expenses list itself is built by
+    # Services::ExpenseFilterService, a separate call site.
+    context "with expenses exactly at local midnight boundaries" do
+      before do
+        PatternLearningEvent.destroy_all if defined?(PatternLearningEvent)
+        ConflictResolution.where.not(undone_by_resolution_id: nil).update_all(undone_by_resolution_id: nil) if defined?(ConflictResolution)
+        ConflictResolution.destroy_all if defined?(ConflictResolution)
+        SyncConflict.destroy_all if defined?(SyncConflict)
+        Expense.destroy_all
+      end
+
+      context "with a period filter" do
+        before do
+          # 00:00:00 local time on the first day of the current month — must count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 10.00,
+            transaction_date: Date.current.beginning_of_month.in_time_zone.beginning_of_day)
+
+          # 23:59:59 local time on the last day of the current month — must count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 20.00,
+            transaction_date: Date.current.end_of_month.in_time_zone.end_of_day)
+
+          # 00:00:00 local time the day AFTER the month ends — must NOT count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 999.00,
+            transaction_date: (Date.current.end_of_month + 1.day).in_time_zone.beginning_of_day)
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the period ends" do
+          get :index, params: { period: "month", filter_type: "dashboard_metric" }
+
+          expect(assigns(:total_amount).to_f).to eq(30.00)
+          expect(assigns(:expense_count)).to eq(2)
+        end
+      end
+
+      context "with an explicit date_from/date_to range" do
+        let(:from_date) { Date.current - 5.days }
+        let(:to_date) { Date.current - 3.days }
+
+        before do
+          # 00:00:00 local time on the from-day — must count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 10.00,
+            transaction_date: from_date.in_time_zone.beginning_of_day)
+
+          # 23:59:59 local time on the to-day — must count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 20.00,
+            transaction_date: to_date.in_time_zone.end_of_day)
+
+          # 00:00:00 local time the day AFTER the range ends — must NOT count
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 999.00,
+            transaction_date: (to_date + 1.day).in_time_zone.beginning_of_day)
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the range ends" do
+          get :index, params: {
+            date_from: from_date.to_s,
+            date_to: to_date.to_s,
+            filter_type: "dashboard_metric"
+          }
+
+          expect(assigns(:total_amount).to_f).to eq(30.00)
+          expect(assigns(:expense_count)).to eq(2)
+        end
+      end
+
+      context "with traditional start_date/end_date filters" do
+        let(:start_date) { Date.current - 5.days }
+        let(:end_date) { Date.current - 3.days }
+
+        before do
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 10.00,
+            transaction_date: start_date.in_time_zone.beginning_of_day)
+
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 20.00,
+            transaction_date: end_date.in_time_zone.end_of_day)
+
+          create(:expense,
+            email_account: email_account,
+            category: category,
+            amount: 999.00,
+            transaction_date: (end_date + 1.day).in_time_zone.beginning_of_day)
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the range ends" do
+          get :index, params: { start_date: start_date.to_s, end_date: end_date.to_s }
+
+          expect(assigns(:total_amount).to_f).to eq(30.00)
+          expect(assigns(:expense_count)).to eq(2)
+        end
+      end
+    end
   end
 
   describe "GET #dashboard", integration: true do


### PR DESCRIPTION
## Summary

Same bug class as #561 (`Services::MetricsCalculator`), found in `ExpensesController`: date-range endpoints for `transaction_date` (a `datetime` column) were built via bare `Date#beginning_of_day`/`#end_of_day`, which convert through the *system* time zone rather than the app's configured `Time.zone` ("Central America", `-06:00`). Expenses recorded near local midnight could land in the wrong period/filter bucket.

**Fixed call sites (`app/controllers/expenses_controller.rb`):**
- `#calculate_period_range` — day/week/month/year buckets now anchor via `#in_time_zone` (`.all_day` for day, `.in_time_zone.beginning_of_*..in_time_zone.end_of_*` otherwise), mirroring `MetricsCalculator#calculate_date_range`.
- `#apply_filters` — both the dashboard `date_from`/`date_to` branch and the traditional `start_date`/`end_date` branch now anchor `parse_date_param(...)` output via `#in_time_zone` before calling `beginning_of_day`/`end_of_day`.

These two methods are only exercised by `#calculate_summary_statistics` (drives `@total_amount` / `@expense_count` / `@categories_summary`) and by `#setup_navigation_context` (display-only `@date_from`/`@date_to`, unaffected — no DB query there). The `@expenses` list itself is built by `Services::ExpenseFilterService`, a separate call site (see below).

**Round-trip check:** grepped `app/views` and `app/javascript` for `date_from`/`date_to` — nothing in this controller renders `@date_from`/`@date_to` back into a URL or data attribute, so there's no frontend format concern here.

## Other instances of the same pattern (found, not fixed — out of scope for this PR)

Grepped `app/controllers` and `app/services` for `beginning_of_day`/`end_of_day` against datetime columns. Notably, the *actual* expense list (not just summary stats) is built by services with the identical bug:

- `app/services/expense_filter_service.rb:205,211-212,257-263,329-339` — powers the main `#index` listing (`Services::ExpenseFilterService`, used at `expenses_controller.rb:11`). Same period/date-range pattern as the pre-fix controller code.
- `app/services/dashboard_expense_filter_service.rb:350-360` — powers the dashboard "Recent Expenses" widget (`expenses_controller.rb:208`).
- `app/services/dashboard_service.rb:60,62,105`
- `app/services/expense_summary_service.rb:33-48`
- `app/services/sync_metrics_collector.rb:269-270`
- `app/services/categorization/pattern_analytics.rb:123`
- `app/controllers/budgets_controller.rb:290`
- `app/controllers/bulk_categorization_actions_controller.rb:151,156`
- `app/controllers/sync_sessions_controller.rb:17`
- `app/controllers/sync_performance_controller.rb:59,62`
- `app/controllers/api/webhooks_controller.rb:135,137`
- `app/controllers/analytics/pattern_dashboard_controller.rb:148`

`expense_filter_service.rb` and `dashboard_expense_filter_service.rb` are the highest-priority follow-ups — they drive the visible expense list/widget, not just summary numbers.

## Test plan

- [x] New boundary regression specs in `spec/controllers/expenses_controller_spec.rb` (mirroring the `MetricsCalculator` spec style from #561): expense at 00:00:00 local on the from/period-start day is included; 23:59:59 local on the to/period-end day is included; 00:00:00 local the day after is excluded. Covers `period=month`, explicit `date_from`/`date_to`, and traditional `start_date`/`end_date`.
- [x] `bin/test-integration` (full suite) — 780 examples, 0 failures
- [x] `bin/test-unit` (full suite) — 8596 examples, 0 failures, 5 pendings (pre-existing)
- [x] `bundle exec rubocop` — no offenses
- [x] Pre-commit hook (unit tests + rubocop + brakeman + rails_best_practices) — passed