### PR TITLE
fix(parser): stop flagging the existing expense as duplicate when a duplicate email arrives

### DIFF
--- a/app/services/email_processing/parser.rb
+++ b/app/services/email_processing/parser.rb
@@ -88,7 +88,13 @@ module Services::EmailProcessing
         end
 
         if existing_expense
-          existing_expense.update(status: :duplicate)
+          # Do NOT flip the pre-existing (legitimate, already-processed)
+          # expense's status here — it is the survivor, not the duplicate.
+          # The incoming email is the duplicate; it is discarded (no new
+          # Expense row is created) and recorded via add_error's log line
+          # instead of mutating data. See PR fixing duplicate-status
+          # semantics — flipping this record's status previously made a
+          # real expense silently vanish from any status-scoped total.
           add_error("Duplicate expense found")
           return existing_expense
         end
@@ -149,7 +155,9 @@ module Services::EmailProcessing
       ).first
 
       if existing
-        existing.update(status: :duplicate)
+        # Same rationale as the find_duplicate_expense branch above: `existing`
+        # is the legitimate, already-persisted expense that won the unique-
+        # index race — it is not the duplicate and must keep its own status.
         add_error("Duplicate expense detected via unique constraint")
         existing
       else

--- a/spec/jobs/process_email_job_spec.rb
+++ b/spec/jobs/process_email_job_spec.rb
@@ -336,14 +336,17 @@ RSpec.describe ProcessEmailJob, type: :job, integration: true do
       expect(ProcessedEmail.where(message_id: '7')).to be_empty
     end
 
-    it 'records a ProcessedEmail when the expense is marked as duplicate' do
+    it 'records a ProcessedEmail for the duplicate email without corrupting the original expense status' do
       ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id)
 
       expect {
         ProcessEmailJob.new.perform(email_account.id, email_data_with_rfc_id.merge(rfc_message_id: '<resent-copy@mail.gmail.com>'))
       }.to change(Expense, :count).by(0).and change(ProcessedEmail, :count).by(1)
 
-      expect(Expense.last.status).to eq('duplicate')
+      # The original expense is the survivor, not the duplicate — its status
+      # must stay `processed`. See fix(parser): stop flagging the existing
+      # expense as duplicate when a duplicate email arrives.
+      expect(Expense.last.status).to eq('processed')
     end
 
     it 'does not record a ProcessedEmail when parsing fails (non-terminal outcome)' do

--- a/spec/services/email_processing/unit/parser_duplicate_detection_spec.rb
+++ b/spec/services/email_processing/unit/parser_duplicate_detection_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe Services::EmailProcessing::Parser, type: :service, unit: true do
         allow(parser).to receive(:find_duplicate_expense).and_return(existing_expense)
       end
 
-      it 'updates existing expense status to duplicate' do
-        expect(existing_expense).to receive(:update).with(status: :duplicate)
+      it 'does NOT mutate the existing expense status — it is the survivor, not the duplicate' do
+        expect(existing_expense).not_to receive(:update)
         parser.send(:create_expense, parsed_data)
       end
 
@@ -240,42 +240,6 @@ RSpec.describe Services::EmailProcessing::Parser, type: :service, unit: true do
       it 'does not call category guessing' do
         expect(parser).not_to receive(:categorize_expense)
         parser.send(:create_expense, parsed_data)
-      end
-
-      context 'when update fails' do
-        before do
-          allow(existing_expense).to receive(:update).and_return(false)
-        end
-
-        it 'still returns the existing expense' do
-          result = parser.send(:create_expense, parsed_data)
-          expect(result).to eq(existing_expense)
-        end
-
-        it 'still adds duplicate error' do
-          parser.send(:create_expense, parsed_data)
-          expect(parser.errors).to include('Duplicate expense found')
-        end
-      end
-
-      context 'when update raises error' do
-        before do
-          allow(existing_expense).to receive(:update).and_raise(StandardError, 'Update failed')
-        end
-
-        it 'rescues the error' do
-          # The error should bubble up since there's no rescue in the create_expense method for update failures
-          expect { parser.send(:create_expense, parsed_data) }.to raise_error(StandardError, 'Update failed')
-        end
-
-        it 'raises the error' do
-          expect { parser.send(:create_expense, parsed_data) }.to raise_error(StandardError, 'Update failed')
-        end
-
-        it 'does not add error message since exception is raised' do
-          expect { parser.send(:create_expense, parsed_data) }.to raise_error(StandardError)
-          # Errors are not added when exception is raised
-        end
       end
     end
 
