### PR TITLE
fix(tz): anchor remaining date-range call sites in the app time zone (completes #561/#564 sweep)

### DIFF
--- a/app/controllers/analytics/pattern_dashboard_controller.rb
+++ b/app/controllers/analytics/pattern_dashboard_controller.rb
@@ -245,7 +245,12 @@ module Analytics
           start_date = max_range_date
         end
 
-        start_date..end_date
+        # created_at is a tz-aware timestamp column; a bare Date..Date range
+        # gets emitted as a naive date literal that Postgres casts in its
+        # own session zone rather than the app's configured Time.zone.
+        # Anchoring both endpoints via #in_time_zone avoids that ambiguity
+        # (same fix as MetricsCalculator#calculate_date_range, PR #561).
+        start_date.in_time_zone.beginning_of_day..end_date.in_time_zone.end_of_day
       rescue Date::Error, ArgumentError => e
         Rails.logger.error "Date parsing error in analytics dashboard: #{e.message}"
         flash.now[:alert] = "Invalid date format. Using default date range."

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -285,9 +285,12 @@ class BudgetsController < ApplicationController
       lookback_days = 30
     end
 
+    # transaction_date is a tz-aware timestamp column; anchor both endpoints
+    # via #in_time_zone so expenses near local midnight land on the
+    # correct side of the window (same fix as MetricsCalculator, PR #561).
     start_date = Date.current - lookback_days.days
     average_spend = email_account.expenses
-      .where(transaction_date: start_date.beginning_of_day..Date.current.end_of_day)
+      .where(transaction_date: start_date.in_time_zone.beginning_of_day..Date.current.in_time_zone.end_of_day)
       .average(:amount) || 0
 
     # Suggest 10% more than average to provide some buffer

--- a/app/controllers/bulk_categorization_actions_controller.rb
+++ b/app/controllers/bulk_categorization_actions_controller.rb
@@ -146,14 +146,19 @@ class BulkCategorizationActionsController < ApplicationController
 
     # Apply date filters using parameterized queries. transaction_date is a
     # timestamp column so bracket the day-aligned bound with beginning/end_of_day.
+    #
+    # IMPORTANT: parse_date returns a bare Date; anchor it via #in_time_zone
+    # before calling beginning_of_day/end_of_day — otherwise the boundary
+    # converts via the system/server zone rather than the app's configured
+    # Time.zone (same fix as MetricsCalculator, PR #561).
     if filters[:date_from].present?
       date_from = parse_date(filters[:date_from])
-      scope = scope.where("transaction_date >= ?", date_from.beginning_of_day) if date_from
+      scope = scope.where("transaction_date >= ?", date_from.in_time_zone.beginning_of_day) if date_from
     end
 
     if filters[:date_to].present?
       date_to = parse_date(filters[:date_to])
-      scope = scope.where("transaction_date <= ?", date_to.end_of_day) if date_to
+      scope = scope.where("transaction_date <= ?", date_to.in_time_zone.end_of_day) if date_to
     end
 
     # Use Arel for safe LIKE queries instead of string interpolation

--- a/app/controllers/sync_sessions_controller.rb
+++ b/app/controllers/sync_sessions_controller.rb
@@ -13,10 +13,15 @@ class SyncSessionsController < ApplicationController
     @email_accounts = EmailAccount.active.order(:bank_name, :email)
     # Additional data for enhanced UI
     @active_accounts_count = EmailAccount.active.count
+    # created_at/completed_at are tz-aware timestamp columns; anchor via
+    # #in_time_zone — a bare Date#beginning_of_day/end_of_day chain (or a
+    # naive Date..Date range) converts/casts via the system/Postgres
+    # session zone rather than the app's configured Time.zone (same fix as
+    # MetricsCalculator, PR #561).
     @today_sync_count = SyncSession.for_user(scoping_user)
-                                   .where(created_at: Date.current.beginning_of_day..Date.current.end_of_day).count
+                                   .where(created_at: Date.current.in_time_zone.all_day).count
     @monthly_expenses_detected = SyncSession.for_user(scoping_user).completed
-                                            .where(completed_at: Date.current.beginning_of_month..Date.current.end_of_month)
+                                            .where(completed_at: Date.current.in_time_zone.beginning_of_month..Date.current.in_time_zone.end_of_month)
                                             .sum(:detected_expenses)
     @last_completed_session = SyncSession.for_user(scoping_user).completed.recent.first
   end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -106,18 +106,26 @@ class Budget < ApplicationRecord
   # Instance methods
 
   # Calculate the current period's date range based on budget period type
+  #
+  # IMPORTANT: must NOT chain bare Date#beginning_of_day/end_of_day — those
+  # convert via the system/server zone rather than the app's configured
+  # Time.zone. This range is queried against transaction_date (a tz-aware
+  # datetime column, see #calculate_current_spend!), so a naive endpoint
+  # can land expenses near local midnight on the wrong side of the period
+  # boundary. Anchoring every endpoint via #in_time_zone avoids that
+  # ambiguity (same fix as MetricsCalculator#calculate_date_range, PR #561).
   def current_period_range
     reference_date = Date.current
 
     case period.to_sym
     when :daily
-      reference_date.beginning_of_day..reference_date.end_of_day
+      reference_date.in_time_zone.all_day
     when :weekly
-      reference_date.beginning_of_week.beginning_of_day..reference_date.end_of_week.end_of_day
+      reference_date.in_time_zone.beginning_of_week..reference_date.in_time_zone.end_of_week
     when :monthly
-      reference_date.beginning_of_month.beginning_of_day..reference_date.end_of_month.end_of_day
+      reference_date.in_time_zone.beginning_of_month..reference_date.in_time_zone.end_of_month
     when :yearly
-      reference_date.beginning_of_year.beginning_of_day..reference_date.end_of_year.end_of_day
+      reference_date.in_time_zone.beginning_of_year..reference_date.in_time_zone.end_of_year
     else
       raise "Invalid period: #{period}"
     end

--- a/app/models/bulk_operation.rb
+++ b/app/models/bulk_operation.rb
@@ -37,9 +37,13 @@ class BulkOperation < ApplicationRecord
   scope :undoable, -> { where(status: :completed, undone_at: nil).where("created_at > ?", 24.hours.ago) }
   scope :by_user, ->(user_id) { where(user_id: user_id) }
   scope :for_user, ->(u) { where(user_id: u.id) }
-  scope :today, -> { where(created_at: Date.current.all_day) }
-  scope :this_week, -> { where(created_at: Date.current.all_week) }
-  scope :this_month, -> { where(created_at: Date.current.all_month) }
+  # created_at is a tz-aware timestamp column; anchor via #in_time_zone —
+  # bare Date#all_day/all_week/all_month build boundaries via the
+  # system/server zone rather than the app's configured Time.zone (same
+  # fix as MetricsCalculator#calculate_date_range, PR #561).
+  scope :today, -> { where(created_at: Date.current.in_time_zone.all_day) }
+  scope :this_week, -> { where(created_at: Date.current.in_time_zone.all_week) }
+  scope :this_month, -> { where(created_at: Date.current.in_time_zone.all_month) }
 
   # Callbacks
   before_validation :set_defaults

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -47,9 +47,14 @@ class Expense < ApplicationRecord
   scope :for_user, ->(u) { where(user_id: u.id) }
   scope :recent, -> { order(transaction_date: :desc) }
   scope :by_status, ->(status) { where(status: status) }
+  # transaction_date is a tz-aware timestamp column; anchor every endpoint
+  # via #in_time_zone — bare Date#beginning_of_day/end_of_day convert via
+  # the system/server zone rather than the app's configured Time.zone, so
+  # expenses near local midnight can land on the wrong side of the
+  # boundary (same fix as MetricsCalculator#calculate_date_range, PR #561).
   scope :by_date_range, ->(start_date, end_date) {
-    range_start = start_date&.to_date&.beginning_of_day
-    range_end   = end_date&.to_date&.end_of_day
+    range_start = start_date&.to_date&.in_time_zone&.beginning_of_day
+    range_end   = end_date&.to_date&.in_time_zone&.end_of_day
     if range_start && range_end
       where(transaction_date: range_start..range_end)
     elsif range_start
@@ -63,10 +68,10 @@ class Expense < ApplicationRecord
   scope :by_amount_range, ->(min, max) { where(amount: min..max) }
   scope :uncategorized, -> { where(category: nil) }
   scope :this_month, -> {
-    where(transaction_date: Date.current.beginning_of_month.beginning_of_day..Date.current.end_of_month.end_of_day)
+    where(transaction_date: Date.current.in_time_zone.beginning_of_month..Date.current.in_time_zone.end_of_month)
   }
   scope :this_year, -> {
-    where(transaction_date: Date.current.beginning_of_year.beginning_of_day..Date.current.end_of_year.end_of_day)
+    where(transaction_date: Date.current.in_time_zone.beginning_of_year..Date.current.in_time_zone.end_of_year)
   }
 
   # Instance methods

--- a/app/services/categorization/pattern_analytics.rb
+++ b/app/services/categorization/pattern_analytics.rb
@@ -119,8 +119,11 @@ module Services::Categorization
     def fetch_feedback_counts(window_start, window_end)
       return {} unless defined?(PatternFeedback) && PatternFeedback.table_exists?
 
+      # created_at is a tz-aware timestamp column; anchor both endpoints via
+      # #in_time_zone so expenses near local midnight land on the correct
+      # side of the window (same fix as MetricsCalculator, PR #561).
       PatternFeedback
-        .where(created_at: window_start.beginning_of_day..window_end.end_of_day)
+        .where(created_at: window_start.in_time_zone.beginning_of_day..window_end.in_time_zone.end_of_day)
         .group(Arel.sql("DATE(created_at)"), :was_correct)
         .count
         .each_with_object({}) do |((date, was_correct), count), hash|

--- a/app/services/dashboard_expense_filter_service.rb
+++ b/app/services/dashboard_expense_filter_service.rb
@@ -344,20 +344,27 @@ class DashboardExpenseFilterService < ExpenseFilterService
   def calculate_period_dates(period)
     # transaction_date is a timestamp column, so boundaries must be Times
     # (not Dates) to bracket the full day in the app's configured zone.
+    #
+    # IMPORTANT: must NOT chain bare Date#beginning_of_day/end_of_day —
+    # those convert via the system/server zone rather than the app's
+    # configured Time.zone. Anchoring via #in_time_zone first avoids that
+    # ambiguity (same fix as MetricsCalculator#calculate_date_range, PR
+    # #561). 7/30.days.ago are already TimeWithZone (Time.current-based),
+    # so they don't need it.
     today = Date.current
     case period.to_s
     when "today", "day"
-      { start: today.beginning_of_day, end: today.end_of_day }
+      { start: today.in_time_zone.beginning_of_day, end: today.in_time_zone.end_of_day }
     when "week"
-      { start: today.beginning_of_week.beginning_of_day, end: today.end_of_week.end_of_day }
+      { start: today.in_time_zone.beginning_of_week, end: today.in_time_zone.end_of_week }
     when "month"
-      { start: today.beginning_of_month.beginning_of_day, end: today.end_of_month.end_of_day }
+      { start: today.in_time_zone.beginning_of_month, end: today.in_time_zone.end_of_month }
     when "year"
-      { start: today.beginning_of_year.beginning_of_day, end: today.end_of_year.end_of_day }
+      { start: today.in_time_zone.beginning_of_year, end: today.in_time_zone.end_of_year }
     when "last_7_days"
-      { start: 7.days.ago.beginning_of_day, end: today.end_of_day }
+      { start: 7.days.ago.beginning_of_day, end: today.in_time_zone.end_of_day }
     when "last_30_days"
-      { start: 30.days.ago.beginning_of_day, end: today.end_of_day }
+      { start: 30.days.ago.beginning_of_day, end: today.in_time_zone.end_of_day }
     else
       {}
     end

--- a/app/services/dashboard_service.rb
+++ b/app/services/dashboard_service.rb
@@ -55,11 +55,18 @@ module Services
     )
 
     # Single query for both monthly totals using conditional aggregation (was 2 queries)
+    #
+    # IMPORTANT: transaction_date is a tz-aware timestamp column. Bare
+    # Date#beginning_of_month/end_of_day convert via the system/server zone
+    # rather than the app's configured Time.zone, so expenses near local
+    # midnight could land on the wrong side of the boundary. Anchoring
+    # every endpoint via #in_time_zone avoids that ambiguity (same fix as
+    # MetricsCalculator#calculate_date_range, PR #561).
     today = Date.current
-    current_month_start  = today.beginning_of_month
-    current_month_end    = today.end_of_month.end_of_day
-    last_month_start     = 1.month.ago.to_date.beginning_of_month
-    last_month_end       = 1.month.ago.to_date.end_of_month.end_of_day
+    current_month_start  = today.in_time_zone.beginning_of_month
+    current_month_end    = today.in_time_zone.end_of_month
+    last_month_start     = 1.month.ago.to_date.in_time_zone.beginning_of_month
+    last_month_end       = 1.month.ago.to_date.in_time_zone.end_of_month
 
     current_filter_sql = ActiveRecord::Base.sanitize_sql_array([
       "COALESCE(SUM(amount) FILTER (WHERE transaction_date BETWEEN ? AND ?), 0)",
@@ -101,8 +108,11 @@ module Services
   end
 
   def monthly_trend
+    # Date.current.end_of_month must be anchored via #in_time_zone — a bare
+    # Date#end_of_day chain converts via the system/server zone rather than
+    # the app's configured Time.zone (see calculate_totals above).
     Expense.where(
-      transaction_date: 6.months.ago.beginning_of_month..Date.current.end_of_month.end_of_day
+      transaction_date: 6.months.ago.beginning_of_month..Date.current.in_time_zone.end_of_month
     ).group_by_month(:transaction_date)
      .sum(:amount)
      .transform_values(&:to_f)

--- a/app/services/expense_filter_service.rb
+++ b/app/services/expense_filter_service.rb
@@ -199,17 +199,23 @@ module Services
       return scope.where(transaction_date: date_range) if date_range
     end
 
-    # Handle dashboard date_from and date_to parameters. transaction_date
-    # is a timestamp column, so bracket by beginning/end of day in app zone.
+    # Handle dashboard date_from and date_to parameters.
+    #
+    # IMPORTANT: transaction_date is a tz-aware timestamp column. Bare
+    # Date#beginning_of_day/end_of_day convert via the system/server zone
+    # rather than the app's configured Time.zone, so expenses near local
+    # midnight could land on the wrong side of the boundary. Anchoring
+    # every endpoint via #in_time_zone avoids that ambiguity (same fix as
+    # MetricsCalculator#calculate_date_range, PR #561).
     if date_from.present? && date_to.present?
-      return scope.where(transaction_date: date_from.to_date.beginning_of_day..date_to.to_date.end_of_day)
+      return scope.where(transaction_date: date_from.to_date.in_time_zone.beginning_of_day..date_to.to_date.in_time_zone.end_of_day)
     end
 
     # Handle traditional start_date and end_date parameters
     return scope unless start_date.present? || end_date.present?
 
-    scope = scope.where("transaction_date >= ?", start_date.to_date.beginning_of_day) if start_date
-    scope = scope.where("transaction_date <= ?", end_date.to_date.end_of_day) if end_date
+    scope = scope.where("transaction_date >= ?", start_date.to_date.in_time_zone.beginning_of_day) if start_date
+    scope = scope.where("transaction_date <= ?", end_date.to_date.in_time_zone.end_of_day) if end_date
     scope
   end
 
@@ -251,16 +257,21 @@ module Services
   def calculate_period_range(period)
     # transaction_date is a timestamp column, so boundaries must be Times
     # (not Dates) to bracket the full day in the app's configured zone.
+    #
+    # IMPORTANT: must NOT chain bare Date#beginning_of_day/end_of_day —
+    # those convert via the system/server zone rather than the app's
+    # configured Time.zone. Anchoring via #in_time_zone first avoids that
+    # ambiguity (same fix as MetricsCalculator#calculate_date_range, PR #561).
     today = Date.current
     case period
     when "day", "today"
-      today.beginning_of_day..today.end_of_day
+      today.in_time_zone.all_day
     when "week"
-      today.beginning_of_week.beginning_of_day..today.end_of_week.end_of_day
+      today.in_time_zone.beginning_of_week..today.in_time_zone.end_of_week
     when "month"
-      today.beginning_of_month.beginning_of_day..today.end_of_month.end_of_day
+      today.in_time_zone.beginning_of_month..today.in_time_zone.end_of_month
     when "year"
-      today.beginning_of_year.beginning_of_day..today.end_of_year.end_of_day
+      today.in_time_zone.beginning_of_year..today.in_time_zone.end_of_year
     else
       nil
     end
@@ -323,20 +334,25 @@ module Services
   end
 
   def parse_date_range(range)
+    # IMPORTANT: anchor every Date-derived endpoint via #in_time_zone — bare
+    # Date#beginning_of_day/end_of_day convert via the system/server zone
+    # rather than the app's configured Time.zone (same fix as
+    # MetricsCalculator#calculate_date_range, PR #561). 30/90.days.ago are
+    # already TimeWithZone (Time.current-based), so they don't need it.
     today = Date.current
     case range.to_s
     when "today"
-      { start: today.beginning_of_day, end: today.end_of_day }
+      { start: today.in_time_zone.beginning_of_day, end: today.in_time_zone.end_of_day }
     when "week"
-      { start: today.beginning_of_week.beginning_of_day, end: today.end_of_week.end_of_day }
+      { start: today.in_time_zone.beginning_of_week, end: today.in_time_zone.end_of_week }
     when "month"
-      { start: today.beginning_of_month.beginning_of_day, end: today.end_of_month.end_of_day }
+      { start: today.in_time_zone.beginning_of_month, end: today.in_time_zone.end_of_month }
     when "year"
-      { start: today.beginning_of_year.beginning_of_day, end: today.end_of_year.end_of_day }
+      { start: today.in_time_zone.beginning_of_year, end: today.in_time_zone.end_of_year }
     when "last_30_days"
-      { start: 30.days.ago.beginning_of_day, end: today.end_of_day }
+      { start: 30.days.ago.beginning_of_day, end: today.in_time_zone.end_of_day }
     when "last_90_days"
-      { start: 90.days.ago.beginning_of_day, end: today.end_of_day }
+      { start: 90.days.ago.beginning_of_day, end: today.in_time_zone.end_of_day }
     else
       {}
     end

--- a/app/services/patterns/statistics_calculator.rb
+++ b/app/services/patterns/statistics_calculator.rb
@@ -267,7 +267,13 @@ module Services::Patterns
     end
 
     def calculate_monthly_growth
-      current_month_count = base_scope.where(created_at: Date.current.beginning_of_month..).count
+      # created_at is a tz-aware timestamp column; Date.current must be
+      # anchored via #in_time_zone before beginning_of_month — a bare Date
+      # method converts via the system/server zone rather than the app's
+      # configured Time.zone (same fix as MetricsCalculator, PR #561).
+      # 1.month.ago is already TimeWithZone (Time.current-based), so it
+      # doesn't need it.
+      current_month_count = base_scope.where(created_at: Date.current.in_time_zone.beginning_of_month..).count
       last_month_count = base_scope.where(created_at: 1.month.ago.beginning_of_month..1.month.ago.end_of_month).count
 
       return 0 if last_month_count.zero?

--- a/spec/controllers/bulk_categorization_actions_controller_unit_spec.rb
+++ b/spec/controllers/bulk_categorization_actions_controller_unit_spec.rb
@@ -234,8 +234,11 @@ RSpec.describe BulkCategorizationActionsController, type: :controller, unit: tru
       allow(Expense).to receive(:includes).with(:category, :email_account).and_return(scope)
       allow(scope).to receive(:where).with(category: nil).and_return(scope)
 
-      expect(scope).to receive(:where).with("transaction_date >= ?", Date.parse("2023-01-01").beginning_of_day).ordered.and_return(scope)
-      expect(scope).to receive(:where).with("transaction_date <= ?", Date.parse("2023-12-31").end_of_day).ordered.and_return(scope)
+      # Anchored via #in_time_zone (the app's configured Time.zone), NOT
+      # bare Date#beginning_of_day/end_of_day, which convert via the
+      # system/server zone (twin of MetricsCalculator, PR #561).
+      expect(scope).to receive(:where).with("transaction_date >= ?", Date.parse("2023-01-01").in_time_zone.beginning_of_day).ordered.and_return(scope)
+      expect(scope).to receive(:where).with("transaction_date <= ?", Date.parse("2023-12-31").in_time_zone.end_of_day).ordered.and_return(scope)
       expect(scope).to receive(:limit).with(1000).and_return(expenses)
 
       post :auto_categorize, params: {

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -139,13 +139,18 @@ RSpec.describe Budget, type: :model, integration: true do
   end
 
   describe '#current_period_range', integration: true do
+    # NOTE: expectations are built via #in_time_zone (the app's configured
+    # Time.zone), NOT bare Date#beginning_of_day/end_of_day — the latter
+    # convert via the system/server zone and would drift from what
+    # #current_period_range actually returns after the timezone fix (twin
+    # of MetricsCalculator#calculate_date_range, PR #561).
     context 'for daily budget' do
       let(:budget) { build(:budget, period: 'daily') }
 
       it 'returns today\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_day)
-        expect(range.end).to eq(Date.current.end_of_day)
+        expect(range.begin).to eq(Date.current.in_time_zone.beginning_of_day)
+        expect(range.end).to eq(Date.current.in_time_zone.end_of_day)
       end
     end
 
@@ -154,8 +159,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current week\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_week.beginning_of_day)
-        expect(range.end).to eq(Date.current.end_of_week.end_of_day)
+        expect(range.begin).to eq(Date.current.in_time_zone.beginning_of_week)
+        expect(range.end).to eq(Date.current.in_time_zone.end_of_week)
       end
     end
 
@@ -164,8 +169,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current month\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_month.beginning_of_day)
-        expect(range.end).to eq(Date.current.end_of_month.end_of_day)
+        expect(range.begin).to eq(Date.current.in_time_zone.beginning_of_month)
+        expect(range.end).to eq(Date.current.in_time_zone.end_of_month)
       end
     end
 
@@ -174,8 +179,8 @@ RSpec.describe Budget, type: :model, integration: true do
 
       it 'returns current year\'s date range' do
         range = budget.current_period_range
-        expect(range.begin).to eq(Date.current.beginning_of_year.beginning_of_day)
-        expect(range.end).to eq(Date.current.end_of_year.end_of_day)
+        expect(range.begin).to eq(Date.current.in_time_zone.beginning_of_year)
+        expect(range.end).to eq(Date.current.in_time_zone.end_of_year)
       end
     end
   end

--- a/spec/models/budget_unit_spec.rb
+++ b/spec/models/budget_unit_spec.rb
@@ -264,11 +264,16 @@ RSpec.describe Budget, type: :model, unit: true do
       end
 
       it "returns correct ranges for different periods" do
+        # NOTE: expectations are built via #in_time_zone (the app's
+        # configured Time.zone), NOT bare Date#beginning_of_day/end_of_day —
+        # the latter convert via the system/server zone and would drift
+        # from what #current_period_range actually returns after the
+        # timezone fix (twin of MetricsCalculator, PR #561).
         expected_ranges = {
-          daily: [ Date.new(2025, 1, 15).beginning_of_day, Date.new(2025, 1, 15).end_of_day ],
-          weekly: [ Date.new(2025, 1, 13).beginning_of_day, Date.new(2025, 1, 19).end_of_day ], # Monday to Sunday
-          monthly: [ Date.new(2025, 1, 1).beginning_of_day, Date.new(2025, 1, 31).end_of_day ],
-          yearly: [ Date.new(2025, 1, 1).beginning_of_day, Date.new(2025, 12, 31).end_of_day ]
+          daily: [ Date.new(2025, 1, 15).in_time_zone.beginning_of_day, Date.new(2025, 1, 15).in_time_zone.end_of_day ],
+          weekly: [ Date.new(2025, 1, 13).in_time_zone.beginning_of_day, Date.new(2025, 1, 19).in_time_zone.end_of_day ], # Monday to Sunday
+          monthly: [ Date.new(2025, 1, 1).in_time_zone.beginning_of_day, Date.new(2025, 1, 31).in_time_zone.end_of_day ],
+          yearly: [ Date.new(2025, 1, 1).in_time_zone.beginning_of_day, Date.new(2025, 12, 31).in_time_zone.end_of_day ]
         }
 
         expected_ranges.each do |period, (expected_start, expected_end)|

--- a/spec/services/dashboard_expense_filter_service_spec.rb
+++ b/spec/services/dashboard_expense_filter_service_spec.rb
@@ -60,10 +60,13 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
     it "handles period-based filtering" do
       service = described_class.new(base_params.merge(period: "week"))
 
-      # Period bounds are Times so range queries on the timestamp
-      # transaction_date column bracket the full day in the app zone.
-      expect(service.start_date).to eq(Date.current.beginning_of_week.beginning_of_day)
-      expect(service.end_date).to eq(Date.current.end_of_week.end_of_day)
+      # Period bounds are Times, anchored via #in_time_zone (the app's
+      # configured Time.zone) — NOT bare Date#beginning_of_day/end_of_day,
+      # which convert via the system/server zone (twin of MetricsCalculator,
+      # PR #561) — so range queries on the timestamp transaction_date
+      # column bracket the full day in the app zone.
+      expect(service.start_date).to eq(Date.current.in_time_zone.beginning_of_week)
+      expect(service.end_date).to eq(Date.current.in_time_zone.end_of_week)
     end
   end
 
@@ -316,15 +319,17 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
       # Comparing Time to a plain Date coerces the Date as 00:00 UTC, which
       # breaks at zone boundaries — e.g. a Sunday fixture at 00:00 -0600 is
       # 06:00 UTC, which is *after* end_of_week (Sun 00:00 UTC). Compare
-      # Time-to-Time using .beginning_of_day / .end_of_day so both sides
-      # share the configured zone.
+      # Time-to-Time using #in_time_zone so both sides share the app's
+      # configured Time.zone (twin of MetricsCalculator, PR #561) — a bare
+      # Date#beginning_of_day/end_of_day chain converts via the
+      # system/server zone instead.
       context "week filter" do
         let(:params) { base_params.merge(period: "week") }
 
         it "returns current week's expenses" do
           dates = result.expenses.map(&:transaction_date)
-          expect(dates.min).to be >= Date.current.beginning_of_week.beginning_of_day
-          expect(dates.max).to be <= Date.current.end_of_week.end_of_day
+          expect(dates.min).to be >= Date.current.in_time_zone.beginning_of_week
+          expect(dates.max).to be <= Date.current.in_time_zone.end_of_week
         end
       end
 
@@ -333,9 +338,48 @@ RSpec.describe Services::DashboardExpenseFilterService, type: :service do
 
         it "returns current month's expenses" do
           dates = result.expenses.map(&:transaction_date)
-          expect(dates.min).to be >= Date.current.beginning_of_month.beginning_of_day
-          expect(dates.max).to be <= Date.current.end_of_month.end_of_day
+          expect(dates.min).to be >= Date.current.in_time_zone.beginning_of_month
+          expect(dates.max).to be <= Date.current.in_time_zone.end_of_month
         end
+      end
+    end
+
+    # REGRESSION: twin of the MetricsCalculator timezone boundary bug (PR
+    # #561) / ExpensesController (PR #564). #calculate_period_dates used to
+    # build transaction_date range endpoints via bare Date#beginning_of_day/
+    # end_of_day, which convert through the system/Postgres session time
+    # zone rather than the app's configured Time.zone ("Central America",
+    # -06:00) — so expenses exactly at local midnight could land on the
+    # wrong side of the Recent Expenses period boundary. Fixed by anchoring
+    # every endpoint via #in_time_zone.
+    context "with expenses exactly at local midnight boundaries (Recent Expenses period filter)" do
+      before { Expense.where(email_account: email_account).delete_all }
+
+      let(:params) { base_params.merge(period: "month") }
+
+      before do
+        # 00:00:00 local time on the first day of the current month — must count
+        create(:expense,
+          email_account: email_account,
+          amount: 10.00,
+          transaction_date: Date.current.beginning_of_month.in_time_zone.beginning_of_day)
+
+        # 23:59:59 local time on the last day of the current month — must count
+        create(:expense,
+          email_account: email_account,
+          amount: 20.00,
+          transaction_date: Date.current.end_of_month.in_time_zone.end_of_day)
+
+        # 00:00:00 local time the day AFTER the month ends — must NOT count
+        create(:expense,
+          email_account: email_account,
+          amount: 999.00,
+          transaction_date: (Date.current.end_of_month + 1.day).in_time_zone.beginning_of_day)
+      end
+
+      it "includes both midnight-boundary expenses and excludes the one after the period ends" do
+        expect(result.total_count).to eq(2)
+        expect(result.expenses.map(&:amount).map(&:to_f)).to contain_exactly(10.00, 20.00)
       end
     end
 

--- a/spec/services/dashboard_service_spec.rb
+++ b/spec/services/dashboard_service_spec.rb
@@ -283,8 +283,11 @@ RSpec.describe Services::DashboardService, integration: true do
       end
 
       it 'does not include future expenses in current month' do
+        # Built via #in_time_zone (the app's configured Time.zone), NOT bare
+        # Date#beginning_of_month/end_of_day, to match how DashboardService
+        # actually anchors the boundary (twin of MetricsCalculator, PR #561).
         current_month_expenses = Expense.where(
-          transaction_date: Date.current.beginning_of_month..Date.current.end_of_month
+          transaction_date: Date.current.in_time_zone.beginning_of_month..Date.current.in_time_zone.end_of_month
         ).sum(:amount)
 
         analytics = service.analytics

--- a/spec/services/expense_filter_service_spec.rb
+++ b/spec/services/expense_filter_service_spec.rb
@@ -224,6 +224,149 @@ RSpec.describe Services::ExpenseFilterService, type: :service do
         expect(result.performance_metrics[:index_used]).to be true
       end
     end
+
+    # REGRESSION: twin of the MetricsCalculator timezone boundary bug (PR
+    # #561) / ExpensesController (PR #564). #calculate_period_range,
+    # #filter_by_dates, and #parse_date_range used to build transaction_date
+    # range endpoints via bare Date#beginning_of_day/end_of_day, which
+    # convert through the system/Postgres session time zone rather than the
+    # app's configured Time.zone ("Central America", -06:00) — so expenses
+    # exactly at local midnight could land on the wrong side of a
+    # period/filter boundary. Fixed by anchoring every endpoint via
+    # #in_time_zone.
+    context "with expenses exactly at local midnight boundaries" do
+      before { Expense.where(email_account: email_account).delete_all }
+
+      context "with a period filter" do
+        let(:service) do
+          described_class.new(account_ids: [ email_account.id ], period: "month")
+        end
+
+        before do
+          # 00:00:00 local time on the first day of the current month — must count
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 10.00,
+            transaction_date: Date.current.beginning_of_month.in_time_zone.beginning_of_day,
+            merchant_name: "Boundary Start",
+            currency: "crc"
+          )
+
+          # 23:59:59 local time on the last day of the current month — must count
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 20.00,
+            transaction_date: Date.current.end_of_month.in_time_zone.end_of_day,
+            merchant_name: "Boundary End",
+            currency: "crc"
+          )
+
+          # 00:00:00 local time the day AFTER the month ends — must NOT count
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 999.00,
+            transaction_date: (Date.current.end_of_month + 1.day).in_time_zone.beginning_of_day,
+            merchant_name: "Outside Boundary",
+            currency: "crc"
+          )
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the period ends" do
+          result = service.call
+          expect(result.total_count).to eq(2)
+          expect(result.expenses.map(&:amount)).to contain_exactly(10.00, 20.00)
+        end
+      end
+
+      context "with an explicit date_from/date_to range" do
+        let(:from_date) { Date.current - 5.days }
+        let(:to_date) { Date.current - 3.days }
+        let(:service) do
+          described_class.new(account_ids: [ email_account.id ], date_from: from_date, date_to: to_date)
+        end
+
+        before do
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 10.00,
+            transaction_date: from_date.in_time_zone.beginning_of_day,
+            merchant_name: "Boundary Start",
+            currency: "crc"
+          )
+
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 20.00,
+            transaction_date: to_date.in_time_zone.end_of_day,
+            merchant_name: "Boundary End",
+            currency: "crc"
+          )
+
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 999.00,
+            transaction_date: (to_date + 1.day).in_time_zone.beginning_of_day,
+            merchant_name: "Outside Boundary",
+            currency: "crc"
+          )
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the range ends" do
+          result = service.call
+          expect(result.total_count).to eq(2)
+          expect(result.expenses.map(&:amount)).to contain_exactly(10.00, 20.00)
+        end
+      end
+
+      context "with traditional start_date/end_date filters" do
+        let(:start_date) { Date.current - 5.days }
+        let(:end_date) { Date.current - 3.days }
+        let(:service) do
+          described_class.new(account_ids: [ email_account.id ], start_date: start_date, end_date: end_date)
+        end
+
+        before do
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 10.00,
+            transaction_date: start_date.in_time_zone.beginning_of_day,
+            merchant_name: "Boundary Start",
+            currency: "crc"
+          )
+
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 20.00,
+            transaction_date: end_date.in_time_zone.end_of_day,
+            merchant_name: "Boundary End",
+            currency: "crc"
+          )
+
+          Expense.create!(
+            email_account: email_account,
+            user: email_account.user,
+            amount: 999.00,
+            transaction_date: (end_date + 1.day).in_time_zone.beginning_of_day,
+            merchant_name: "Outside Boundary",
+            currency: "crc"
+          )
+        end
+
+        it "includes both midnight-boundary expenses and excludes the one after the range ends" do
+          result = service.call
+          expect(result.total_count).to eq(2)
+          expect(result.expenses.map(&:amount)).to contain_exactly(10.00, 20.00)
+        end
+      end
+    end
   end
 
   describe "#to_json" do


