### PR TITLE
fix(llm): compare block type as string, not against a Symbol

### DIFF
--- a/app/services/categorization/llm/client.rb
+++ b/app/services/categorization/llm/client.rb
@@ -192,8 +192,10 @@ module Services::Categorization
           return server_usage.web_search_requests if server_usage.respond_to?(:web_search_requests)
         end
 
-        # Fallback: count server_tool_use blocks in content
-        response.content.count { |b| b.respond_to?(:type) && b.type == "server_tool_use" }
+        # Fallback: count server_tool_use blocks in content.
+        # block.type is a Symbol (:server_tool_use) in the anthropic gem — compare
+        # loosely or this never matches (see app/services/budgets/mapping_llm_resolver.rb).
+        response.content.count { |b| b.respond_to?(:type) && b.type.to_s == "server_tool_use" }
       end
 
       def calculate_cost(input_tokens, output_tokens, search_count)

--- a/spec/services/categorization/llm/client_spec.rb
+++ b/spec/services/categorization/llm/client_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     let(:anthropic_client) { instance_double(Anthropic::Client) }
     let(:messages_api) { instance_double(Anthropic::Resources::Messages) }
     let(:usage) { double("Usage", input_tokens: 150, output_tokens: 10, server_tool_use: nil) }
-    let(:text_block) { double("TextBlock", text: "food", type: "text") }
+    let(:text_block) { double("TextBlock", text: "food", type: :text) }
     let(:response) do
       double("Message", content: [ text_block ], usage: usage, stop_reason: "end_turn")
     end
@@ -180,7 +180,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     it "extracts category key from verbose response" do
       verbose_block = double("TextBlock",
         text: "Based on my search, this is a hardware_store in Costa Rica.",
-        type: "text")
+        type: :text)
       allow(verbose_block).to receive(:respond_to?).with(:text).and_return(true)
       allow(verbose_block).to receive(:respond_to?).with(:type).and_return(true)
       verbose_response = double("Message", content: [ verbose_block ], usage: usage, stop_reason: "end_turn")
@@ -194,7 +194,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     it "prefers longer key matches to avoid substring collisions" do
       ambiguous_block = double("TextBlock",
         text: "This is a hardware_store, not a regular home store.",
-        type: "text")
+        type: :text)
       allow(ambiguous_block).to receive(:respond_to?).with(:text).and_return(true)
       allow(ambiguous_block).to receive(:respond_to?).with(:type).and_return(true)
       ambiguous_response = double("Message", content: [ ambiguous_block ], usage: usage, stop_reason: "end_turn")
@@ -206,7 +206,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
     end
 
     context "when stop_reason is pause_turn (web search in progress)" do
-      let(:search_block) { double("ServerToolUse", type: "server_tool_use") }
+      let(:search_block) { double("ServerToolUse", type: :server_tool_use) }
       let(:pause_response) do
         double("Message",
           content: [ search_block ],
@@ -231,6 +231,21 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
         expect(result[:response_text]).to eq("food")
         expect(result[:token_count][:input]).to eq(650) # 500 + 150
       end
+
+      it "counts the server_tool_use block via the content fallback (usage.server_tool_use unavailable)" do
+        # search_block.type is a Symbol (:server_tool_use), matching the real
+        # anthropic gem. Before the fix this fallback compared against the
+        # String "server_tool_use" and could never match, so search_count
+        # (and its cost contribution) was silently always zero here.
+        result = client.categorize(prompt_text: prompt_text)
+
+        # total_input: 500 + 150 = 650, total_output: 5 + 10 = 15,
+        # total_searches: 1 (from the pause_response fallback count)
+        expected_cost = (650 * Services::Categorization::Llm::Client::INPUT_COST_PER_TOKEN) +
+          (15 * Services::Categorization::Llm::Client::OUTPUT_COST_PER_TOKEN) +
+          (1 * Services::Categorization::Llm::Client::SEARCH_COST_PER_QUERY)
+        expect(result[:cost]).to be_within(0.0000001).of(expected_cost)
+      end
     end
 
     context "when search continuations are exhausted" do
@@ -244,7 +259,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
           content: [ double("Block").tap { |b|
             allow(b).to receive(:respond_to?).with(:text).and_return(false)
             allow(b).to receive(:respond_to?).with(:type).and_return(true)
-            allow(b).to receive(:type).and_return("server_tool_use")
+            allow(b).to receive(:type).and_return(:server_tool_use)
           } ],
           usage: pause_usage,
           stop_reason: "pause_turn")