@@ -550,26 +514,30 @@ RSpec.describe Services::EmailProcessing::Parser, type: :service, unit: true do
         allow(parser).to receive(:find_duplicate_expense).and_return(existing_expense)
       end
 
-      it 'changes status from pending to duplicate' do
-        expect(existing_expense).to receive(:update).with(status: :duplicate)
+      # Regression coverage for the duplicate-status-flip bug: regardless of
+      # the survivor's prior status, create_expense must never mutate it —
+      # the pre-existing expense is legitimate and the incoming email is the
+      # duplicate, not the other way around.
+      it 'leaves a pending existing expense untouched' do
+        expect(existing_expense).not_to receive(:update)
         parser.send(:create_expense, parsed_data)
       end
 
-      it 'changes status from processed to duplicate' do
+      it 'leaves a processed existing expense untouched' do
         allow(existing_expense).to receive(:status).and_return('processed')
-        expect(existing_expense).to receive(:update).with(status: :duplicate)
+        expect(existing_expense).not_to receive(:update)
         parser.send(:create_expense, parsed_data)
       end
 
-      it 'changes status from error to duplicate' do
-        allow(existing_expense).to receive(:status).and_return('error')
-        expect(existing_expense).to receive(:update).with(status: :duplicate)
+      it 'leaves a failed existing expense untouched' do
+        allow(existing_expense).to receive(:status).and_return('failed')
+        expect(existing_expense).not_to receive(:update)
         parser.send(:create_expense, parsed_data)
       end
 
-      it 'updates already duplicate status' do
+      it 'leaves an already-duplicate existing expense untouched' do
         allow(existing_expense).to receive(:status).and_return('duplicate')
-        expect(existing_expense).to receive(:update).with(status: :duplicate)
+        expect(existing_expense).not_to receive(:update)
         parser.send(:create_expense, parsed_data)
       end
     end
@@ -664,13 +632,13 @@ RSpec.describe Services::EmailProcessing::Parser, type: :service, unit: true do
         allow(new_expense).to receive(:save).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
       end
 
-      it 'rescues RecordNotUnique and returns existing duplicate' do
+      it 'rescues RecordNotUnique, returns the winner of the race, and does NOT mutate its status' do
         allow(Expense).to receive(:where).and_return(expense_relation)
         allow(expense_relation).to receive(:first).and_return(conflicting_expense)
 
         result = parser.send(:create_expense, parsed_data)
 
-        expect(conflicting_expense).to have_received(:update).with(status: :duplicate)
+        expect(conflicting_expense).not_to have_received(:update)
         expect(result).to eq(conflicting_expense)
       end
 
@@ -692,6 +660,77 @@ RSpec.describe Services::EmailProcessing::Parser, type: :service, unit: true do
         expect(result).to be_nil
         expect(parser.errors).to include('Duplicate expense conflict but original not found')
       end