### PR DESCRIPTION
## Summary

Completes the app-wide timezone-range sweep started in #561 (MetricsCalculator) and #564 (ExpensesController). Same bug class: date ranges built via bare `Date#beginning_of_day/end_of_day` (convert via the system/server zone) or naive `Date..Date` ranges (Postgres casts them in its own session zone) — queried against tz-aware datetime columns (`transaction_date`, `created_at`, `completed_at`, etc). Expenses/records near local midnight could land on the wrong side of a period/filter boundary. Fixed by anchoring every endpoint via `#in_time_zone`, matching `MetricsCalculator#calculate_date_range`'s idiom.

## Per-site table

### Fixed — genuine instances of the bug class

| Site | Notes |
|---|---|
| `ExpenseFilterService#filter_by_dates` / `#calculate_period_range` / `#parse_date_range` | Powers the main expenses index listing |
| `DashboardExpenseFilterService#calculate_period_dates` | Powers dashboard Recent Expenses |
| `DashboardService#calculate_totals` / `#monthly_trend` | Dashboard analytics totals/trend |
| `Budget#current_period_range` | Drives `#calculate_current_spend!` — core budget spend tracking |
| `Expense.by_date_range` / `.this_month` / `.this_year` scopes | |
| `BulkOperation.today` / `.this_week` / `.this_month` scopes | Found via own sweep (`.all_day`/`.all_week`/`.all_month` on a bare Date have the same bug) |
| `Categorization::PatternAnalytics#fetch_feedback_counts` | |
| `Patterns::StatisticsCalculator#calculate_monthly_growth` | Found via own sweep |
| `BudgetsController#calculate_suggested_budget_amount` | |
| `BulkCategorizationActionsController#find_expenses_for_auto_categorize` | |
| `SyncSessionsController#index` (`today_sync_count` / `monthly_expenses_detected`) | |
| `Analytics::PatternDashboardController#parse_custom_date_range` | Found via own sweep — naive `Date..Date` range |