@@ -264,7 +279,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
 
     context "when response contains no recognizable category key" do
       let(:gibberish_block) do
-        double("TextBlock", text: "I cannot determine what this merchant sells", type: "text").tap do |b|
+        double("TextBlock", text: "I cannot determine what this merchant sells", type: :text).tap do |b|
           allow(b).to receive(:respond_to?).with(:text).and_return(true)
           allow(b).to receive(:respond_to?).with(:type).and_return(true)
         end
@@ -284,7 +299,7 @@ RSpec.describe Services::Categorization::Llm::Client, :unit do
 
     context "when response starts with a valid key followed by explanation" do
       let(:first_word_block) do
-        double("TextBlock", text: "food - this is a local restaurant in Cartago", type: "text").tap do |b|
+        double("TextBlock", text: "food - this is a local restaurant in Cartago", type: :text).tap do |b|
           allow(b).to receive(:respond_to?).with(:text).and_return(true)
           allow(b).to receive(:respond_to?).with(:type).and_return(true)
         end


### PR DESCRIPTION
## Summary
- `Categorization::Llm::Client#extract_search_count`'s fallback comparison (`b.type == "server_tool_use"`) has **never matched** in production. The `anthropic` gem defines `type` as a `Symbol` (`required :type, const: :server_tool_use`), verified in the gem source at both 1.43 and 1.59 — comparing it against the String `"server_tool_use"` is always false.
- This bug is dormant/silent because it's only the *fallback* path: the primary path (`response.usage.server_tool_use.web_search_requests`) is tried first and normally succeeds. The fallback only fires when the SDK's usage object lacks `server_tool_use`, at which point search-cost accounting for that request silently drops to zero instead of reflecting the real search count.
- Fixed the same way the sibling file already handles this exact trap: `app/services/budgets/mapping_llm_resolver.rb:42` uses `block.type.to_s == "text"` with a comment citing a 2026-07-06 production incident. Applied the same `.to_s` comparison here, with a comment noting the Symbol type and pointing at the sibling file.
- The existing spec doubles in `spec/services/categorization/llm/client_spec.rb` stubbed `type:` as **Strings** (`"text"`, `"server_tool_use"`), which is exactly what hid the bug — Ruby's `respond_to?(:type) && b.type == "server_tool_use"` happened to look plausible against a String double even though it never matched the real gem's Symbol. Changed all response-content doubles to Symbols (`:text`, `:server_tool_use`) to match the real gem's return type. (Left the unrelated `tools: [{ type: "web_search_20250305", ... }]` request-param double as a String — that's an outbound API param, not a gem response type, and is genuinely a String.)

## New coverage
- Added an example ("counts the server_tool_use block via the content fallback...") in the existing `pause_turn` context asserting `result[:cost]` reflects the search cost contributed by the fallback-counted `server_tool_use` block.
- Verified this test is meaningful by temporarily reverting the fix locally: the new test **fails** against the old String comparison (expected cost 0.010725, got 0.000725 — i.e., search count silently counted as 0) and **passes** with the fix restored.

## Test plan
- [x] `bundle exec rspec spec/services/categorization/llm/client_spec.rb` — 29 examples, 0 failures
- [x] `bundle exec rubocop app/services/categorization/llm/client.rb spec/services/categorization/llm/client_spec.rb` — no offenses
- [x] Confirmed new test fails without the fix, passes with it (see above)
- [x] Full pre-commit hook suite (unit tests, RuboCop, Brakeman, Rails Best Practices) — all green