+    end
+  end
+
+  # Real-database regression coverage for the duplicate-status-flip bug
+  # (Obsidian follow-up #7, surfaced during the PR #562 review). Unlike the
+  # instance_double-based specs above, this round-trips a REAL persisted
+  # Expense through the parser so the assertions can't be satisfied by a
+  # mock that merely "isn't called" — they verify the actual DB row and the
+  # actual production scope (Expense.by_status) a dashboard/filter view
+  # would query. These fail on main today (main flips the survivor's status
+  # to :duplicate and drops it out of the `by_status(:processed)` scope).
+  describe 'real database integration — duplicate email does not corrupt the survivor', unit: true do
+    let(:real_parsing_rule) { create(:parsing_rule, :bac, bank_name: "TEST_DUPSEM_BANK") }
+    let(:real_email_account) { create(:email_account, :bac, bank_name: "TEST_DUPSEM_BANK") }
+    let(:real_email_data) do
+      {
+        message_id: 456,
+        from: 'notifications@bac.net',
+        subject: 'Notificación de transacción',
+        date: 'Wed, 02 Aug 2025 14:16:00 +0000',
+        body: 'irrelevant — pre_parsed_data bypasses the strategy parser'
+      }
+    end
+
+    let!(:existing_expense) do
+      real_parsing_rule # ensure the parsing rule exists before the account is used
+      create(:expense, :processed,
+        email_account: real_email_account,
+        user: real_email_account.user,
+        amount: BigDecimal('100.00'),
+        transaction_date: Date.current,
+        merchant_name: 'Test Merchant',
+        bank_name: "TEST_DUPSEM_BANK")
+    end
+
+    let(:duplicate_pre_parsed) do
+      {
+        amount: BigDecimal('100.00'),
+        transaction_date: Date.current,
+        merchant_name: 'Test Merchant',
+        description: 'Duplicate notification of the same purchase'
+      }
+    end
+
+    let(:duplicate_parser) do
+      Services::EmailProcessing::Parser.new(real_email_account, real_email_data, pre_parsed_data: duplicate_pre_parsed)
+    end
+
+    it 'does not create a new expense row for the duplicate email' do
+      expect { duplicate_parser.parse_expense }.not_to change(Expense, :count)
+    end
+
+    it 'keeps the pre-existing expense processed (does not flip it to duplicate)' do
+      duplicate_parser.parse_expense
+      expect(existing_expense.reload.status).to eq('processed')
+    end
+
+    it 'reports the duplicate via parser errors' do
+      duplicate_parser.parse_expense
+      expect(duplicate_parser.errors).to include('Duplicate expense found')
+    end
+
+    it 'returns the untouched existing expense from parse_expense' do
+      result = duplicate_parser.parse_expense
+      expect(result).to eq(existing_expense)
+    end
+
+    it 'still appears in the status-filtered scope a dashboard/filter view would use' do
+      duplicate_parser.parse_expense
+      expect(Expense.by_status(:processed)).to include(existing_expense)
+      expect(Expense.by_status(:duplicate)).not_to include(existing_expense)
     end
   end
 end


### PR DESCRIPTION
## Summary

Obsidian follow-up #7 (surfaced during the PR #562 review). `Services::EmailProcessing::Parser#create_expense` and its `RecordNotUnique` rescue path (`handle_record_not_unique`) both flipped the **pre-existing, already-processed** expense's status to `:duplicate` whenever a duplicate email arrived — corrupting the legitimate survivor instead of just discarding the incoming duplicate.

## Phase 1 — Impact & reachability analysis

**a. Downstream impact of the status flip.** Audited every scope/service that reads `Expense` for totals/lists (`MetricsCalculator`, `Budget#calculate_current_spend!`, `DashboardService`, `DashboardExpenseFilterService`, `ExpenseFilterService`). None of them filter out `status: :duplicate` by default — `Expense`'s only `default_scope` is `deleted_at: nil` (via `SoftDelete`), and the flip does **not** set `deleted_at`. So the flipped expense keeps counting toward dashboard/budget totals. The real damage is elsewhere:
  - It's mislabeled with a `duplicate` badge in the UI on a completely legitimate transaction.
  - It's miscounted in every status-breakdown facet (`MetricsCalculator#calculate_status_breakdown`, the dashboard's status facet).
  - **It disappears from any explicit `status=processed` filter** — e.g. `ExpenseFilterService#filter_by_status`/`Expense.by_status(:processed)`, the same scope the expenses index "Processed" filter uses.
  - Every call is `existing.update(status: :duplicate)`, no `deleted_at` — so a second duplicate-email hit on the same (now mislabeled) record re-runs the same corrupting update, compounding the mislabeling.

**b. Reachability in production, given the newer layers.**
  - `ProcessedEmail.already_processed?` only blocks a **repeat of the same RFC822 Message-ID** — it does not stop two *different* emails (different Message-IDs, e.g. a bank resend) referencing the same transaction.
  - `ConflictDetectionService` (used by `Processor#detect_and_handle_conflict`) runs a probabilistic similarity check **before** `ProcessEmailJob` is even enqueued, but only when a `sync_session` is present. It is skipped entirely when `sync_session` is `nil` — and that path is live in production: `Api::WebhooksController#process_emails` (the iPhone Shortcuts / webhook trigger) calls `ProcessEmailsJob.perform_later(account.id, since: since)` with **no `sync_session_id`**. On that path, `Parser#find_duplicate_expense`'s looser rule (amount + date ±1 day, no merchant/description/currency check — confirmed by the existing spec `'does not consider merchant_name for matching'`) is the *only* duplicate guard.
  - Even when a `sync_session` **is** present, `ConflictDetectionService`'s weighted score (`amount 35 + date 25 + merchant 20 + description 10 + currency 10`, threshold 70) can rule "no conflict" (score ≤ 60 when merchant/description/currency all mismatch) for two *genuinely different* transactions that still land inside Parser's cruder ±1‑day/exact‑amount window — so the email proceeds to `ProcessEmailJob` and hits the buggy branch anyway.

