### PR TITLE
chore(jobs): pin recurring-task time zones explicitly

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,5 +1,14 @@
 # Recurring jobs configuration for Solid Queue
 # These jobs run automatically on the specified schedules
+#
+# Every entry below pins an explicit time_zone. solid_queue >= 1.5 added an
+# engine initializer that defaults RecurringTask#time_zone to
+# config.time_zone ("Central America", UTC-6) for any entry that omits it.
+# Before 1.5, unpinned schedules were interpreted in process-local time
+# (UTC in the container). Pinning "UTC" here preserves today's behavior so
+# schedule changes stay deliberate rather than a side effect of a gem
+# upgrade; moving a job to Costa Rica local time later is then a one-line
+# intentional edit.
 
 default: &default
   # Calculate metrics for all email accounts every hour
@@ -9,12 +18,14 @@ default: &default
     queue: default
     priority: 5
     schedule: every hour at minute 5
+    time_zone: "UTC"
     description: "Pre-calculate expense metrics for all active email accounts"
 
   # Clean up old finished jobs periodically
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every 6 hours at minute 30
+    time_zone: "UTC"
     description: "Clean up completed Solid Queue jobs to prevent database bloat"
 
   # Clean up old broadcast analytics data and recovered failed broadcast records hourly
@@ -23,6 +34,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every hour at minute 15
+    time_zone: "UTC"
     description: "Clean up old broadcast analytics data and recovered failed broadcast records"
 
   # Retry failed broadcasts from the dead letter queue every 30 minutes
@@ -31,6 +43,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every 30 minutes
+    time_zone: "UTC"
     description: "Retry failed broadcasts from the dead letter queue"
 
   # Feed uncorrected categorizations into categorization vectors daily ("silence = acceptance")
@@ -39,6 +52,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every day at 3am
+    time_zone: "UTC"
     description: "Learn from uncorrected categorizations to improve similarity-based matching"
 
   # Clean up stale categorization vectors monthly (last_seen_at > 6 months)
@@ -47,6 +61,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every month
+    time_zone: "UTC"
     description: "Remove stale categorization vectors not seen in 6+ months"
 
   # Weekly categorization metrics summary with ONNX trigger warnings
@@ -55,6 +70,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every Sunday at 6am
+    time_zone: "UTC"
     description: "Compute weekly categorization performance summary and evaluate ONNX trigger warnings"
 
   # Clean up expired LLM categorization cache entries monthly
@@ -63,6 +79,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every month
+    time_zone: "UTC"
     description: "Remove expired LLM categorization cache entries"
 
   # Run data quality audit daily to check pattern coverage and detect issues
@@ -71,6 +88,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every day at 3am
+    time_zone: "UTC"
     description: "Run data quality audit to check pattern coverage, detect duplicates, and identify issues"
 
   # Purge email parsing failures older than 30 days. raw_email_content holds
@@ -81,6 +99,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every day at 4am
+    time_zone: "UTC"
     description: "Purge email parsing failures older than 30 days (PER-496 retention)"
 
   # Purge SolidQueue::FailedExecution rows older than 30 days. The existing
@@ -92,6 +111,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every day at 4:15am
+    time_zone: "UTC"
     description: "Purge failed job executions older than 30 days (PER-503 retention)"
 
   # Purge QueuedEmailPayload rows past their retention window (2026-08 audit
@@ -103,6 +123,7 @@ default: &default
     queue: low
     priority: 10
     schedule: every day at 4:30am
+    time_zone: "UTC"
     description: "Purge encrypted queued-email payloads past their retention window (2026-08 audit)"
 
   # Pull the latest monthly budget from each active external budget source
@@ -111,6 +132,7 @@ default: &default
     command: "ExternalBudgetSource.active.find_each { |s| ExternalBudgets::PullJob.perform_later(s.id) }"
     queue: default
     schedule: every day at 6am
+    time_zone: "UTC"
     description: "Pull latest monthly budget from each active external source"
 
   # Nightly Postgres backup to Hetzner Storage Box.
@@ -137,14 +159,16 @@ development:
     queue: default
     priority: 5
     schedule: every 30 minutes
+    time_zone: "UTC"
     description: "Pre-calculate expense metrics for all active email accounts (dev mode)"
-  
+
   # Warm pattern cache more frequently in development for testing
   warm_pattern_cache:
     class: PatternCacheWarmerJob
     queue: low
     priority: 10
     schedule: every 5 minutes
+    time_zone: "UTC"
     description: "Pre-warm pattern cache with frequently used patterns (dev mode)"
 
 test:
@@ -161,4 +185,5 @@ production:
     queue: low
     priority: 10
     schedule: every 15 minutes
+    time_zone: "UTC"
     description: "Pre-warm pattern cache with frequently used patterns for optimal categorization performance"