### Already zone-correct — skipped

| Site | Why |
|---|---|
| `ExpenseSummaryService` | `1.week/month/year.ago.beginning_of_day` / `Time.current.end_of_day` — already `Time.current`-based (TimeWithZone) |
| `SyncMetricsCollector#historical_performance_data` | `i.days.ago.beginning_of_day..date.end_of_day` — same, already zone-correct |
| `SyncPerformanceController#set_date_range` | `7/30.days.ago.beginning_of_day` — already zone-correct |
| `Analytics::PatternDashboardController` today/week/month/quarter/year branches | `Time.current.beginning_of_day..Time.current` / `X.ago..Time.current` — already zone-correct |
| `Patterns::StatisticsCalculator` `1.month.ago.beginning_of_month..1.month.ago.end_of_month` | Already zone-correct |

### Intentionally skipped — out of the reported bug class

| Site | Why |
|---|---|
| `Api::WebhooksController#parse_since_parameter` | Feeds an IMAP `SINCE` search, not an ActiveRecord/Postgres query against a tz-aware column |
| `Budget.for_period_containing` | `start_date`/`end_date` are `t.date` columns (pure Date), not tz-aware timestamps |
| `bulk_categorization/grouping_service.rb`, `categorization/bulk_categorization_service.rb` `group_by_date`/`group_by_date_range` | In-memory grouping keys on already-fetched records, not a DB query |
| `postgres_backup_job.rb` retention logic | Remote backup filename retention, unrelated to any AR/Postgres timestamp column |
| `MetricsRefreshJob#determine_affected_periods` | Produces bare reference Dates fed into `MetricsCalculator.new(reference_date:)`, which is already zone-safe internally |

## Boundary regression specs added

Mirroring #564's spec idiom (expenses exactly at local-midnight boundaries, must land on the correct side):
- `spec/services/expense_filter_service_spec.rb` — period filter, `date_from`/`date_to`, `start_date`/`end_date`
- `spec/services/dashboard_expense_filter_service_spec.rb` — Recent Expenses period filter

Also updated existing specs that asserted the **old naive** boundary values (they'd otherwise pin the bug back in) to the correct tz-aware expectation, never normalized to whatever the code now returns:
- `spec/models/budget_spec.rb`, `spec/models/budget_unit_spec.rb` — `#current_period_range`
- `spec/services/dashboard_service_spec.rb` — current-month total boundary
- `spec/controllers/bulk_categorization_actions_controller_unit_spec.rb` — mocked `where` args

## Verification

- `bin/test-unit`: 8600 examples, 0 failures (isolated worktree test DB)
- `bundle exec rubocop` on all touched files: no offenses
- Pre-commit hook (unit tests + RuboCop + Brakeman + Rails Best Practices): all green