**c. Can two legitimate distinct expenses trigger this?** Yes. `find_duplicate_expense` matches on `email_account + amount + transaction_date (±1 day)` only — it does **not** check `merchant_name` (unlike the DB's `idx_expenses_duplicate_check` unique index, which requires exact `merchant_name` + exact `transaction_date`). Two unrelated same-amount purchases at different merchants within a day of each other (e.g. two ₡5,000 coffee purchases) collide under Parser's rule even though they're not duplicates by the DB constraint or by `ConflictDetectionService`'s own definition. Under the old code this both (1) silently dropped the second legitimate expense and (2) corrupted the first one's status.

**d. Git history.** `git log -S'status: :duplicate' -- app/services/email_processing/parser.rb` traces back to `af2c042` (PER-277, the advisory-lock/unique-index race-condition fix) and further to the original `create_expense` implementation — the flip was never a deliberate "mark the loser" design, just a status-naming mistake baked in from the start and then carried forward through several refactors. No ticket intent to preserve.

## Phase 2 — Fix

- `create_expense`: on finding a duplicate, no longer calls `existing_expense.update(status: :duplicate)`. The survivor keeps its actual status. Still returns `existing_expense` (truthy) and still calls `add_error("Duplicate expense found")` — so callers behave exactly as before (no new row created, `ProcessEmailJob` still records the terminal `ProcessedEmail` outcome) except the survivor is no longer mutated. The existing `add_error` → `Rails.logger.error` call is the non-destructive record of the detection.
- `handle_record_not_unique` (the `RecordNotUnique` rescue path, hit under the advisory-lock race): same fix — the record that won the unique-index race keeps its own status.
- The ±1‑day/no‑merchant matching rule in `find_duplicate_expense` is **unchanged** (out of scope per the ticket) — see the separate finding below.

## Separate finding (not fixed here, scope discipline)

`find_duplicate_expense`'s matching rule (amount + ±1‑day date, no merchant/description) is looser than both the DB's unique index and `ConflictDetectionService`'s similarity scoring, and can match two legitimate distinct transactions (1c above). Recommend tightening it (e.g. add merchant_name, like the DB index) or removing it as a redundant/stale check now that `ConflictDetectionService` is the primary duplicate gate on the `sync_session` path — but that changes matching semantics, so left for a follow-up ticket.

## Tests

- `spec/services/email_processing/unit/parser_duplicate_detection_spec.rb`:
  - Rewrote all specs that asserted `existing_expense.update(status: :duplicate)` (in `#create_expense with duplicate detection`, `duplicate status handling`, and the `RecordNotUnique` rescue path) to instead assert `existing_expense`/`conflicting_expense` **never** receives `:update`, across every prior status (pending/processed/failed/duplicate).
  - Removed the now-inapplicable "when update fails" / "when update raises error" mock contexts (there's no more `.update` call on that branch to fail/raise).
  - Added a new **real-database** regression block (`real database integration — duplicate email does not corrupt the survivor`) that persists a real `processed` `Expense`, feeds a duplicate through the real parser via `pre_parsed_data`, and asserts: no new `Expense` row, the survivor's `status` stays `'processed'` after `.reload`, `parser.errors` includes `'Duplicate expense found'`, and the survivor still appears in `Expense.by_status(:processed)` (the scope the UI's status filter actually uses) while not appearing in `Expense.by_status(:duplicate)`.
- `spec/jobs/process_email_job_spec.rb`: fixed `'records a ProcessedEmail when the expense is marked as duplicate'` (renamed to `'... without corrupting the original expense status'`) — it asserted `Expense.last.status == 'duplicate'`; now asserts `'processed'`.
- **Verified mutation quality**: stashed the parser.rb fix and reran the affected specs — 11 examples failed on unmodified `main`-equivalent code (the intended regression signal), all now pass with the fix applied.

## Verify

- `bundle exec rspec spec/services/email_processing/ spec/models/expense_spec.rb spec/jobs/process_email_job_spec.rb spec/services/conflict_detection_service_spec.rb spec/services/conflict_resolution_service_spec.rb` → 844 examples, 0 failures
- `bin/test-unit` → 8568 examples, 0 failures, 5 pendings (pre-existing, unrelated)
- `bundle exec rubocop` → 919 files inspected, no offenses
- Pre-commit hook (unit tests + RuboCop + Brakeman + Rails Best Practices) → all green