### PR TITLE
ci: raise unit-tests timeout above the suite's real runtime

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,10 @@ env:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Suite runs ~3m17s-3m38s and keeps growing (8600+ examples). 5 min left almost no
+    # headroom and killed PR #572 mid-suite on a transient stall (silent timeout, no
+    # rspec summary, no test failures) rather than a real regression.
+    timeout-minutes: 12
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- `unit-tests.yml`'s `unit-tests` job had `timeout-minutes: 5`, but recent passing runs actually take **~3m17s-3m38s** (observed range) / **~3m53s-4m02s** (measured on this session's own CI checks) with 8600+ examples and growing. That left almost no headroom (~1.0-1.3x), and PR #572's run was killed mid-suite by the hard timeout during a transient stall — the log showed silence followed by "The operation was canceled", with no rspec summary and no actual test failures. Every future PR carries the same risk as the suite keeps growing.
- Raised `timeout-minutes` from **5 → 12** on the `unit-tests` job, with a comment explaining why (observed runtime, growth trend, ref to #572).

## Other workflows audited (`grep -rn "timeout-minutes" .github/workflows/`)

Left unchanged — each already has generous headroom or isn't in the PR-blocking path:

| File | Job | Limit | Observed | Headroom | Verdict |
|---|---|---|---|---|---|
| `unit-tests.yml` | `unit-coverage-validation` | 2m | ~13s | ~9x | leave alone |
| `integration-tests.yml` | `integration-tests` | 15m | n/a (disabled) | n/a | leave alone — workflow is `workflow_dispatch`-only since #335 (flaky DB deadlocks), not triggered by `pull_request`/`push`, so it doesn't gate PRs |
| `integration-tests.yml` | `integration-coverage-validation` | 2m | n/a (disabled) | n/a | leave alone, same reason |
| `test-suite.yml` | `performance-tests` | 30m | ~2m5s-2m9s | ~14x | leave alone |
| `test-suite.yml` | `combined-coverage` | 5m | ~23s-25s | ~12x | leave alone |

## Validation

- `ruby -ryaml -e 'YAML.load_file(".github/workflows/unit-tests.yml"); puts "OK"'` → `OK`
- Pre-commit hook ran the full unit suite locally (8568 examples) — passed clean on the second attempt; first attempt hit an unrelated one-off flaky failure in `circuit_breaker_spec.rb` (timing-sensitive circuit-breaker recovery test, unconnected to this CI config change).

## Test plan

- [ ] Confirm the `unit-tests` job on this PR's own CI run completes well under the new 12m limit
- [ ] Watch the next few PRs for any recurrence of the silent-timeout kill pattern from #572