--- a/spec/config/recurring_spec.rb
+++ b/spec/config/recurring_spec.rb
@@ -48,6 +48,36 @@ RSpec.describe "Recurring tasks configuration", :unit do
     end
   end
 
+  describe "time zone pinning" do
+    # solid_queue >= 1.5 added an engine initializer that defaults any entry
+    # missing time_zone: to config.time_zone ("Central America", UTC-6) via
+    # SolidQueue::RecurringTask. Before 1.5, unpinned schedules ran in
+    # process-local time (UTC in the container). We assert PRESENCE of an
+    # explicit time_zone rather than a specific value: a future job may
+    # legitimately want a different zone (e.g. "America/Costa_Rica"), and
+    # this guard only needs to catch entries that forgot to make that choice
+    # deliberately, not enforce which zone they picked.
+    it "declares an explicit time_zone for every production job entry" do
+      missing = production_recurring.select { |_name, cfg| cfg.is_a?(Hash) }
+        .reject { |_name, cfg| cfg.key?("time_zone") }
+        .keys
+
+      expect(missing).to be_empty,
+        "Recurring task entries missing an explicit time_zone (solid_queue >= 1.5 " \
+        "otherwise defaults to config.time_zone, silently shifting the schedule): " \
+        "#{missing.join(', ')}"
+    end
+
+    it "declares a non-blank time_zone value for every production job entry" do
+      blank = production_recurring.select { |_name, cfg| cfg.is_a?(Hash) && cfg.key?("time_zone") }
+        .select { |_name, cfg| cfg["time_zone"].nil? || cfg["time_zone"].to_s.strip.empty? }
+        .keys
+
+      expect(blank).to be_empty,
+        "Recurring task entries with a blank time_zone: #{blank.join(', ')}"
+    end
+  end
+
   describe "Solid Queue is the active scheduler" do
     it "recurring.yml exists with a production section" do
       expect(File.exist?(Rails.root.join("config", "recurring.yml"))).to be true


### PR DESCRIPTION
## Summary

`solid_queue` 1.5.0 added an engine initializer that defaults `SolidQueue.time_zone` to `app.config.time_zone` unless `config.solid_queue.time_zone` is set, and `RecurringTask` applies that zone to any `config/recurring.yml` entry lacking its own `time_zone:`. Before 1.5, unpinned schedules were interpreted in process-local time (UTC in the container — no TZ set in the Dockerfile).

This app sets `config.time_zone = "Central America"` (UTC-6) in `config/application.rb:36` and never sets `config.solid_queue.time_zone`. **PR #583 (solid_queue 1.4.0 → 1.6.0) must not merge before this lands** — merging it as-is would silently shift every unpinned schedule by ~6 hours (e.g. a "3am" job moving from 03:00 UTC to 03:00 Central America = 09:00 UTC, into business hours).

`postgres_nightly_backup` already pinned `time_zone: "UTC"` with a comment explaining the hazard — evidence the author anticipated this. This PR extends that same fix to every other entry.

- Added `time_zone: "UTC"` to all recurring-task entries lacking one, across the `default`, `development`, and `production` blocks of `config/recurring.yml` (16 entries: 13 in `default`, 2 in `development`, 1 in `production`; `postgres_nightly_backup` was already pinned).
- Added an explanatory comment near the top of the file.
- Chose UTC specifically to preserve today's (pre-1.5) behavior. Rationale: schedule changes should be deliberate, not a side effect of a gem upgrade; pinning immunizes every entry against future default changes; moving a job to Costa Rica local time later becomes a one-line intentional edit.

## Guard spec

`spec/config/recurring_spec.rb` previously only regex-matched raw YAML text and couldn't catch a future entry that forgets `time_zone:`. Added two new examples under `"time zone pinning"`:
- asserts every `production` entry has a `time_zone` key present
- asserts that key's value is non-blank

Chose to assert **presence** of `time_zone` rather than a specific value (`"UTC"`) — a future job may legitimately want a different zone, and the guard's job is only to force that choice to be explicit, not to lock in what the choice is. Kept YAML-level (`YAML.safe_load` + hash assertions), no SolidQueue internals booted. Verified the guard actually fails when a `time_zone:` line is removed, then confirmed it passes again on the real file.

## Test plan
- [x] `ruby -ryaml -e 'YAML.load_file("config/recurring.yml", aliases: true); puts "YAML OK"'` — passes (plain `YAML.load_file` without `aliases: true` fails on this file both before and after this change, since it already used YAML anchors/aliases — pre-existing, not introduced here)
- [x] `bundle exec rspec spec/config/recurring_spec.rb` — 7 examples, 0 failures
- [x] `bin/test-unit` — 8570 examples, 0 failures, 5 pendings (all pre-existing)
- [x] `bundle exec rubocop` (via pre-commit hook, full repo) — 919 files, no offenses
- [x] `bundle exec brakeman` (via pre-commit hook) — 0 warnings