### PR TITLE
docs(coverage): record why the worker-merge keeps nil-wins (not bootsnap)

### DIFF
--- a/lib/coverage_policy_validator.rb
+++ b/lib/coverage_policy_validator.rb
@@ -134,11 +134,20 @@ class CoveragePolicyValidator
 
         merged[file_path] = if merged.key?(file_path)
           merged[file_path].zip(lines).map do |a, b|
-            # SimpleCov::Combine::LinesCombiner semantics: when entries
-            # disagree on relevance (0 in one, nil in another — bootsnap
-            # ISeq caching causes this across workers), the line is NOT
-            # relevant. Naive to_i summing would count it as uncovered
-            # and inflate the denominator.
+            # When entries disagree on relevance (0 in one, nil in another), the
+            # line is NOT relevant ("nil-wins") — this is correct, not a mirror of
+            # SimpleCov's own combiner. On SimpleCov <= 0.22, the `rails` profile's
+            # track_files glob backfills any app/lib file a worker never `require`d
+            # via LinesClassifier, a regex line scanner that marks every non-blank,
+            # non-comment line "relevant" with 0 hits — unable to tell a multi-line
+            # hash/array literal or bare `end`/`else`/`when` from a real statement.
+            # Evidence: one file's 4-worker resultset had two workers that actually
+            # ran it report relevant=250 covered=243/177, and two that never loaded
+            # it fabricate relevant=528 covered=0; nil-wins discards those stubs.
+            # Bootsnap is NOT the cause — DISABLE_BOOTSNAP=1 produced identical
+            # results. SimpleCov >= 1.0 (PR #569) fixes this upstream via
+            # Coverage.line_stub, shrinking the effect to ~0.2% — nil-wins stays as
+            # defense-in-depth in case fabricated stubs reappear.
             sum = a.to_i + b.to_i
             sum.zero? && (a.nil? || b.nil?) ? nil : sum
           end

--- a/spec/lib/coverage_policy_validator_spec.rb
+++ b/spec/lib/coverage_policy_validator_spec.rb
@@ -61,10 +61,15 @@ RSpec.describe CoveragePolicyValidator, unit: true do
       expect(load_data).to eq("app/models/expense.rb" => [ nil, 1 ])
     end
 
-    it "resolves relevance disagreement as not-relevant, like SimpleCov's combiner" do
-      # bootsnap ISeq caching can make the same line report 0 (relevant,
-      # uncovered) in one worker and nil (not relevant) in another. SimpleCov
-      # merges that to nil; counting it as 0 would inflate the denominator.
+    it "resolves relevance disagreement as not-relevant (nil-wins)" do
+      # On SimpleCov <= 0.22, a worker that never loaded a tracked file gets
+      # its coverage fabricated by LinesClassifier — a regex line scanner
+      # (see simplecov-ruby/simplecov#654) that can't tell multi-line
+      # literals or bare `when`/`else`/`end` from real statements, roughly
+      # doubling the file's apparent line count with all-zero fabricated
+      # hits. nil-wins discards those fabricated stubs in favor of a worker
+      # that actually ran the file; an inclusive rule would union the
+      # fabricated lines in and understate coverage instead.
       stub_resultset(
         "integration-tests-100" => {
           "timestamp" => 100,


### PR DESCRIPTION
## Summary

Comment-only fix. `CoveragePolicyValidator#merge_latest_run`'s in-code comment gave two justifications for the nil-wins merge rule — both false. This PR corrects the comment (and a spec description carrying the same false claims) to record the real mechanism. **No behavior changes**: the merge rule itself was, and remains, correct.

## Background

When merging per-worker parallel-test coverage resultsets, if two workers disagree on whether a line is "relevant" (one reports `0`, the other `nil`), `merge_latest_run` resolves the disagreement to `nil` — the line is dropped from the denominator ("nil-wins"). The old comment claimed this:

1. matches "SimpleCov::Combine::LinesCombiner semantics", and
2. is caused by bootsnap ISeq caching disagreeing across workers.

Both claims are false, but the rule they were defending is correct.

## Root cause (verified two independent ways)

`SimpleCov.start 'rails'` sets `track_files "{app,lib}/**/*.rb"`. On simplecov **0.22** (pre-#569 bump), any tracked file a given parallel worker never actually `require`d gets backfilled by `SimpleCov::Combine`/`SimulateCoverage` → `LinesClassifier` — a pure **regex** line classifier, not real `Coverage` data. It marks every non-blank, non-comment line as "relevant" with 0 hits. It cannot tell that a multi-line hash/array literal body, or a bare `end`/`else`/`when`/`rescue`/`begin`, isn't its own executable statement — this roughly **doubles** a file's apparent relevant-line count for any worker that merely never touched it.

**Decisive raw evidence** — one file's unmerged 4-worker resultset:
- Two workers that actually ran the file: `relevant=250 covered=243` and `relevant=250 covered=177`
- Two workers that never loaded it: `relevant=528 covered=0` (fabricated stubs)

The fabrications contribute only zeros, which is why the covered-line numerator was identical across every configuration measured — only the (fabricated) denominator moved.

**nil-wins is correct**: it discards the fabricated `relevant=528 covered=0` stubs in favor of the workers that actually exercised the file. An "inclusive" rule (relevant-on-either-side) would union the fabricated lines in and report a false ~58% instead of the true ~82%.

**Ground truth confirms it**: Ruby's own `Coverage` module, run serially (single process) and again with `DISABLE_BOOTSNAP=1`, produced byte-identical results that matched the current merged output exactly.

## Bootsnap refutation

Bootsnap explicitly bypasses its own ISeq cache whenever `Coverage.running?` is true, so it cannot be the source of the cross-worker disagreement. Disabling it entirely (`DISABLE_BOOTSNAP=1`) changed nothing — confirming it plays no role here.

## Relationship to #569

simplecov **>= 1.0** fixes this upstream (simplecov-ruby/simplecov#654) by using `Coverage.line_stub` instead of the regex `LinesClassifier` for backfilled files. PR #569 already bumped this repo to simplecov 1.0.3, so on `main` today the merge-rule choice (nil-wins vs. inclusive) now shifts results by only ~0.2%. nil-wins is kept anyway as defense-in-depth in case fabricated stubs ever reappear (e.g. a future downgrade, a different backfill path, or a similar bug elsewhere).

## Changes

- `lib/coverage_policy_validator.rb`: comment-only — replaced the false "matches SimpleCov's combiner" / bootsnap explanation with the verified LinesClassifier/track_files mechanism, the raw evidence, the bootsnap refutation, and the #569 relationship. Logic is byte-identical to `main` (verified via diff).
- `spec/lib/coverage_policy_validator_spec.rb`: renamed the example description and rewrote its comment to drop the same false claims; the asserted behavior (`nil-wins`) is unchanged from `main`.

## Test plan

- [x] `bundle exec rspec spec/lib/coverage_policy_validator_spec.rb` — 10 examples, 0 failures
- [x] `bundle exec rubocop lib/coverage_policy_validator.rb spec/lib/coverage_policy_validator_spec.rb` — no offenses
- [x] `git diff origin/main -- lib/coverage_policy_validator.rb | grep -c '^[+-][^+-]'` → 19 changed lines, all pure `#` comment lines (0 non-comment changes)
- [x] Pre-commit hook: full unit suite (8568 examples, 0 failures), rubocop, brakeman, rails-best-practices — all green